### PR TITLE
docs(es): sincroniza HTML_table_basics con la fuente en inglés

### DIFF
--- a/files/es/learn_web_development/core/structuring_content/html_table_basics/index.md
+++ b/files/es/learn_web_development/core/structuring_content/html_table_basics/index.md
@@ -1,54 +1,66 @@
 ---
 title: Conceptos básicos de las tablas HTML
+short-title: Conceptos básicos de tablas
 slug: Learn_web_development/Core/Structuring_content/HTML_table_basics
-original_slug: Learn/HTML/Tables/Basics
+l10n:
+  sourceCommit: ce12c10364f35c64184dec44be85537b7e10d91f
 ---
 
-{{LearnSidebar}}{{NextMenu("Learn_web_development/Core/Structuring_content/Table_accessibility", "conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Splash_page", "Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}
 
-Este artículo te ayudará a comenzar con las tablas HTML. Vamos a exponer conceptos básicos como filas y celdas, encabezados, celdas que abarcan múltiples columnas y filas, y la forma de agrupar todas las celdas de una columna para aplicarles estilo.
+Este artículo te ayudará a comenzar con las tablas HTML. Vamos a exponer conceptos básicos como filas y celdas, encabezados, celdas que abarcan varias columnas y filas, y la forma de agrupar todas las celdas de una columna para aplicarles estilo.
 
 <table>
   <tbody>
     <tr>
       <th scope="row">Prerrequisitos:</th>
       <td>
-        Conceptos básicos de HTML (ver
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
-          >Introducción al HTML</a
-        >).
+        Familiaridad básica con HTML, como se cubre en
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Basic_HTML_syntax"
+          >Primeros pasos con HTML</a
+        >.
       </td>
     </tr>
     <tr>
-      <th scope="row">Objetivo:</th>
-      <td>Adquirir conocimientos básicos de las tablas HTML.</td>
+      <th scope="row">Resultados del aprendizaje:</th>
+      <td>
+        <ul>
+          <li>Para qué sirven las tablas: estructurar datos tabulares.</li>
+          <li>Para qué no sirven: la maquetación, ni <em>ninguna otra cosa</em>.</li>
+          <li>Sintaxis básica de una tabla: <code>&lt;table&gt;</code>, <code>&lt;tr&gt;</code> y <code>&lt;td&gt;</code>.</li>
+          <li>Definir encabezados de tabla con <code>&lt;th&gt;</code>.</li>
+          <li>Abarcar varias columnas y filas con <code>colspan</code> y <code>rowspan</code>.</li>
+          <li>Agrupar columnas con <code>&lt;colgroup&gt;</code> y <code>&lt;col&gt;</code>.</li>
+        </ul>
+      </td>
     </tr>
   </tbody>
 </table>
 
 ## ¿Qué es una tabla?
 
-Una tabla es un conjunto estructurado de datos distribuidos en filas y columnas (**datos tabulados**). Una tabla permite buscar con rapidez y facilidad valores entre diferentes tipos de datos que indiquen algún tipo de conexión. Por ejemplo, una persona y su edad, o un día de la semana o el horario de una piscina municipal.
+Una tabla es un conjunto estructurado de datos compuesto por filas y columnas (**datos tabulares**). Una tabla te permite consultar de forma rápida y sencilla valores que indican algún tipo de conexión entre distintos tipos de datos, por ejemplo una persona y su edad, o un día de la semana, o el horario de una piscina municipal.
 
-![Una tabla de datos de ejemplo que muestra los nombres y las edades de algunas personas: Chris 38, Dennis 45, Sarah 29, Karen 47.](numbers-table.png)
+![Una tabla de ejemplo que muestra nombres y edades de algunas personas: Chris 38, Dennis 45, Sarah 29, Karen 47.](numbers-table.png)
 
-![Una tabla de datos que muestra unos horarios de clases natación](swimming-timetable.png)
+![Un horario de piscina que muestra una tabla de datos de ejemplo](swimming-timetable.png)
 
-Las tablas se utilizan con mucha frecuencia en la sociedad desde hace años, como lo demuestra este documento censal de los EUA de 1800:
+Las tablas se usan mucho en la sociedad humana, y desde hace mucho tiempo, como demuestra este documento del censo de los Estados Unidos de 1800:
 
-![Un pergamino muy antiguo; cuesta un poco leer los datos, pero muestra con claridad que las tablas de datos ya se utilizaban en 1800.](1800-census.jpg)
+![Un documento en pergamino muy antiguo; los datos no se leen con facilidad, pero se ve claramente que se está usando una tabla de datos.](1800-census.jpg)
 
-Por lo tanto, no es de extrañar que los creadores de HTML proporcionen un medio con el que estructurar y presentar datos en tablas en la web.
+No es de extrañar, por tanto, que quienes crearon HTML proporcionaran un medio para estructurar y presentar datos tabulares en la web.
 
 ### ¿Cómo funciona una tabla?
 
-El aspecto básico de una tabla es que es un elemento rígido. Es fácil interpretar la información haciendo asociaciones visuales entre los encabezados de las filas y las columnas. Por ejemplo, observa la tabla siguiente y busca un gigante de gas joviano con 62 lunas. Puedes encontrar la respuesta asociando los encabezados de la fila y la columna correspondientes.
+El aspecto básico de una tabla es que es un elemento rígido. Es fácil interpretar la información haciendo asociaciones visuales entre los encabezados de las filas y las columnas. Por ejemplo, observa la tabla siguiente y busca un gigante gaseoso joviano con 62 lunas. Puedes encontrar la respuesta asociando los encabezados de la fila y la columna correspondientes.
 
+```html hidden
 <table>
   <caption>
     Datos sobre los planetas de nuestro sistema solar (datos planetarios tomados
     de la hoja técnica sobre datos planetarios de la NASA (<a
-      href="http://nssdc.gsfc.nasa.gov/planetary/factsheet/"
+      href="https://nssdc.gsfc.nasa.gov/planetary/factsheet/"
       >Nasa's Planetary Fact Sheet - Metric</a
     >).
   </caption>
@@ -182,47 +194,63 @@ El aspecto básico de una tabla es que es un elemento rígido. Es fácil interpr
       <td>
         Desclasificado como planeta en 2006, pero aún es una
         <a
-          href="http://www.usatoday.com/story/tech/2014/10/02/pluto-planet-solar-system/16578959/"
+          href="https://www.usatoday.com/story/tech/2014/10/02/pluto-planet-solar-system/16578959/"
           >cuestión polémica</a
         >.
       </td>
     </tr>
   </tbody>
 </table>
+```
 
-Cuando se hace correctamente, incluso las personas ciegas pueden interpretar los datos de una tabla HTML. Una tabla HTML bien hecha debe mejorar la experiencia de los usuarios videntes e invidentes por igual.
+```css hidden
+table {
+  border-collapse: collapse;
+  border: 2px solid black;
+}
+
+th,
+td {
+  padding: 5px;
+  border: 1px solid black;
+}
+```
+
+{{EmbedLiveSample("¿Cómo_funciona_una_tabla", 100, 560)}}
+
+Cuando se implementan correctamente, las herramientas de accesibilidad como los lectores de pantalla manejan bien las tablas HTML, así que una tabla HTML bien hecha debe mejorar la experiencia de las personas videntes e invidentes por igual.
 
 ### Dar estilo a las tablas
 
-También puedes [echar un vistazo al ejemplo vivo](https://mdn.github.io/learning-area/html/tables/assessment-finished/planets-data.html) en GitHub. Observarás que la tabla que encontrarás allí tiene un aspecto más legible; esto se debe a que la tabla que ves en esta página tiene un estilo mínimo, mientras que en la de la versión de GitHub se ha aplicado un CSS más significativo.
+También puedes [echar un vistazo al ejemplo en vivo de los datos de los planetas](https://mdn.github.io/learning-area/html/tables/planets-data/) en GitHub. Una cosa que notarás es que allí la tabla se lee bastante mejor: esto se debe a que la tabla que ves más arriba en esta página tiene un estilo mínimo, mientras que la versión de GitHub tiene aplicado un CSS bastante más elaborado.
 
-No te hagas ilusiones; para que las tablas sean efectivas en la web, debes proporcionar cierta información de estilo con [CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics_b957eec7deaf1ea2b20721d6838ea6e1), así como una buena estructura sólida con HTML. En este módulo nos centramos en la parte HTML; para averiguar sobre la parte del CSS debes visitar nuestro artículo [Aplicar estilo a las tablas](/es/docs/Learn_web_development/Core/Styling_basics/Tables).
+No te hagas ilusiones: para que las tablas sean eficaces en la web, necesitas aportar cierta información de estilo con [CSS](/es/docs/Learn_web_development/Core/Styling_basics), además de una buena estructura sólida con HTML. En esta lección nos centramos en la parte de HTML; aprenderás a dar estilo a las tablas más adelante, en nuestra lección [Dar estilo a tablas](/es/docs/Learn_web_development/Core/Styling_basics/Tables).
 
-En este módulo no nos vamos a centrar en el CSS, sino que te vamos a proporcionar una hoja de estilo de CSS que dará a tus tablas algo más de legibilidad de la que se obtiene por defecto si no se proporciona ningún estilo. Puedes encontrar la hoja de estilo [aquí](https://github.com/mdn/learning-area/blob/master/html/tables/basic/minimal-table.css), así como también una [plantilla HTML](https://github.com/mdn/learning-area/blob/master/html/tables/basic/blank-template.html) para aplicar la hoja de estilo (te darán un buen punto de partida para experimentar con las tablas HTML).
+En este módulo no nos centraremos en CSS, pero te proporcionamos una hoja de estilos CSS mínima para que la uses y tus tablas se lean mejor que con el estilo predeterminado que se obtiene sin dar ningún estilo. Puedes encontrar la [hoja de estilos aquí](https://github.com/mdn/learning-area/blob/main/html/tables/basic/minimal-table.css), y también una [plantilla HTML](https://github.com/mdn/learning-area/blob/main/html/tables/basic/blank-template.html) que la aplica; juntas te darán un buen punto de partida para experimentar con tablas HTML.
 
 ### ¿Cuándo no debes usar tablas HTML?
 
-Las tablas HTML están pensadas para utilizarse con datos tabulados. Por desgracia, mucha gente utiliza las tablas HTML para hacer compaginaciones de páginas web. Por ejemplo, una fila para contener la cabecera, una fila para contener las columnas de contenido, una fila para contener el pie de página, etc. Puede encontrar más detalles y un ejemplo en [Diseños de página](/es/docs/Learn_web_development/Core/Accessibility/HTML#page_layouts) en nuestro [Módulo de aprendizaje de accesibilidad](/es/docs/Learn_web_development/Core/Accessibility). Se solía hacer este uso de las tablas porque la compatibilidad CSS entre navegadores solía ser terrible. Los diseños de tablas son mucho menos comunes hoy en día, pero aún se pueden ver en algunos rincones de la web.
+Las tablas HTML deben usarse para datos tabulares (información que resulta fácil de manejar en filas y columnas): para eso están diseñadas. Por desgracia, mucha gente solía usar tablas HTML para maquetar páginas web, por ejemplo una fila para la cabecera de la página, una fila para cada columna de contenido, una fila para el pie, etc. Esta técnica se usaba en el pasado porque la compatibilidad con CSS en los navegadores era mucho más limitada. Los navegadores modernos tienen una compatibilidad sólida con CSS, así que las maquetaciones basadas en tablas ya no son necesarias. Hoy son extremadamente raras, pero todavía puedes verlas en algunos rincones de la web.
 
-En resumen, es una mala idea usar tablas para el diseño en lugar de las [técnicas de diseño CSS](/es/docs/Learn_web_development/Core/CSS_layout). Las razones principales son las siguientes:
+En resumen, usar tablas para maquetar en vez de [técnicas de maquetación con CSS](/es/docs/Learn_web_development/Core/CSS_layout) es mala idea. Los motivos principales son estos:
 
-1. **Las tablas de diseño reducen la accesibilidad para los usuarios con discapacidad visual**: Los [lectores de pantalla](/es/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Screenreaders) que utilizan las personas con visibilidad reducida interpretan las etiquetas de una página HTML y leen su contenido para el usuario. Puesto que las tablas no son la herramienta adecuada para el diseño y el marcado es más complejo que con las técnicas de diseño CSS, la salida de los lectores de pantalla será confusa para estos usuarios.
-2. **Las tablas generan estructuras incorrectas**: Como ya se mencionó, los diseños de tabla suelen involucrar estructuras de marcado más complejas que las técnicas de diseño. Esto puede dificultar la escritura, el mantenimiento y la depuración del código.
-3. **Las tablas no tienen respuesta adaptativa automática**: Cuando usas contenedores de diseño adecuados (tales como {{HTMLElement ("header")}}, {{HTMLElement ("section")}}, {{HTMLElement ("article")}} o {{HTMLElement ("div")}}), su ancho predeterminado es el 100% de su elemento padre. En cambio, las tablas se dimensionan de forma predeterminada según su contenido, por lo que se necesitan medidas adicionales para que el diseño de la tabla funcione de manera efectiva en todos los dispositivos.
+1. **Las tablas de maquetación reducen la accesibilidad para las personas con discapacidad visual**: los [lectores de pantalla](/es/docs/Learn_web_development/Core/Accessibility/Tooling#screen_readers), que usan las personas ciegas, interpretan las etiquetas que hay en una página HTML y leen su contenido en voz alta. Como las tablas no son la herramienta adecuada para maquetar, y el marcado es más complejo que con las técnicas de maquetación de CSS, la salida del lector de pantalla resultará confusa para quien lo usa.
+2. **Las tablas producen sopa de etiquetas**: como se ha mencionado, las maquetaciones con tablas suelen implicar estructuras de marcado más complejas que las técnicas de maquetación adecuadas. Esto puede hacer que el código sea más difícil de escribir, mantener y depurar.
+3. **Las tablas no son adaptables automáticamente**: cuando usas contenedores de maquetación adecuados (como {{htmlelement("header")}}, {{htmlelement("section")}}, {{htmlelement("article")}} o {{htmlelement("div")}}), su ancho es de forma predeterminada el 100 % del elemento padre. Las tablas, en cambio, se dimensionan de forma predeterminada según su contenido, así que hacen falta medidas adicionales para que el estilo de una maquetación con tablas funcione bien en una variedad de dispositivos.
 
-## Aprendizaje activo: Crea tu primera tabla
+## Crea tu primera tabla
 
-Ya hemos hablado bastante sobre la teoría de las tablas, así que veamos un ejemplo práctico y construyamos una tabla simple.
+Ya hemos hablado bastante de teoría, así que vamos a meternos en un ejemplo práctico y a construir una tabla sencilla.
 
-1. En primer lugar, haz una copia local de [blank-template.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/blank-template.html) y [minimal-table.css](https://github.com/mdn/learning-area/blob/master/html/tables/basic/minimal-table.css) en un directorio nuevo de tu ordenador.
-2. El contenido de cada tabla está delimitado entre estas dos etiquetas: **[`<table></table>`](/es/docs/Web/HTML/Reference/Elements/table)**. Añádelas al cuerpo de tu código HTML.
-3. El contenedor más pequeño dentro de una tabla es una celda, que se crea con un elemento **[`<td>`](/es/docs/Web/HTML/Reference/Elements/td)** ('td' significa 'table data', _datos de tabla_). Añade lo siguiente dentro de tus etiquetas de tabla:
+1. Antes que nada, haz una copia de [blank-template.html](https://github.com/mdn/learning-area/blob/main/html/tables/basic/blank-template.html) y [minimal-table.css](https://github.com/mdn/learning-area/blob/main/html/tables/basic/minimal-table.css) en un directorio nuevo de tu equipo. La plantilla HTML ya contiene un elemento `<link>` que aplica el CSS al HTML, así que no tienes que preocuparte por eso.
+2. El contenido de toda tabla va encerrado entre estas dos etiquetas: **[`<table></table>`](/es/docs/Web/HTML/Reference/Elements/table)**. Agrégalas dentro del `body` de tu HTML.
+3. El contenedor más pequeño dentro de una tabla es una celda, que se crea con un elemento **[`<td>`](/es/docs/Web/HTML/Reference/Elements/td)** («td» viene de _table data_, datos de tabla). Agrega lo siguiente dentro de las etiquetas de tu tabla:
 
    ```html
    <td>Hola, soy tu primera celda.</td>
    ```
 
-4. Si quieres una fila de cuatro celdas, tienes que copiar estas etiquetas tres veces. Actualiza el contenido de la tabla para que se vea así:
+4. Si queremos una fila de cuatro celdas, tenemos que copiar estas etiquetas tres veces. Actualiza el contenido de tu tabla para que quede así:
 
    ```html
    <td>Hola, soy tu primera celda.</td>
@@ -231,11 +259,11 @@ Ya hemos hablado bastante sobre la teoría de las tablas, así que veamos un eje
    <td>Soy tu cuarta celda.</td>
    ```
 
-Como verás, las celdas no se colocan una debajo de la otra, sino que se alinean automáticamente entre sí en la misma fila. Cada elemento \<td> crea una sola celda, y juntas forman la primera fila. Cada celda que agregamos hace crecer la fila.
+Como verás, las celdas no se colocan una debajo de otra, sino que se alinean automáticamente entre sí en la misma fila. Cada elemento `<td>` crea una sola celda y juntas forman la primera fila. Cada celda que agregamos hace que la fila se alargue.
 
-Para detener el crecimiento de esta fila y comenzar a colocar las celdas posteriores en una segunda fila, necesitamos usar el elemento **[`<tr>`](/es/docs/Web/HTML/Reference/Elements/tr)** ('tr' significa 'table row', _fila de tabla_). Vamos a verlo en detalle.
+Para que esta fila deje de crecer y las celdas siguientes empiecen a colocarse en una segunda fila, tenemos que usar el elemento [`<tr>`](/es/docs/Web/HTML/Reference/Elements/tr) («tr» viene de _table row_, fila de tabla). Vamos a investigarlo ahora.
 
-1. Coloca las cuatro celdas que has creado dentro de las etiquetas `<tr>`, de esta forma:
+1. Coloca las cuatro celdas que ya has creado dentro de etiquetas `<tr>`, así:
 
    ```html
    <tr>
@@ -246,35 +274,38 @@ Para detener el crecimiento de esta fila y comenzar a colocar las celdas posteri
    </tr>
    ```
 
-2. Ahora que has hecho una fila, intenta hacer una o dos más: cada fila debe estar delimitada por un elemento `<tr>` adicional, con cada celda contenida en un `<td>`.
+2. Ahora que has hecho una fila, prueba a hacer una o dos más: cada fila hay que envolverla en un elemento `<tr>` adicional, con cada celda contenida en un `<td>`.
 
-Esto debería dar como resultado una tabla similar a la siguiente:
+<details>
+<summary>Haz clic aquí para ver la solución</summary>
 
+Tu HTML terminado debería verse más o menos así:
+
+```html
 <table>
-  <tbody>
-    <tr>
-      <td>Hola, soy tu primera celda.</td>
-      <td>Soy tu segunda celda.</td>
-      <td>Soy tu tercera celda.</td>
-      <td>Soy tu cuarta celda.</td>
-    </tr>
-    <tr>
-      <td>Segunda fila, primera celda.</td>
-      <td>Celda 2.</td>
-      <td>Celda 3.</td>
-      <td>Celda 4.</td>
-    </tr>
-  </tbody>
-</table>
+  <tr>
+    <td>Hola, soy tu primera celda.</td>
+    <td>Soy tu segunda celda.</td>
+    <td>Soy tu tercera celda.</td>
+    <td>Soy tu cuarta celda.</td>
+  </tr>
 
-> [!NOTE]
-> También puedes encontrar esto en GitHub como [simple-table.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/simple-table.html) (consúltalo [en vivo](https://mdn.github.io/learning-area/html/tables/basic/simple-table.html)).
+  <tr>
+    <td>Segunda fila, primera celda.</td>
+    <td>Celda 2.</td>
+    <td>Celda 3.</td>
+    <td>Celda 4.</td>
+  </tr>
+</table>
+```
+
+</details>
 
 ## Añadir encabezados con elementos \<th>
 
-Ahora nos vamos a centrar en los encabezados de tabla: celdas especiales que van al comienzo de una fila o columna y definen el tipo de datos que contiene esa fila o columna (por ejemplo, observa las celdas «Propietario» y «Edad» en el primer ejemplo que se muestra en este artículo). Para ilustrar por qué son útiles, echa un vistazo al ejemplo de tabla siguiente. En primer lugar, el código fuente:
+Ahora vamos a centrarnos en los encabezados de tabla: celdas especiales que van al comienzo de una fila o columna y definen el tipo de datos que contiene esa fila o columna (por ejemplo, observa las celdas «Persona» y «Edad» del primer ejemplo que se muestra en este artículo). Para ilustrar por qué son útiles, echa un vistazo al ejemplo de tabla siguiente. En primer lugar, el código fuente:
 
-```html
+```html live-sample___table-headers
 <table>
   <tr>
     <td>&nbsp;</td>
@@ -305,88 +336,146 @@ Ahora nos vamos a centrar en los encabezados de tabla: celdas especiales que van
     <td>Cuñada</td>
   </tr>
   <tr>
-    <td>Hábitos alimentarios</td>
-    <td>Come las sobras de todos</td>
-
-    <td>Mordisquea la comida</td>
-    <td>Come en abundancia</td>
-
-    <td>Come hasta que revienta</td>
+    <td>Hábitos alimenticios</td>
+    <td>Se come las sobras de todos</td>
+    <td>Picotea la comida</td>
+    <td>Buena comedora</td>
+    <td>Come hasta reventar</td>
   </tr>
 </table>
 ```
 
-Ahora observa la tabla representada:
+```css hidden live-sample___table-headers
+table {
+  border-collapse: collapse;
+}
+td,
+th {
+  border: 1px solid black;
+  padding: 10px 20px;
+}
+```
 
+Y ahora la tabla ya renderizada:
+
+{{EmbedLiveSample("table-headers", "", "250")}}
+
+El problema aquí es que, aunque más o menos se entiende lo que pasa, no resulta tan fácil relacionar los datos entre sí como podría serlo. Si los encabezados de fila y de columna destacaran de alguna manera, sería mucho mejor.
+
+### Añadir encabezados a la tabla de perros
+
+Ahora nos gustaría que probaras a mejorar el ejemplo de la tabla de perros añadiendo algunos encabezados.
+
+1. Primero, haz otra copia de nuestros archivos [blank-template.html](https://github.com/mdn/learning-area/blob/main/html/tables/basic/blank-template.html) y [minimal-table.css](https://github.com/mdn/learning-area/blob/main/html/tables/basic/minimal-table.css) en un directorio nuevo de tu equipo.
+2. Añade el código siguiente dentro del `<body>` de tu HTML:
+
+   ```html
+   <h1>Tabla de perros</h1>
+   <table>
+     <tr>
+       <td>&nbsp;</td>
+       <td>Knocky</td>
+       <td>Flor</td>
+       <td>Ella</td>
+       <td>Juan</td>
+     </tr>
+     <tr>
+       <td>Raza</td>
+       <td>Jack Russell</td>
+       <td>Caniche</td>
+       <td>Perro callejero</td>
+       <td>Cocker Spaniel</td>
+     </tr>
+     <tr>
+       <td>Edad</td>
+       <td>16</td>
+       <td>9</td>
+       <td>10</td>
+       <td>5</td>
+     </tr>
+     <tr>
+       <td>Propietario</td>
+       <td>Suegra</td>
+       <td>Yo</td>
+       <td>Yo</td>
+       <td>Cuñada</td>
+     </tr>
+     <tr>
+       <td>Hábitos alimenticios</td>
+       <td>Se come las sobras de todos</td>
+       <td>Picotea la comida</td>
+       <td>Buena comedora</td>
+       <td>Come hasta reventar</td>
+     </tr>
+   </table>
+   ```
+
+3. Para que los encabezados de la tabla se reconozcan como encabezados, tanto visual como semánticamente, puedes usar el elemento [`<th>`](/es/docs/Web/HTML/Reference/Elements/th) («th» viene de _table header_, encabezado de tabla). Funciona exactamente igual que un `<td>`, salvo que denota un encabezado y no una celda normal. Ve a tu HTML y cambia por elementos `<th>` todos los elementos `<td>` que rodean los encabezados de la tabla.
+4. Guarda tu HTML y cárgalo en un navegador: deberías ver que ahora los encabezados se ven como encabezados.
+
+<details>
+<summary>Haz clic aquí para ver la solución</summary>
+
+Tu HTML terminado debería verse más o menos así:
+
+```html
 <table>
-  <tbody>
-    <tr>
-      <td></td>
-      <td>Knocky</td>
-      <td>Flor</td>
-      <td>Ella</td>
-      <td>Juan</td>
-    </tr>
-    <tr>
-      <td>Raza</td>
-      <td>Jack Russell</td>
-      <td>Caniche</td>
-      <td>Perro callejero</td>
-      <td>Cocker Spaniel</td>
-    </tr>
-    <tr>
-      <td>Edad</td>
-      <td>16</td>
-      <td>9</td>
-      <td>10</td>
-      <td>5</td>
-    </tr>
-    <tr>
-      <td>Propietario</td>
-      <td>Suegra</td>
-      <td>Yo</td>
-      <td>Yo</td>
-      <td>Cuñada</td>
-    </tr>
-    <tr>
-      <td>Hábitos alimentarios</td>
-      <td>Come las sobras de todos</td>
-      <td>Mordisquea la comida</td>
-      <td>Come en abundancia</td>
-      <td>Come hasta que revienta</td>
-    </tr>
-  </tbody>
+  <tr>
+    <td>&nbsp;</td>
+    <th>Knocky</th>
+    <th>Flor</th>
+    <th>Ella</th>
+    <th>Juan</th>
+  </tr>
+  <tr>
+    <th>Raza</th>
+    <td>Jack Russell</td>
+    <td>Caniche</td>
+    <td>Perro callejero</td>
+    <td>Cocker Spaniel</td>
+  </tr>
+  <tr>
+    <th>Edad</th>
+    <td>16</td>
+    <td>9</td>
+    <td>10</td>
+    <td>5</td>
+  </tr>
+  <tr>
+    <th>Propietario</th>
+    <td>Suegra</td>
+    <td>Yo</td>
+    <td>Yo</td>
+    <td>Cuñada</td>
+  </tr>
+  <tr>
+    <th>Hábitos alimenticios</th>
+    <td>Se come las sobras de todos</td>
+    <td>Picotea la comida</td>
+    <td>Buena comedora</td>
+    <td>Come hasta reventar</td>
+  </tr>
 </table>
+```
 
-El problema aquí es que, si bien puedes distinguir lo que sucede, no es tan fácil cruzar datos de referencia. Sería mucho mejor si los encabezados de las columnas y las filas se destacasen de alguna manera.
-
-### Aprendizaje activo: encabezados de tabla
-
-Intentemos mejorar esta tabla.
-
-1. Primero, haz una copia local de nuestros archivos [dogs-table.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/dogs-table.html) y [minimal-table.css](https://github.com/mdn/learning-area/blob/master/html/tables/basic/minimal-table.css) en un directorio nuevo de tu ordenador. El HTML contiene el mismo ejemplo sobre perros que viste arriba.
-2. Para reconocer los encabezados de la tabla como encabezados, tanto visual como semánticamente, puedes usar el elemento **[`<th>`](/es/docs/Web/HTML/Reference/Elements/th)** ('th' significa 'table header', _encabezado de tabla_). Funciona exactamente igual que un `<td>`, excepto que denota un encabezado, no una celda normal. Entra en el código HTML, y cambiar todos los elementos `<td>` que delimitan los encabezados de tabla por elementos `<th>`.
-3. Guarda tu HTML y cárgalo en un navegador. Los encabezados deberían verse como tal.
-
-> [!NOTE]
-> Puedes encontrar nuestro ejemplo terminado en [dogs-table-fixed.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/dogs-table-fixed.html) en GitHub ([o consultarlo en vivo](https://mdn.github.io/learning-area/html/tables/basic/dogs-table-fixed.html)).
+</details>
 
 ### ¿Por qué son útiles los encabezados?
 
-Ya hemos respondido parcialmente a esta pregunta: es más fácil encontrar los datos que buscas cuando los encabezados se destacan con claridad, y el diseño suele presentar un aspecto mejor.
+Ya hemos respondido en parte a esta pregunta: es más fácil encontrar los datos que buscas cuando los encabezados destacan claramente, y en general el diseño se ve mejor.
 
 > [!NOTE]
-> Los encabezados de las tablas vienen con un estilo predeterminado: están en negrita y centrados (incluso si no añades tu estilo propio a la tabla) para que destaquen.
+> Los encabezados de tabla vienen con algo de estilo predeterminado: aparecen en negrita y centrados aunque no añadas tu propio estilo a la tabla, para ayudarles a destacar.
 
-Los encabezados de tabla también presentan otra ventaja: junto con el atributo de `scope` (que veremos en el próximo artículo), mejoran la accesibilidad de las tablas porque asocian cada encabezado con todos los datos de la misma fila o columna. Así que los lectores de pantalla pueden leer una fila o columna de datos a la vez, lo cual es bastante útil.
+Los encabezados de tabla tienen además otra ventaja: junto con el atributo `scope` (que veremos en el artículo siguiente), permiten hacer las tablas más accesibles asociando cada encabezado con todos los datos de la misma fila o columna. Los lectores de pantalla pueden entonces leer de una vez toda una fila o columna de datos, lo cual resulta bastante útil.
 
-## Celdas que abarcan varias filas y columnas
+## Permitir que las celdas abarquen varias filas y columnas
 
-A veces queremos que las celdas abarquen varias filas o columnas. Toma el ejemplo siguiente, que muestra los nombres de algunos animales comunes. En algunos casos, queremos mostrar los nombres de los machos y las hembras junto al nombre del animal. A veces no lo queremos, y en tales casos queremos que el nombre del animal abarque toda la tabla.
+A veces queremos que las celdas abarquen varias filas o columnas. Toma el ejemplo sencillo siguiente, que muestra los nombres de algunos animales comunes. En algunos casos queremos mostrar los nombres de los machos y las hembras junto al nombre del animal. A veces no, y en esos casos queremos que el nombre del animal abarque toda la tabla.
 
 El marcado inicial se ve así:
 
-```html
+```html live-sample___multiple-rows-columns
 <table>
   <tr>
     <th>Animales</th>
@@ -406,7 +495,6 @@ El marcado inicial se ve así:
   </tr>
   <tr>
     <th>Pollo</th>
-
     <td>Gallina</td>
   </tr>
   <tr>
@@ -415,147 +503,258 @@ El marcado inicial se ve así:
 </table>
 ```
 
-Pero la salida no nos da exactamente lo que queremos:
+```css hidden live-sample___multiple-rows-columns
+table {
+  border-collapse: collapse;
+}
+td,
+th {
+  border: 1px solid black;
+  padding: 10px 20px;
+}
+```
 
-<table>
-  <tbody>
-    <tr>
-      <th>Animales</th>
-    </tr>
-    <tr>
-      <th>Hipopótamo</th>
-    </tr>
-    <tr>
-      <th>Caballo</th>
-      <td>Yegua</td>
-    </tr>
-    <tr>
-      <td>Semental</td>
-    </tr>
-    <tr>
-      <th>Cocodrilo</th>
-    </tr>
-    <tr>
-      <th>Pollo</th>
-      <td>Gallina</td>
-    </tr>
-    <tr>
-      <td>Gallo</td>
-    </tr>
-  </tbody>
-</table>
+Pero el resultado no es exactamente lo que queremos:
 
-Necesitamos una forma de hacer que «Animales», «Hipopótamo» y «Cocodrilo» se extiendan dos columnas más allá, y «Caballo» y «Pollo» se extiendan dos filas más abajo. Por fortuna, los encabezados de tabla y las celdas tienen los atributos `colspan` y `rowspan`, que nos permiten hacer exactamente esas cosas. Ambos aceptan un valor numérico sin unidades, que es igual al número de filas o columnas que desea abarcar. Por ejemplo, `colspan="2"` extiende una celda dos columnas más allá.
+{{EmbedLiveSample("multiple-rows-columns", "", "350")}}
 
-Usemos `colspan` y `rowspan` para mejorar esta tabla.
+### Arreglar la disposición con `rowspan` y `colspan`
 
-1. Primero, haz una copia local de nuestros archivos [animals-table.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/animals-table.html) y [minimal-table.css](https://github.com/mdn/learning-area/blob/master/html/tables/basic/minimal-table.css) en un directorio nuevo de tu ordenador. El HTML contiene el mismo ejemplo sobre animales que viste arriba.
-2. Luego, usa `colspan` para extender las celdas «Animales», «Hipopótamo» y «Cocodrilo» dos columnas más allá.
-3. Por último, usa `rowspan` para extender las celdas de «Caballo» y «Pollo» dos filas más abajo.
-4. Guarda tu código y ábrelo en un navegador para ver la mejora.
+Necesitamos una forma de que «Animales», «Hipopótamo» y «Cocodrilo» abarquen dos columnas, y que «Caballo» y «Pollo» abarquen hacia abajo dos filas. Por suerte, los encabezados y las celdas de tabla tienen los atributos `colspan` y `rowspan`, que nos permiten hacer justamente eso. Ambos aceptan un valor numérico sin unidades, que equivale al número de filas o columnas que quieres abarcar. Por ejemplo, `colspan="2"` hace que una celda abarque dos columnas.
 
-> [!NOTE]
-> Puedes encontrar nuestro ejemplo terminado en [animals-table-fixed.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/animals-table-fixed.html) en GitHub ([o consultarlo en vivo](https://mdn.github.io/learning-area/html/tables/basic/animals-table-fixed.html)).
+Vamos a usar `colspan` y `rowspan` para mejorar esta tabla.
 
-## Proporcionar un estilo común a las columnas
+1. Haz otra copia local de nuestros archivos [blank-template.html](https://github.com/mdn/learning-area/blob/main/html/tables/basic/blank-template.html) y [minimal-table.css](https://github.com/mdn/learning-area/blob/main/html/tables/basic/minimal-table.css) en un directorio nuevo de tu equipo.
+2. Añade lo siguiente dentro del `<body>` de tu HTML:
 
-Hay una última característica de la que queremos hablar en este artículo antes de continuar. El HTML tiene un método para definir información de estilo para una columna completa de datos en un solo lugar: los elementos **[`<col>`](/es/docs/Web/HTML/Reference/Elements/col)** y **[`<colgroup>`](/es/docs/Web/HTML/Reference/Elements/colgroup)**. Estos atributos existen porque especificar el estilo de las columnas puede resultar enojoso e ineficiente; en general hay que especificar la información de estilo en _cada_ `<td>` o `<th>` de la columna, o utilizar un selector complejo como {{cssxref(":nth-child()")}}.
+   ```html
+   <table>
+     <tr>
+       <th>Animales</th>
+     </tr>
+     <tr>
+       <th>Hipopótamo</th>
+     </tr>
+     <tr>
+       <th>Caballo</th>
+       <td>Yegua</td>
+     </tr>
+     <tr>
+       <td>Semental</td>
+     </tr>
+     <tr>
+       <th>Cocodrilo</th>
+     </tr>
+     <tr>
+       <th>Pollo</th>
+       <td>Gallina</td>
+     </tr>
+     <tr>
+       <td>Gallo</td>
+     </tr>
+   </table>
+   ```
 
-Tomemos el ejemplo sencillo siguiente:
+3. A continuación, usa `colspan` para que «Animales», «Hipopótamo» y «Cocodrilo» abarquen dos columnas.
+4. Por último, usa `rowspan` para que «Caballo» y «Pollo» abarquen dos filas.
+5. Guarda y abre tu código en un navegador para ver la mejora.
+
+<details>
+<summary>Haz clic aquí para ver la solución</summary>
+
+Tu HTML terminado debería verse más o menos así:
 
 ```html
 <table>
   <tr>
-    <th>Dato 1</th>
-    <th style="background-color: yellow">Dato 2</th>
+    <th colspan="2">Animales</th>
   </tr>
   <tr>
-    <td>Calcuta</td>
-    <td style="background-color: yellow">Pizza</td>
+    <th colspan="2">Hipopótamo</th>
   </tr>
   <tr>
-    <td>Robots</td>
-    <td style="background-color: yellow">Jazz</td>
+    <th rowspan="2">Caballo</th>
+    <td>Yegua</td>
+  </tr>
+  <tr>
+    <td>Semental</td>
+  </tr>
+  <tr>
+    <th colspan="2">Cocodrilo</th>
+  </tr>
+  <tr>
+    <th rowspan="2">Pollo</th>
+    <td>Gallina</td>
+  </tr>
+  <tr>
+    <td>Gallo</td>
   </tr>
 </table>
 ```
 
-Esto nos da el resultado siguiente:
+</details>
 
-<table>
-  <tr>
-    <th>Dato 1</th>
-    <th style="background-color: yellow">Dato 2</th>
-  </tr>
-  <tr>
-    <td>Calcuta</td>
-    <td style="background-color: yellow">Pizza</td>
-  </tr>
-  <tr>
-    <td>Robots</td>
-    <td style="background-color: yellow">Jazz</td>
-  </tr>
-</table>
+## Agrupar columnas con `<colgroup>` y `<col>`
 
-Esto no es ideal, porque hay que repetir la información de estilo en las tres celdas de la columna (en un proyecto real probablemente habría definida una clase `class` en las tres celdas y el estilo se especificaría en una hoja de estilo por separado). En vez de hacer esto, podemos especificar la información una sola vez, con un elemento `<col>`. Los elementos `<col>` se especifican dentro de un contenedor `<colgroup>` justo debajo de la etiqueta de apertura `<table>`. Podríamos crear el mismo efecto que vemos arriba especificando nuestra tabla de la manera siguiente:
+Hay una forma de apuntar a columnas enteras de una tabla como una sola entidad, por ejemplo al aplicar estilos a una tabla (algo que aprenderás más adelante en [Dar estilo a tablas](/es/docs/Learn_web_development/Core/Styling_basics/Tables)). A medida que ganes experiencia creando tablas HTML, descubrirás que aplicar un color de fondo, por ejemplo, a todas las celdas de una sola columna es más difícil de lo que parece. Los elementos {{htmlelement("colgroup")}} y {{htmlelement("col")}} ofrecen una solución a este problema.
 
-```html
+El elemento `<colgroup>` debe incluirse como hijo de la tabla, justo después de la etiqueta de apertura `<table>`. Dentro del elemento `<colgroup>` puedes incluir uno o más elementos `<col>`, que representan grupos de columnas. El elemento `<col>` puede incluir un atributo `span` que indica el número de columnas de ese grupo. También puede incluir atributos globales como `style` (si quieres apuntar al grupo con estilos en línea) o `class` (si quieres apuntar a ese grupo con CSS o JavaScript mediante un nombre de clase). Los elementos `<col>` representan las columnas de la tabla desde el principio, por ejemplo desde el lado izquierdo en una tabla escrita en un idioma que se lee de izquierda a derecha, como el español.
+
+Veamos un ejemplo para entenderlo. La tabla siguiente muestra un horario escolar:
+
+```html live-sample___colgroup-col
+<h1>Horario escolar de idiomas</h1>
+
 <table>
   <colgroup>
-    <col />
-    <col style="background-color: yellow" />
+    <col span="2" />
+    <col class="column-background" />
+    <col class="column-fixed-width" />
+    <col class="column-background" />
+    <col class="column-background-border" />
+    <col span="2" class="column-fixed-width" />
   </colgroup>
   <tr>
-    <th>Dato 1</th>
-
-    <th>Dato 2</th>
+    <td>&nbsp;</td>
+    <th>Lun</th>
+    <th>Mar</th>
+    <th>Mié</th>
+    <th>Jue</th>
+    <th>Vie</th>
+    <th>Sáb</th>
+    <th>Dom</th>
   </tr>
   <tr>
-    <td>Calcuta</td>
-    <td>Pizza</td>
+    <th>1.ª hora</th>
+    <td>Inglés</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+    <td>Alemán</td>
+    <td>Neerlandés</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
   </tr>
   <tr>
-    <td>Robots</td>
-    <td>Jazz</td>
+    <th>2.ª hora</th>
+    <td>Inglés</td>
+    <td>Inglés</td>
+    <td>&nbsp;</td>
+    <td>Alemán</td>
+    <td>Neerlandés</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+  </tr>
+  <tr>
+    <th>3.ª hora</th>
+    <td>&nbsp;</td>
+    <td>Alemán</td>
+    <td>&nbsp;</td>
+    <td>Alemán</td>
+    <td>Neerlandés</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
+  </tr>
+  <tr>
+    <th>4.ª hora</th>
+    <td>&nbsp;</td>
+    <td>Inglés</td>
+    <td>&nbsp;</td>
+    <td>Inglés</td>
+    <td>Neerlandés</td>
+    <td>&nbsp;</td>
+    <td>&nbsp;</td>
   </tr>
 </table>
 ```
 
-En efecto, definimos dos tipos de «columnas de estilo», una que especifica la información para la aplicación de estilo en cada columna. No aplicamos estilo a la primera columna, sino que aún tenemos que incluir un elemento `<col>` en blanco; de lo contrario, el estilo también se aplicaría a la primera columna.
-
-Si quisiéramos aplicar la información de estilo a ambas columnas, podríamos incluir un elemento `<col>` con un atributo `span`, como este:
+En esta tabla hay ocho columnas. Veamos más de cerca la estructura de `<colgroup>` y `<col>` para mostrar cómo les afecta:
 
 ```html
 <colgroup>
-  <col style="background-color: yellow" span="2" />
+  <col span="2" />
+  <col class="column-background" />
+  <col class="column-fixed-width" />
+  <col class="column-background" />
+  <col class="column-background-border" />
+  <col span="2" class="column-fixed-width" />
 </colgroup>
 ```
 
-Al igual que `colspan` y `rowspan`, `span` toma un valor numérico sin unidades que especifica el número de columnas a las que se desea aplicar el estilo.
+Si observamos los elementos `<col>`:
 
-### Aprendizaje activo: colgroup y col
+- El primero tiene `span="2"`, así que representa la primera _y_ la segunda columna desde la izquierda de la tabla. No apuntamos a estas columnas con ningún estilo, pero necesitamos incluirlo para poder apuntar a las columnas siguientes.
+- El segundo y el cuarto no tienen el atributo `span`, así que representan una sola columna: la tercera y la quinta, respectivamente. Tienen aplicada la clase `column-background`.
+- El tercero no tiene el atributo `span` y tiene aplicada la clase `column-fixed-width`. Representa la cuarta columna.
+- El quinto no tiene el atributo `span` y tiene aplicada la clase `column-background-border`. Representa la sexta columna.
+- El sexto tiene `span="2"` y la clase `column-fixed-width`. Representa la séptima y la octava columna.
 
-Ahora es el momento de intentarlo tú mismo.
+Hemos ocultado la mayor parte del CSS de este ejemplo, pero te mostramos las reglas que aplican estilos a los elementos `<col>` que tienen las clases `column-background`, `column-fixed-width` y `column-background-border`:
 
-A continuación puedes ver el horario de una profesora de idiomas. El viernes tiene que enseñar holandés todo el día, pero también enseña alemán durante unas horas los martes y los jueves, y quiere resaltar las columnas que contienen los días que da clase.
+```css hidden live-sample___colgroup-col
+html {
+  font-family: sans-serif;
+}
 
-{{EmbedGHLiveSample("learning-area/html/tables/basic/timetable-fixed.html", '100%', 320)}}
+body {
+  margin: 0 20px;
+}
 
-Recrea la tabla a partir de los pasos siguientes.
+table {
+  border-collapse: collapse;
+  border: 2px solid rgb(200 200 200);
+  letter-spacing: 1px;
+  font-size: 0.8rem;
+}
 
-1. Primero, haz una copia local de nuestro archivo [timetable.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/timetable.html) en un directorio nuevo de tu ordenador. El HTML contiene la misma tabla que viste arriba, menos la información de estilo de las columnas.
-2. Añade un elemento `<colgroup>` en la parte superior de la tabla, justo debajo de la etiqueta `<table>`, en la que puedes añadir tus elementos `<col>` (consulta los pasos restantes a continuación).
-3. Las dos primeras columnas deben dejarse sin estilo.
-4. Añade un color de fondo a la tercera columna. El valor para tu atributo de `style` es `background-color:#97DB9A;`
-5. Establece un ancho distinto para la cuarta columna. El valor de tu atributo de `style` es `width: 42px;`
-6. Añade un color de fondo a la quinta columna. El valor para tu atributo de `style` es `background-color:#97DB9A;`
-7. Añade un color de fondo diferente más un borde a la sexta columna, para indicar que este es un día especial porque da clases de un idioma diferente. Los valores para tu atributo de `style` son `background-color:#DCC48E; border:4px solid #C1437A;`
-8. Los últimos dos días los tiene libres, así que no establezcas ningún color de fondo, pero sí un valor para el ancho; el valor para el atributo de `style` es `width: 42px;`
+td,
+th {
+  border: 1px solid rgb(190 190 190);
+  padding: 10px 20px;
+}
 
-Mira cómo sigue en el ejemplo. Si te encallas o quieres verificar tu trabajo, puedes encontrar nuestra versión en GitHub como [timetable-fixed.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/timetable-fixed.html) (o también puedes consultarlo [en vivo](https://mdn.github.io/learning-area/html/tables/basic/timetable-fixed.html)).
+td {
+  text-align: center;
+}
+```
+
+```css live-sample___colgroup-col
+.column-background {
+  background-color: #97db9a;
+}
+
+.column-fixed-width {
+  width: 40px;
+}
+
+.column-background-border {
+  background-color: #dcc48e;
+  border: 4px solid #c1437a;
+}
+```
+
+- Los elementos `<col>` con la clase `column-background` tienen un color de fondo sólido.
+- Los elementos `<col>` con la clase `column-fixed-width` tienen un ancho fijo estrecho.
+- El elemento `<col>` con la clase `column-background-border` tiene un color de fondo sólido y un borde grueso.
+
+No hace falta que te preocupes ahora por cómo funciona el CSS; lo aprenderás en detalle más adelante, en nuestro módulo [Fundamentos de estilo con CSS](/es/docs/Learn_web_development/Core/Styling_basics).
+
+Veamos cómo se renderiza el código anterior:
+
+{{embedlivesample("colgroup-col", "100%", 400)}}
+
+Fíjate en cómo las distintas columnas reciben los estilos especificados en las clases.
+
+> [!NOTE]
+> Aunque `<colgroup>` y `<col>` sirven sobre todo para dar estilo, son una funcionalidad de HTML, así que los hemos cubierto aquí y no en nuestros módulos de CSS. También es justo decir que son una funcionalidad _limitada_: como se muestra en la [página de referencia de `<colgroup>`](/es/docs/Web/HTML/Reference/Elements/colgroup#usage_notes), sólo se puede aplicar un subconjunto limitado de estilos a un elemento `<col>`, y la mayoría del resto de ajustes que estuvieron disponibles históricamente están obsoletos (eliminados, o marcados para su eliminación).
+
+## Repaso interactivo de los conceptos de tablas
+
+El contenido incrustado a continuación, de Scrimba<sup>[_socio de aprendizaje de MDN_](/es/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds)</sup>, ofrece una lección interactiva que resume la mayoría de las técnicas cubiertas en este artículo. Échale un vistazo para repasar los puntos clave y practicar un poco más.
+
+<mdn-scrim-inline url="https://scrimba.com/frontend-path-c0j/~03s" scrimtitle="HTML tables"></scrim-inline>
 
 ## Resumen
 
-Con esto casi hemos abarcado todos los conceptos básicos de las tablas HTML. En el próximo artículo, veremos algunas características un poco más avanzadas de las tablas y comenzaremos a pensar acerca de su accesibilidad para las personas con discapacidad visual.
+Con esto terminan los conceptos básicos de las tablas HTML. En el artículo siguiente veremos algunas funcionalidades adicionales que sirven para hacer las tablas HTML más accesibles a las personas con discapacidad visual.
 
-{{NextMenu("Learn_web_development/Core/Structuring_content/Table_accessibility", "conflicting/Learn_web_development/Core/Structuring_content/HTML_table_basics")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Splash_page", "Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}


### PR DESCRIPTION
### Description

Sincroniza `files/es/learn_web_development/core/structuring_content/html_table_basics/index.md` con la fuente en inglés (`ce12c103`, 2026-09-01).

### Motivation

La página tenía **561 líneas frente a 755** en inglés y **16 vallas de código frente a 36**, y nunca se registró para sincronización (sin `l10n.sourceCommit`). Faltaban secciones completas y los ejemplos usaban la sintaxis antigua, sin identificadores `live-sample___`.

### Verification

| | es | en |
| --- | ---: | ---: |
| encabezados | 13 | 13 |
| vallas de código | 36 | 36 |
| enlaces | 27 | 27 |

- Las 36 vallas coinciden con el inglés en **sangría y etiqueta de lenguaje**, comprobado posición por posición. Importa porque varias van dentro de elementos de lista numerada, y sacarlas a la columna 0 cerraría la lista antes de tiempo.
- Sin enlaces `/en-US/`, sin referencias a `conflicting/`, sin unicode invisible, sin espacios sobrantes, sin tratamiento de usted.
- `prettier --check` y `markdownlint-cli2` pasan.

### Additional details

**Traducción de los ejemplos.** Se traduce el texto visible de las tablas y se conservan los nombres propios y las razas (`Knocky`, `Flor`, `Ella`, `Juan`, `Jack Russell`, `Cocker Spaniel`).

En el ejemplo de animales se usa **Pollo / Gallina / Gallo**, siguiendo la traducción anterior. Traducir tanto _Chicken_ como _Hen_ por «Gallina» dejaría la especie y la hembra con el mismo nombre, y el ejemplo de `rowspan` es precisamente sobre agrupar la especie con sus dos sexos: se perdería el sentido del ejercicio.

**Líneas en blanco alrededor de las vallas dentro de listas.** El archivo lleva una línea en blanco entre el texto del paso y su valla, que el inglés no tiene. No es una divergencia gratuita: la configuración de `markdownlint` de este repositorio marca `MD031` en esos cuatro puntos. Lo comprobé copiando el archivo en inglés dentro de `files/es/` y linteándolo con la configuración de aquí: **da los mismos 4 errores**. O sea que es una diferencia entre las configuraciones de `mdn/content` y `mdn/translated-content`, no algo introducido en esta traducción. La sangría de las vallas no se toca.

**Enlaces externos a https.** Los dos enlaces del ejemplo de planetas estaban en `http://`; el inglés usa `https://`.

Fixes #38422