### PR TITLE
[zh-cn]: update the translation of HTMLMediaElement `loadedmetadata` event

### DIFF
--- a/files/zh-cn/web/api/htmlmediaelement/loadedmetadata_event/index.md
+++ b/files/zh-cn/web/api/htmlmediaelement/loadedmetadata_event/index.md
@@ -1,22 +1,51 @@
 ---
-title: GlobalEventHandlers.onloadedmetadata
+title: HTMLMediaElement：loadedmetadata 事件
 slug: Web/API/HTMLMediaElement/loadedmetadata_event
+l10n:
+  sourceCommit: f5e710f5c620c8d3c8b179f3b062d6bbdc8389ec
 ---
 
-{{ ApiRef("HTML DOM") }}
+{{APIRef("HTMLMediaElement")}}
 
-{{domxref("GlobalEventHandlers")}} mixin 的 **`onloadedmetadata`** 属性是处理[`loadedmetadata`](/zh-CN/docs/Web/API/HTMLMediaElement/loadedmetadata_event)事件的事件处理器。
-
-`loadedmetadata`事件在元数据（metadata）被加载完成后触发。
+**`loadedmetadata`** 事件在元数据加载完成后触发。
 
 ## 语法
 
-```plain
-element.onloadedmetadata = handlerFunction;
-var handlerFunction = element.onloadedmetadata;
+在类似 {{domxref("EventTarget.addEventListener", "addEventListener()")}} 的方法中使用事件名，或者设置事件处理器属性。
+
+```js-nolint
+addEventListener("loadedmetadata", (event) => { })
+
+onloadedmetadata = (event) => { }
 ```
 
-`handlerFunction`应当是`null`或是由[JavaScript 函数](/zh-CN/docs/Web/JavaScript/Reference/Functions)声明的事件 handler。
+## 事件类型
+
+通用 {{domxref("Event")}}。
+
+## 示例
+
+这些示例为 HTMLMediaElement 的 `loadedmetadata` 事件添加事件监听器，并在该事件处理器响应事件触发时发送一条消息。
+
+使用 `addEventListener()`：
+
+```js
+const video = document.querySelector("video");
+
+video.addEventListener("loadedmetadata", (event) => {
+  console.log("现已获知媒体的时长、尺寸和轨道。");
+});
+```
+
+使用 `onloadedmetadata` 事件处理器属性：
+
+```js
+const video = document.querySelector("video");
+
+video.onloadedmetadata = (event) => {
+  console.log("现已获知媒体的时长、尺寸和轨道。");
+};
+```
 
 ## 规范
 
@@ -26,7 +55,29 @@ var handlerFunction = element.onloadedmetadata;
 
 {{Compat}}
 
-## 参考
+## 相关事件
 
-- [`loadedmetadata`](/zh-CN/docs/Web/API/HTMLMediaElement/loadedmetadata_event)
-- [DOM 事件句柄](/zh-CN/docs/Web/API/Document_Object_Model/Events)
+- HTMLMediaElement {{domxref("HTMLMediaElement.playing_event", 'playing')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.waiting_event", 'waiting')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.seeking_event", 'seeking')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.seeked_event", 'seeked')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.ended_event", 'ended')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.loadeddata_event", 'loadeddata')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.canplay_event", 'canplay')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.canplaythrough_event", 'canplaythrough')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.durationchange_event", 'durationchange')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.timeupdate_event", 'timeupdate')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.play_event", 'play')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.pause_event", 'pause')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.ratechange_event", 'ratechange')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.volumechange_event", 'volumechange')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.suspend_event", 'suspend')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.emptied_event", 'emptied')}} 事件
+- HTMLMediaElement {{domxref("HTMLMediaElement.stalled_event", 'stalled')}} 事件
+
+## 参见
+
+- {{domxref("HTMLAudioElement")}}
+- {{domxref("HTMLVideoElement")}}
+- {{HTMLElement("audio")}}
+- {{HTMLElement("video")}}


### PR DESCRIPTION
### Description
* MDN URL: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/loadedmetadata_event
### Related issues and pull requests
* GitHub URL: https://github.com/mdn/content/blob/main/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
* Last commit: https://github.com/mdn/content/commit/f5e710f5c620c8d3c8b179f3b062d6bbdc8389ec

