### PR TITLE
docs(es): document how to choose the right reference macro

### DIFF
--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -378,6 +378,36 @@ Rari/Yari distingue mayúsculas en los nombres de macro. Usa exactamente la capi
 - `{{SeeCompatTable}}`, no `{{seecompattable}}`
 - `{{Non-standard_Header}}`, no `{{non-standard_header}}`
 
+#### Elegir el macro de referencia correcto
+
+Cada macro `*xref` construye la URL sobre un subárbol fijo de la documentación. Si eliges el equivocado, el enlace apunta a una página que no existe o que sólo funciona por una redirección, y nada en el PR lo delata: la macro se renderiza igual y el CI pasa.
+
+| Macro                            | Enlaza a                                | Úsalo para                                                 |
+| -------------------------------- | --------------------------------------- | ---------------------------------------------------------- |
+| `{{domxref("X")}}`               | `/es/docs/Web/API/X`                    | Interfaces, métodos, propiedades y eventos de las APIs web |
+| `{{jsxref("X")}}`                | `/es/docs/Web/JavaScript/Reference/…/X` | Objetos globales y sintaxis de JavaScript                  |
+| `{{cssxref("X")}}`               | `/es/docs/Web/CSS/X`                    | Propiedades, tipos de valor, funciones y pseudoclases CSS  |
+| `{{HTMLElement("X")}}`           | `/es/docs/Web/HTML/…`                   | Elementos HTML                                             |
+| `{{httpheader("X")}}`            | `/es/docs/Web/HTTP/Headers/X`           | Cabeceras HTTP                                             |
+| `{{SVGAttr}}` / `{{SVGElement}}` | `/es/docs/Web/SVG/…`                    | Atributos y elementos SVG                                  |
+| `{{Glossary("X", "texto")}}`     | `/es/docs/Glossary/X`                   | Términos del glosario                                      |
+
+Todas aceptan los mismos argumentos: `{{macro("Página", "texto a mostrar", "ancla")}}`.
+
+**El error más frecuente es usar `domxref` para tipos de JavaScript.** Aparecen en las páginas de APIs web, así que es natural tratarlos como parte del DOM, pero sus páginas viven en la referencia de JavaScript. `/es/docs/Web/API/DOMString` devuelve un 404; `Web/API/Boolean`, `Web/API/Promise` y `Web/API/USVString` responden 200 sólo porque redirigen a la referencia de JavaScript, es decir, el enlace funciona por accidente y con un salto de más.
+
+Los tipos de WebIDL además no se enlazan con su propio nombre, porque no tienen página propia: se enlazan al tipo de JavaScript que representan, y el texto mostrado cambia con ellos.
+
+| En la fuente en inglés                                                              | Qué usar                              |
+| ----------------------------------------------------------------------------------- | ------------------------------------- |
+| `DOMString`, `USVString`, `ByteString`, `CSSOMString`                               | `{{jsxref("String")}}`                |
+| `ArrayBufferView`                                                                   | `{{jsxref("TypedArray")}}`            |
+| `Boolean`, `Promise`, `Number`, `JSON`, `ArrayBuffer`, `Float32Array`, `Uint8Array` | `{{jsxref("…")}}` con el mismo nombre |
+
+Si necesitas conservar el nombre traducido en el texto visible, va como segundo argumento y la página sigue siendo la inglesa: `{{jsxref("Promise", "Promesa")}}`.
+
+Para saber a qué subárbol pertenece un macro que no esté en la tabla, mira su fuente en `yari/kumascript/macros/<Macro>.ejs`: la ruta base está escrita en el propio archivo.
+
 ---
 
 ## Arreglar "flaws" (defectos)

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -341,19 +341,24 @@ Cuando en inglés aparece `{{Glossary("TLD")}}` y el término natural en españo
 
 ### Elegir el macro de referencia correcto
 
-Cada macro `*xref` construye la URL sobre un subárbol fijo de la documentación. Si eliges el equivocado, el enlace apunta a una página que no existe o que sólo funciona por una redirección, y nada en el PR lo delata: la macro se renderiza igual y el CI pasa.
+Cada macro de referencia construye la URL sobre un subárbol fijo de la documentación. Si eliges el equivocado, el enlace apunta a una página que no existe, o que sólo funciona por una redirección, y nada en el PR lo delata: la macro se renderiza igual y el CI pasa en verde.
 
-| Macro                            | Enlaza a                                | Úsalo para                                                 |
-| -------------------------------- | --------------------------------------- | ---------------------------------------------------------- |
-| `{{domxref("X")}}`               | `/es/docs/Web/API/X`                    | Interfaces, métodos, propiedades y eventos de las APIs web |
-| `{{jsxref("X")}}`                | `/es/docs/Web/JavaScript/Reference/…/X` | Objetos globales y sintaxis de JavaScript                  |
-| `{{cssxref("X")}}`               | `/es/docs/Web/CSS/X`                    | Propiedades, tipos de valor, funciones y pseudoclases CSS  |
-| `{{HTMLElement("X")}}`           | `/es/docs/Web/HTML/…`                   | Elementos HTML                                             |
-| `{{httpheader("X")}}`            | `/es/docs/Web/HTTP/Headers/X`           | Cabeceras HTTP                                             |
-| `{{SVGAttr}}` / `{{SVGElement}}` | `/es/docs/Web/SVG/…`                    | Atributos y elementos SVG                                  |
-| `{{Glossary("X", "texto")}}`     | `/es/docs/Glossary/X`                   | Términos del glosario                                      |
+| Macro                        | Enlaza a                                 | Úsalo para                                                 |
+| ---------------------------- | ---------------------------------------- | ---------------------------------------------------------- |
+| `{{domxref("X")}}`           | `/es/docs/Web/API/X`                     | Interfaces, métodos, propiedades y eventos de las APIs web |
+| `{{jsxref("X")}}`            | `/es/docs/Web/JavaScript/Reference/…/X`  | Objetos globales y sintaxis de JavaScript                  |
+| `{{cssxref("X")}}`           | `/es/docs/Web/CSS/Reference/…/X`         | Propiedades, tipos de valor, funciones y pseudoclases CSS  |
+| `{{HTMLElement("X")}}`       | `/es/docs/Web/HTML/Reference/Elements/X` | Elementos HTML                                             |
+| `{{httpheader("X")}}`        | `/es/docs/Web/HTTP/Reference/Headers/X`  | Cabeceras HTTP                                             |
+| `{{SVGElement("X")}}`        | `/es/docs/Web/SVG/Reference/Element/X`   | Elementos SVG                                              |
+| `{{SVGAttr("X")}}`           | `/es/docs/Web/SVG/Reference/Attribute/X` | Atributos SVG                                              |
+| `{{Glossary("X", "texto")}}` | `/es/docs/Glossary/X`                    | Términos del glosario                                      |
 
-Todas aceptan los mismos argumentos: `{{macro("Página", "texto a mostrar", "ancla")}}`.
+**Los argumentos no son iguales en todas.** Esto se presta a error porque la forma se parece:
+
+- `domxref`, `jsxref`, `cssxref`, `HTMLElement` y `httpheader` aceptan `(página, texto a mostrar, ancla)`.
+- **`Glossary` acepta sólo `(término, texto a mostrar)`**, sin ancla. Un tercer argumento no hace nada.
+- **`SVGElement` y `SVGAttr` aceptan sólo el nombre**; no tienen parámetro de texto a mostrar.
 
 **El error más frecuente es usar `domxref` para tipos de JavaScript.** Aparecen en las páginas de APIs web, así que es natural tratarlos como parte del DOM, pero sus páginas viven en la referencia de JavaScript. `/es/docs/Web/API/DOMString` devuelve un 404; `Web/API/Boolean`, `Web/API/Promise` y `Web/API/USVString` responden 200 sólo porque redirigen a la referencia de JavaScript, es decir, el enlace funciona por accidente y con un salto de más.
 
@@ -367,7 +372,9 @@ Los tipos de WebIDL además no se enlazan con su propio nombre, porque no tienen
 
 Si necesitas conservar el nombre traducido en el texto visible, va como segundo argumento y la página sigue siendo la inglesa: `{{jsxref("Promise", "Promesa")}}`.
 
-Para saber a qué subárbol pertenece un macro que no esté en la tabla, mira su fuente en `yari/kumascript/macros/<Macro>.ejs`: la ruta base está escrita en el propio archivo.
+**Para un macro que no esté en la tabla**, la fuente autorizada es [rari](https://github.com/mdn/rari), el motor que renderiza MDN hoy: cada macro es un archivo en `crates/rari-doc/src/templ/templs/`, y ahí están tanto la ruta base como los argumentos que acepta. Por ejemplo, `links/svgattr.rs` declara `svgattr(name: String)`, que es de donde sale que sólo admita un argumento.
+
+Conviene saber que `kumascript/macros/` en [Yari](https://github.com/mdn/yari) **ya no es la implementación que se usa al renderizar**, aunque los archivos sigan ahí. Por ejemplo, `HTMLElement.ejs` construye `Web/HTML/Element/`, mientras que la página publicada enlaza a `Web/HTML/Reference/Elements/`. Si consultas Yari para resolver una duda sobre macros, puedes acabar con una ruta que no coincide con la real.
 
 ### Estilo de escritura
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -15,6 +15,11 @@ Guía para colaborar traduciendo y manteniendo el contenido de MDN Web Docs al e
 - [Imágenes y otros archivos](#imágenes-y-otros-archivos)
 - [Mantener el `l10n.sourceCommit` al día](#mantener-el-l10nsourcecommit-al-día)
 - [Convención de traducciones](#convención-de-traducciones)
+  - [Términos técnicos](#términos-técnicos)
+  - [Marcadores en línea](#marcadores-en-línea)
+  - [Formato matemático](#formato-matemático)
+  - [Macros de glosario](#macros-de-glosario)
+  - [Elegir el macro de referencia correcto](#elegir-el-macro-de-referencia-correcto)
   - [Estilo de escritura](#estilo-de-escritura)
 - [Arreglar "flaws" (defectos)](#arreglar-flaws-defectos)
 - [Charla con nosotros](#charla-con-nosotros)
@@ -334,6 +339,36 @@ Cuando en inglés aparece `{{Glossary("TLD")}}` y el término natural en españo
 
 > Excepción: si la frase en español ya explica el término justo después del macro (por ejemplo, `{{Glossary("TLD")}} (Top-Level Domain) Dominio de primer nivel`), deja el macro con un solo argumento para evitar duplicar el texto renderizado.
 
+### Elegir el macro de referencia correcto
+
+Cada macro `*xref` construye la URL sobre un subárbol fijo de la documentación. Si eliges el equivocado, el enlace apunta a una página que no existe o que sólo funciona por una redirección, y nada en el PR lo delata: la macro se renderiza igual y el CI pasa.
+
+| Macro                            | Enlaza a                                | Úsalo para                                                 |
+| -------------------------------- | --------------------------------------- | ---------------------------------------------------------- |
+| `{{domxref("X")}}`               | `/es/docs/Web/API/X`                    | Interfaces, métodos, propiedades y eventos de las APIs web |
+| `{{jsxref("X")}}`                | `/es/docs/Web/JavaScript/Reference/…/X` | Objetos globales y sintaxis de JavaScript                  |
+| `{{cssxref("X")}}`               | `/es/docs/Web/CSS/X`                    | Propiedades, tipos de valor, funciones y pseudoclases CSS  |
+| `{{HTMLElement("X")}}`           | `/es/docs/Web/HTML/…`                   | Elementos HTML                                             |
+| `{{httpheader("X")}}`            | `/es/docs/Web/HTTP/Headers/X`           | Cabeceras HTTP                                             |
+| `{{SVGAttr}}` / `{{SVGElement}}` | `/es/docs/Web/SVG/…`                    | Atributos y elementos SVG                                  |
+| `{{Glossary("X", "texto")}}`     | `/es/docs/Glossary/X`                   | Términos del glosario                                      |
+
+Todas aceptan los mismos argumentos: `{{macro("Página", "texto a mostrar", "ancla")}}`.
+
+**El error más frecuente es usar `domxref` para tipos de JavaScript.** Aparecen en las páginas de APIs web, así que es natural tratarlos como parte del DOM, pero sus páginas viven en la referencia de JavaScript. `/es/docs/Web/API/DOMString` devuelve un 404; `Web/API/Boolean`, `Web/API/Promise` y `Web/API/USVString` responden 200 sólo porque redirigen a la referencia de JavaScript, es decir, el enlace funciona por accidente y con un salto de más.
+
+Los tipos de WebIDL además no se enlazan con su propio nombre, porque no tienen página propia: se enlazan al tipo de JavaScript que representan, y el texto mostrado cambia con ellos.
+
+| En la fuente en inglés                                                              | Qué usar                              |
+| ----------------------------------------------------------------------------------- | ------------------------------------- |
+| `DOMString`, `USVString`, `ByteString`, `CSSOMString`                               | `{{jsxref("String")}}`                |
+| `ArrayBufferView`                                                                   | `{{jsxref("TypedArray")}}`            |
+| `Boolean`, `Promise`, `Number`, `JSON`, `ArrayBuffer`, `Float32Array`, `Uint8Array` | `{{jsxref("…")}}` con el mismo nombre |
+
+Si necesitas conservar el nombre traducido en el texto visible, va como segundo argumento y la página sigue siendo la inglesa: `{{jsxref("Promise", "Promesa")}}`.
+
+Para saber a qué subárbol pertenece un macro que no esté en la tabla, mira su fuente en `yari/kumascript/macros/<Macro>.ejs`: la ruta base está escrita en el propio archivo.
+
 ### Estilo de escritura
 
 #### Tuteo (tú) en lugar de usted
@@ -377,36 +412,6 @@ Rari/Yari distingue mayúsculas en los nombres de macro. Usa exactamente la capi
 - `{{Deprecated_Header}}`, no `{{deprecated_header}}`
 - `{{SeeCompatTable}}`, no `{{seecompattable}}`
 - `{{Non-standard_Header}}`, no `{{non-standard_header}}`
-
-#### Elegir el macro de referencia correcto
-
-Cada macro `*xref` construye la URL sobre un subárbol fijo de la documentación. Si eliges el equivocado, el enlace apunta a una página que no existe o que sólo funciona por una redirección, y nada en el PR lo delata: la macro se renderiza igual y el CI pasa.
-
-| Macro                            | Enlaza a                                | Úsalo para                                                 |
-| -------------------------------- | --------------------------------------- | ---------------------------------------------------------- |
-| `{{domxref("X")}}`               | `/es/docs/Web/API/X`                    | Interfaces, métodos, propiedades y eventos de las APIs web |
-| `{{jsxref("X")}}`                | `/es/docs/Web/JavaScript/Reference/…/X` | Objetos globales y sintaxis de JavaScript                  |
-| `{{cssxref("X")}}`               | `/es/docs/Web/CSS/X`                    | Propiedades, tipos de valor, funciones y pseudoclases CSS  |
-| `{{HTMLElement("X")}}`           | `/es/docs/Web/HTML/…`                   | Elementos HTML                                             |
-| `{{httpheader("X")}}`            | `/es/docs/Web/HTTP/Headers/X`           | Cabeceras HTTP                                             |
-| `{{SVGAttr}}` / `{{SVGElement}}` | `/es/docs/Web/SVG/…`                    | Atributos y elementos SVG                                  |
-| `{{Glossary("X", "texto")}}`     | `/es/docs/Glossary/X`                   | Términos del glosario                                      |
-
-Todas aceptan los mismos argumentos: `{{macro("Página", "texto a mostrar", "ancla")}}`.
-
-**El error más frecuente es usar `domxref` para tipos de JavaScript.** Aparecen en las páginas de APIs web, así que es natural tratarlos como parte del DOM, pero sus páginas viven en la referencia de JavaScript. `/es/docs/Web/API/DOMString` devuelve un 404; `Web/API/Boolean`, `Web/API/Promise` y `Web/API/USVString` responden 200 sólo porque redirigen a la referencia de JavaScript, es decir, el enlace funciona por accidente y con un salto de más.
-
-Los tipos de WebIDL además no se enlazan con su propio nombre, porque no tienen página propia: se enlazan al tipo de JavaScript que representan, y el texto mostrado cambia con ellos.
-
-| En la fuente en inglés                                                              | Qué usar                              |
-| ----------------------------------------------------------------------------------- | ------------------------------------- |
-| `DOMString`, `USVString`, `ByteString`, `CSSOMString`                               | `{{jsxref("String")}}`                |
-| `ArrayBufferView`                                                                   | `{{jsxref("TypedArray")}}`            |
-| `Boolean`, `Promise`, `Number`, `JSON`, `ArrayBuffer`, `Float32Array`, `Uint8Array` | `{{jsxref("…")}}` con el mismo nombre |
-
-Si necesitas conservar el nombre traducido en el texto visible, va como segundo argumento y la página sigue siendo la inglesa: `{{jsxref("Promise", "Promesa")}}`.
-
-Para saber a qué subárbol pertenece un macro que no esté en la tabla, mira su fuente en `yari/kumascript/macros/<Macro>.ejs`: la ruta base está escrita en el propio archivo.
 
 ---
 


### PR DESCRIPTION
### Description

Añade a la guía una sección sobre qué macro de referencia usar para cada cosa, y qué argumentos acepta cada una.

### Motivation

Cada macro de referencia construye su URL sobre un subárbol fijo. Si se elige el equivocado, el enlace apunta a una página inexistente o que sólo funciona por una redirección, y **nada lo delata**: la macro se renderiza igual y el CI pasa en verde.

No es teórico. #38340 sustituyó 149 llamadas en 38 archivos en español por esta razón. Resolviendo los destinos antiguos:

```
404 -> /en-US/docs/Web/API/DOMString
200 -> /en-US/docs/Web/API/USVString  ->  redirige a Global_Objects/String
200 -> /en-US/docs/Web/API/Boolean    ->  redirige a Global_Objects/Boolean
```

La guía sólo mencionaba `{{domxref(...)}}` y `{{jsxref(...)}}` como ejemplos de marcado que no se traduce, sin nada sobre cómo elegir entre ellos.

### Changes

- Tabla de macro a subárbol para `domxref`, `jsxref`, `cssxref`, `HTMLElement`, `httpheader`, `SVGElement`, `SVGAttr` y `Glossary`.
- Los argumentos que acepta cada una, que **no son los mismos**.
- Los tipos de WebIDL, que no se enlazan con su propio nombre: `DOMString`, `USVString`, `ByteString` y `CSSOMString` van a `{{jsxref("String")}}`, y `ArrayBufferView` a `{{jsxref("TypedArray")}}`.
- Nota de que el nombre traducido va en el segundo argumento (`{{jsxref("Promise", "Promesa")}}`) mientras la página sigue siendo la inglesa.
- Se sube la sección a nivel 3, junto a «Macros de glosario», porque elegir macro no es una cuestión de estilo de escritura, y se completa la tabla de contenido de «Convención de traducciones», que listaba una de sus cinco subsecciones.

### Verificado contra rari

La primera versión de este PR tomó las rutas de `kumascript/macros/` en Yari y contenía **dos errores**, corregidos en el segundo commit tras contrastar con [rari](https://github.com/mdn/rari):

1. **Cuatro de siete rutas estaban mal.** Las referencias viven hoy bajo `Reference/`, así que `cssxref`, `HTMLElement`, `httpheader` y los macros de SVG apuntaban a rutas que ya no existen.
2. **«Todas aceptan los mismos argumentos» era falso.** rari declara `glossary(term_name, display_name)` sin ancla, y `svgattr(name)` con un único argumento; `svgelement` ignora su segundo parámetro. Un tercer argumento en `Glossary` no hace nada.

Las ocho filas se comprobaron una a una contra `crates/rari-doc/src/templ/templs/`.

Vale la pena saberlo para futuras dudas: **`kumascript/macros/` en Yari ya no es la implementación que se usa al renderizar**, aunque los archivos sigan ahí y el repositorio siga activo. `HTMLElement.ejs` construye `Web/HTML/Element/` mientras la página publicada enlaza a `Web/HTML/Reference/Elements/`. La sección lo deja anotado para que nadie repita el error.

Sólo documentación, no toca archivos de contenido. `prettier --check` y `markdownlint-cli2` pasan, y las 19 anclas del índice resuelven.
