### PR TITLE
[ru] Fix broken live sample in the Grid layout guide (Базовый пример)

### DIFF
--- a/files/ru/web/css/guides/grid_layout/index.md
+++ b/files/ru/web/css/guides/grid_layout/index.md
@@ -79,7 +79,7 @@ slug: Web/CSS/Guides/Grid_layout
 }
 ```
 
-{{ EmbedLiveSample('example', '500', '440') }}
+{{EmbedLiveSample("Базовый_пример", "500", "440")}}
 
 ## Ссылки
 

--- a/files/ru/web/css/guides/grid_layout/index.md
+++ b/files/ru/web/css/guides/grid_layout/index.md
@@ -100,9 +100,9 @@ slug: Web/CSS/Guides/Grid_layout
 - {{cssxref("grid-row")}}
 - {{cssxref("grid-column")}}
 - {{cssxref("grid-area")}}
-- {{cssxref("grid-row-gap")}}
-- {{cssxref("grid-column-gap")}}
-- {{cssxref("grid-gap")}}
+- {{cssxref("row-gap")}}
+- {{cssxref("column-gap")}}
+- {{cssxref("gap")}}
 
 ### CSS функции
 


### PR DESCRIPTION
## Description

The «Базовый пример» section of the Russian Grid layout guide embeds its live sample with `{{EmbedLiveSample('example', …)}}`, but there is no heading/section with the id `example` on the page, so the rendered sample does not pick up the HTML block of that section (see the screenshot in the issue).

This PR points the macro at the actual section id, `Базовый_пример`, so the sample renders the hidden CSS, the HTML and the CSS blocks under that heading — the same way the en-US page does with `{{EmbedLiveSample("Grid_layout_in_action", …)}}`.

## Motivation

Fixes #37011

## Additional details

One-line change, no content translated or reworded.
