### PR TITLE
fix(es): deja de enlazar a la copia archivada de HTML_table_basics

### DIFF
--- a/files/es/learn_web_development/core/structuring_content/planet_data_table/index.md
+++ b/files/es/learn_web_development/core/structuring_content/planet_data_table/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Planet_data_table
 original_slug: Learn/HTML/Tables/Structuring_planet_data
 ---
 
-{{LearnSidebar}}{{PreviousMenu("Learn_web_development/Core/Structuring_content/Table_accessibility", "conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics")}}
+{{LearnSidebar}}{{PreviousMenu("Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}
 
 En nuestra evaluación te proporcionamos datos sobre los planetas de nuestro sistema solar y tu los estructurarás en una tabla HTML.
 
@@ -66,4 +66,4 @@ Los siguientes pasos describen lo que necesitas para completar el ejemplo de la 
 
 Si estas siguiendo esta evaluación como parte de un curso organizado, deberías de ser capaz de entregar tu trabajo a tu profesor(a)/mentor para ver la puntuación. Si estas aprendiendo por tu cuenta, puedes obtener la guía de puntuación preguntando en [Learning Area Discourse thread](https://discourse.mozilla-community.org/t/learning-web-development-marking-guides-and-questions/16294) o en el canal IRC [#mdn](irc://irc.mozilla.org/mdn) en [Mozilla IRC](https://wiki.mozilla.org/IRC). Intenta hacer el ejercicio primero — ¡haciendo trampas no aprenderás nada!
 
-{{PreviousMenu("Learn_web_development/Core/Structuring_content/Table_accessibility", "conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics")}}
+{{PreviousMenu("Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/table_accessibility/index.md
+++ b/files/es/learn_web_development/core/structuring_content/table_accessibility/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Table_accessibility
 original_slug: Learn/HTML/Tables/Advanced
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_table_basics", "Learn_web_development/Core/Structuring_content/Planet_data_table", "conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_table_basics", "Learn_web_development/Core/Structuring_content/Planet_data_table", "Learn_web_development/Core/Structuring_content")}}
 
 En el segundo artículo de este módulo, analizamos algunas características más avanzadas de las tablas HTML, como los subtítulos/resúmenes, la agrupación de filas en las secciones del encabezado, el cuerpo y el pie de página; y también analizamos la accesibilidad de las tablas para usuarios con discapacidad visual.
 
@@ -458,4 +458,4 @@ Volviendo a nuestro ejemplo de gastos, los dos fragmentos anteriores podrían re
 
 Podrías aprender algo más sobre las tablas en HTML, pero en realidad te hemos proporcionado toda la información que necesitas saber en este momento. En este punto, es posible que desees ir y aprender sobre la aplicación de estilo a tablas HTML: consulta [Aplicar estilo a las tablas](/es/docs/Learn_web_development/Core/Styling_basics/Tables).
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_table_basics", "Learn_web_development/Core/Structuring_content/Planet_data_table", "conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_table_basics", "Learn_web_development/Core/Structuring_content/Planet_data_table", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/styling_basics/tables/index.md
+++ b/files/es/learn_web_development/core/styling_basics/tables/index.md
@@ -16,7 +16,7 @@ Aplicar estilos a una tabla HTML no es el trabajo más interesante del mundo, pe
         Conocimientos básicos de HTML (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
-        >) y <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics">tablas HTML</a>, y nociones de
+        >) y <a href="/es/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics">tablas HTML</a>, y nociones de
         cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>.)
       </td>

--- a/files/es/mdn/tutorials/index.md
+++ b/files/es/mdn/tutorials/index.md
@@ -32,7 +32,7 @@ Estos recursos son creados por empresas y desarrolladores web con visión de fut
 
 - [Multimedia e inserción](/es/docs/conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b)
   - : Este módulo explora cómo usar HTML para incluir multimedia en sus páginas web, incluidas las diferentes formas en que se pueden incluir imágenes y cómo incrustar video, audio e incluso otras páginas web completas.
-- [Tablas HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics)
+- [Tablas HTML](/es/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics)
   - : Representar datos tabulares en una página web de una manera {{glossary("Accessibility", "accesible")}} y comprensible puede ser un desafío. Este módulo cubre el marcado básico de tablas, junto con funciones más complejas, como la implementación de subtítulos y resúmenes.
 
 ### Nivel avanzado

--- a/files/es/orphaned/learn/front-end_web_developer/index.md
+++ b/files/es/orphaned/learn/front-end_web_developer/index.md
@@ -73,7 +73,7 @@ Las evaluaciones de cada módulo están diseñadas para comprobar tu conocimient
 
 - [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content) (15 a 20 horas de lectura/ejercicios)
 - [Multimedia e inserción](/es/docs/conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b) (15 a 20 horas de lectura/ejercicios)
-- [tablas HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics) (5 a 10 horas de lectura/ejercicios)
+- [tablas HTML](/es/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics) (5 a 10 horas de lectura/ejercicios)
 
 ### Estilo y diseño con CSS
 


### PR DESCRIPTION
### Description

Primer PR de #38407. Elimina las 7 referencias restantes a
`conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics`, en 5 páginas publicadas.

### Motivation

La copia archivada tenía 30 líneas; la traducción viva de esa lección tiene más de 700 tras #38425. Quien seguía cualquiera de esos enlaces llegaba a una página huérfana, sin migas de pan ni barra lateral, y cuya URL en inglés devuelve `404`.

Nada lo detectaba: `/es/docs/conflicting/...` responde `200`, así que el enlace resuelve, la página renderiza y el CI pasa en verde.

### Changes

Las referencias venían en dos formas, y **no se arreglan igual**:

| Forma | Dónde | Corrección |
| --- | --- | --- |
| Enlace markdown / HTML | `styling_basics/tables`, `mdn/tutorials`, `orphaned/learn/front-end_web_developer` | apunta a la lección viva `/es/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics` |
| Argumento de macro de navegación | `planet_data_table`, `table_accessibility` | ese hueco es la **página índice del módulo**, no una lección: toma `Learn_web_development/Core/Structuring_content`, que es lo que usa la fuente en inglés |

El segundo caso es el que conviene mirar con calma. Resolver la redirección del slug archivado devuelve la lección, no el índice del módulo, así que una sustitución automática habría dejado el argumento equivocado, sólo que sin `conflicting/`. El valor correcto sale de comparar con el inglés.

### Additional details

**Reducido tras #38424 y #38425.** Este PR empezó tocando 7 archivos. Al sincronizarse el índice del módulo (#38424) y la lección de tablas (#38425), esos dos archivos se reescribieron por completo y ya no contienen referencias a `conflicting/`, así que sus cambios aquí quedaron de más y se han quitado en un rebase.

**No borra la copia archivada.** Dos líneas de `files/es/_redirects.txt` todavía apuntan a ese slug:

```
/es/docs/Learn/HTML/Tablas   /es/docs/conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics
/es/docs/Learn/HTML/Tables   /es/docs/conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics
```

Borrar la página sin actualizarlas convertiría esas dos URLs en un `404` de verdad, y `_redirects.txt` se genera con el CLI de MDN, no se edita a mano. La poda va en #38420, que depende de que #38407 esté hecho.

**Verificación:** tras el cambio no queda **ninguna** referencia a ese destino en todo `files/es/` (excluyendo la propia copia archivada). `prettier --check` y `markdownlint-cli2` pasan en los 5 archivos.

Parte de #38407.
