### PR TITLE
chore(es): sync of `Learn_web_development/Extensions/Server-side/First_steps/Client-Server_overview`

### DIFF
--- a/files/es/learn_web_development/extensions/server-side/first_steps/client-server_overview/index.md
+++ b/files/es/learn_web_development/extensions/server-side/first_steps/client-server_overview/index.md
@@ -1,74 +1,74 @@
 ---
-title: Visión General Cliente-Servidor
+title: Descripción general de cliente-servidor
 slug: Learn_web_development/Extensions/Server-side/First_steps/Client-Server_overview
-original_slug: Learn/Server-side/First_steps/Client-Server_overview
+l10n:
+  sourceCommit: 3e543cdfe8dddfb4774a64bf3decdcbab42a4111
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/First_steps/Introduction", "Learn_web_development/Extensions/Server-side/First_steps/Web_frameworks", "Learn_web_development/Extensions/Server-side/First_steps")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/First_steps/Introduction", "Learn_web_development/Extensions/Server-side/First_steps/Web_frameworks", "Learn_web_development/Extensions/Server-side/First_steps")}}
 
-Ahora que conoces el propósito y los beneficios potenciales de la programación de lado-servidor vamos a examinar en detalle lo que ocurre cuando un servidor recibe una "petición dinámica" desde un explorador web. Ya que el código de lado servidor de la mayoría de los sitios web gestiona peticiones y respuestas de formas similares, este artículo te ayudará a entender lo que necesitas hacer para escribir la mayor parte de tu propio código.
+Ahora que conoces el propósito y los beneficios potenciales de la programación del lado del servidor, vamos a examinar en detalle qué ocurre cuando un servidor recibe una "solicitud dinámica" de un navegador. Dado que la mayoría del código del lado del servidor de los sitios web gestiona las solicitudes y respuestas de formas similares, esto te ayudará a entender lo que necesitas hacer al escribir la mayor parte de tu propio código.
 
 <table>
   <tbody>
     <tr>
-      <th scope="row">Prerequisitos:</th>
+      <th scope="row">Requisitos previos:</th>
       <td>
-        Conocimientos básicos de computación. Noción básica de lo que es un
-        servidor.
+        Comprensión básica de qué es un servidor web.
       </td>
     </tr>
     <tr>
       <th scope="row">Objetivo:</th>
       <td>
-        Comprender lo que son las interacciones cliente-servidor en un sitio web
-        dinámico, y en particular que operaciones necesita realizar el código de
-        lado servidor.
+        Comprender las interacciones cliente-servidor en un sitio web
+        dinámico, y en particular qué operaciones debe realizar el código
+        del lado del servidor.
       </td>
     </tr>
   </tbody>
 </table>
 
-No hay código real en el debate porque ¡todavía no hemos seleccionado el framework web que usaremos para escribir nuestro código! Sin embargo este debate sí que es muy relevante incluso ahora, porque el comportamiento descrito debería ser implementado por tu código de lado servidor independientemente de qué lenguaje de programación o framework web hayas seleccionado.
+No hay código real en el debate porque ¡todavía no hemos elegido un framework web para escribir nuestro código! Sin embargo, este debate sigue siendo muy relevante, porque el comportamiento descrito debe estar implementado por tu código del lado del servidor, independientemente del lenguaje de programación o framework web que elijas.
 
-## Servidores Web y HTTP (iniciación)
+## Servidores web y HTTP (una introducción)
 
-Los exploradores web se comunican con los [servidores web](/es/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_web_server) usando el Protocolo de Transferencia de HyperTexto (**H**yper**T**ext**T**ransfer **P**rotocol [HTTP](/es/docs/Web/HTTP)). Cuando pinchas en un enlace sobre una página web, envías un formulario o ejecutas una búsqueda, el explorador envía una petición (_Request)_ HTTP al servidor.
+Los navegadores web se comunican con [servidores web](/es/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_web_server) usando el **P**rotocolo de **T**ransferencia de **H**iper**T**exto ([HTTP](/es/docs/Web/HTTP)). Cuando haces clic en un enlace de una página web, envías un formulario o realizas una búsqueda, el navegador envía una _solicitud HTTP_ al servidor.
 
-Esta petición incluye:
+Esta solicitud incluye:
 
-- Una URL que identifica el servidor de destino y un recurso (ej. un fichero HTML, un punto de datos particular en el servidor, o una herramienta a ejecutar).
-- Un método que define la acción requerida (por ejemplo, obtener un fichero o salvar o actualizar algunos datos). Los diferentes métodos/verbos y sus acciones asociadas se listan debajo:
-  - `GET`: Obtener un recurso específico (ej. un fichero HTML que contiene información acerca de un producto o una lista de productos).
-  - `POST`: Crear un nuevo recurso (ej. añadir un nuevo artículo a una wiki, añadir un nuevo contacto a una base de datos).
-  - `HEAD`: Obtener la información de los metadatos sobre un recurso específico sin obtener el cuerpo entero tal como haría `GET`. Podrías, por ejemplo, usar una petición `HEAD` para encontrar la última vez que un recurso fue actualizado, y a continuación usar la petición `GET` (más "cara") para descargar el recurso sólo si éste ha cambiado.
-  - `PUT`: Actualizar un recurso existente (o crear uno nuevo si no existe).
-  - `DELETE`: Borrar el recurso específico.
-  - `TRACE`, `OPTIONS`, `CONNECT`, `PATCH`: Estos verbos son para tareas menos comunes/avanzadas, por lo que no los trataremos aquí.
+- Una URL que identifica el servidor de destino y el recurso (por ejemplo, un archivo HTML, un dato en particular del servidor, o una herramienta a ejecutar).
+- Un método que define la acción requerida (por ejemplo, obtener un archivo, o guardar o actualizar algunos datos). Los diferentes métodos/verbos y sus acciones asociadas se listan a continuación:
+  - `GET`: Obtiene un recurso específico (por ejemplo, un archivo HTML con información sobre un producto, o una lista de productos).
+  - `POST`: Crea un nuevo recurso (por ejemplo, añade un nuevo artículo a una wiki, añade un nuevo contacto a una base de datos).
+  - `HEAD`: Obtiene la información de metadatos sobre un recurso específico sin obtener el cuerpo, como haría `GET`. Podrías usar, por ejemplo, una solicitud `HEAD` para averiguar la última vez que un recurso fue actualizado, y usar solo la solicitud `GET` (más "costosa") para descargarlo si ha cambiado.
+  - `PUT`: Actualiza un recurso existente (o crea uno nuevo si no existe).
+  - `DELETE`: Elimina el recurso especificado.
+  - `TRACE`, `OPTIONS`, `CONNECT`, `PATCH`: Estos verbos son para tareas menos comunes/avanzadas, así que no los trataremos aquí.
 
-- Se puede codificar información adicional con la petición (por ejemplo, datos de un formulario HTML). La información puede ser codificada como:
-  - Parámetros URL: Las peticiones `GET` codifican los datos en la URL enviada al servidor añadiendo al final pares nombre/valor — por ejemplo, `http://mysite.com?name=Fred&age=11`. Siempre encontrarás un signo de interrogación(`?`) separando los parámetros URL del resto de la misma, un signo igual (`=`) separando cada nombre de su valor asociado y un ampersand (`&`) separando cada par. Los parámetros URL son inherentemente "inseguros" ya que pueden ser modificados por los usuarios y ser enviados de nuevo. Como consecuencia los parámetros URL/peticiones `GET` no se usan para peticiones de actualización de datos en el servidor.
-  - Datos `POST`. Las peticiones `POST` añaden nuevos recursos, cuyos datos están codificados dentro del cuerpo de la petición.
-  - Cookies de lado cliente. Los Cookies contienen datos de sesión acerca del cliente, incluyendo las claves que el servidor puede usar para determinar su estado de incio de sesión y los permisos/accesos a los recursos.
+- Se puede codificar información adicional junto con la solicitud (por ejemplo, datos de un formulario HTML). La información puede codificarse como:
+  - Parámetros de URL: las solicitudes `GET` codifican los datos en la URL enviada al servidor añadiendo pares nombre/valor al final de esta — por ejemplo, `http://example.com?name=Fred&age=11`. Siempre hay un signo de interrogación (`?`) que separa el resto de la URL de los parámetros de URL, un signo igual (`=`) que separa cada nombre de su valor asociado, y un ampersand (`&`) que separa cada par. Los parámetros de URL son inherentemente "inseguros", ya que los usuarios pueden modificarlos y volver a enviarlos. Como consecuencia, los parámetros de URL/solicitudes `GET` no se usan para solicitudes que actualizan datos en el servidor.
+  - Datos `POST`. Las solicitudes `POST` añaden nuevos recursos, cuyos datos se codifican dentro del cuerpo de la solicitud.
+  - Cookies del lado del cliente. Las cookies contienen datos de sesión sobre el cliente, incluyendo claves que el servidor puede usar para determinar su estado de inicio de sesión y sus permisos/accesos a los recursos.
 
-Los servidores web esperan los mensajes de petición de los clientes, los procesan cuando llegan y responden al explorador web con un mensaje de respuesta HTTP. La respuesta contiene un [código de estado de respuesta HTTP](/es/docs/Web/HTTP/Reference/Status) que indica si la petición ha tenido éxito o no (ej. "`200 OK`" para indicar éxito, "`404 Not Found`" si el resurso no ha podido ser encontrado, "`403 Forbidden`" si el usuario no está autorizado a acceder al recurso, etc). El cuerpo de la respuesta de éxito a una petición `GET` contendría el recurso solicitado.
+Los servidores web esperan los mensajes de solicitud de los clientes, los procesan cuando llegan, y responden al navegador web con un mensaje de respuesta HTTP. La respuesta contiene un [código de estado de respuesta HTTP](/es/docs/Web/HTTP/Reference/Status) que indica si la solicitud tuvo éxito o no (por ejemplo, {{HTTPStatus("200", "200 OK")}} en caso de éxito, {{HTTPStatus("404", "404 Not Found")}} si el recurso no se puede encontrar, {{HTTPStatus("403", "403 Forbidden")}} si el usuario no está autorizado a ver el recurso, etc.). El cuerpo de la respuesta a una solicitud `GET` exitosa contiene el recurso solicitado.
 
-Cuando se devuelve una página HTML es renderizada por el explorador web. Como parte del procesamiento el explorador puede descubrir enlaces a otros recursos (ej. una página HTML normalmente referencia las páginas JavaScript y CSS), y enviará peticiones HTTP separadas para descargar estos ficheros.
+Cuando se devuelve una página HTML, el navegador web la renderiza. Como parte del procesamiento, el navegador puede descubrir enlaces a otros recursos (por ejemplo, una página HTML normalmente hace referencia a archivos JavaScript y CSS), y enviará solicitudes HTTP separadas para descargar esos archivos.
 
-Los sitios web tanto estáticos como dinámicos (abordados en las secciones siguientes) usan exactamente los mismos protocolos/patrones de comunicación.
+Tanto los sitios web estáticos como los dinámicos (que se tratan en las siguientes secciones) usan exactamente el mismo protocolo/patrones de comunicación.
 
-### Ejemplo de petición/respuesta GET
+### Ejemplo de solicitud/respuesta GET
 
-Puedes realizar una petición `GET` simplemente pinchando sobre un enlace o buscando en un sitio (como la página inicial de un motor de búsquedas). Por ejemplo, la petición HTTP que se envía cuando realizas una búsqueda en MDN del término "visión general cliente servidor" se parecerá mucho al texto que se muestra más abajo (no será idéntica porque algunas partes del mensaje dependen de tu explorador/configuración).
+Puedes hacer una simple solicitud `GET` haciendo clic en un enlace o buscando en un sitio (como la página principal de un motor de búsqueda). Por ejemplo, la solicitud HTTP que se envía cuando realizas una búsqueda en MDN del término "descripción general de cliente-servidor" se parecerá mucho al texto que se muestra a continuación (no será idéntica porque partes del mensaje dependen de tu navegador/configuración).
 
 > [!NOTE]
-> El formato de los mensajes HTTP está definido en el "estándard web" ([RFC7230](https://www.rfc-editor.org/rfc/rfc7230.txt)). No necesitas conocer este nivel de detalle, pero al menos ¡ahora sabes de donde viene todo esto!
+> El formato de los mensajes HTTP está definido en un "estándar web" ([RFC9110](https://httpwg.org/specs/rfc9110.html#messages)). No necesitas conocer este nivel de detalle, ¡pero al menos ahora sabes de dónde viene todo esto!
 
-#### La petición
+#### La solicitud
 
-Cada linea de la petición contiene información sobre ella. La primera parte se llama **cabecera** o **header**, y contiene información útil sobre la petición, de la misma manera que un [HTML head](/es/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata) contiene información útil sobre un documento (pero no el contenido mismo, que está en el cuerpo):
+Cada línea de la solicitud contiene información sobre ella. La primera parte se llama el **encabezado**, y contiene información útil sobre la solicitud, de la misma manera que un [encabezado HTML](/es/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata) contiene información útil sobre un documento HTML (pero no el contenido en sí, que está en el cuerpo):
 
-```
-GET https://developer.mozilla.org/en-US/search?q=client+server+overview&topic=apps&topic=html&topic=css&topic=js&topic=api&topic=webdev HTTP/1.1
+```http
+GET /en-US/search?q=client+server+overview&topic=apps&topic=html&topic=css&topic=js&topic=api&topic=webdev HTTP/1.1
 Host: developer.mozilla.org
 Connection: keep-alive
 Pragma: no-cache
@@ -78,46 +78,46 @@ User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like
 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 Referer: https://developer.mozilla.org/en-US/
 Accept-Encoding: gzip, deflate, sdch, br
-Accept-Charset: ISO-8859-1,UTF-8;q=0.7,*;q=0.7
 Accept-Language: en-US,en;q=0.8,es;q=0.6
 Cookie: sessionid=6ynxs23n521lu21b1t136rhbv7ezngie; csrftoken=zIPUJsAZv6pcgCBJSCj1zU6pQZbfMUAT; dwf_section_edit=False; dwf_sg_task_completion=False; _gat=1; _ga=GA1.2.1688886003.1471911953; ffo=true
 ```
 
-La primera y segunda líneas contienen la mayoría de la información de la que hemos hablado arriba:
+La primera y segunda líneas contienen la mayor parte de la información que mencionamos antes:
 
-- El tipo de petición (`GET`).
+- El tipo de solicitud (`GET`).
 - La URL del recurso de destino (`/en-US/search`).
-- Los parámetros URL (`q=client%2Bserver%2Boverview&topic=apps&topic=html&topic=css&topic=js&topic=api&topic=webdev`).
-- El destino/host del sitio web (developer.mozilla.org).
-- El final de la primera linea también incluye una cadena corta que identifica la versión del protocolo utilizado (`HTTP/1.1`).
+- Los parámetros de URL (`q=client%2Bserver%2Boverview&topic=apps&topic=html&topic=css&topic=js&topic=api&topic=webdev`).
+- El sitio web de destino/host (developer.mozilla.org).
+- El final de la primera línea también incluye una cadena corta que identifica la versión específica del protocolo (`HTTP/1.1`).
 
-La última linea contiene información sobre los cookies del lado cliente — puedes ver que en este caso el cookie incluye un id para gestionar las sesiones (`Cookie: sessionid=6ynxs23n521lu21b1t136rhbv7ezngie; ...`).
+La última línea contiene información sobre las cookies del lado del cliente — puedes ver que en este caso la cookie incluye un id para gestionar sesiones (`Cookie: sessionid=6ynxs23n521lu21b1t136rhbv7ezngie; …`).
 
-Las líneas restantes contienen información sobre el explorador web usado y la clase de respuestas que puede manejar. Por ejemplo, puedes ver aquí que:
+Las líneas restantes contienen información sobre el navegador usado y el tipo de respuestas que puede manejar.
+Por ejemplo, aquí puedes ver que:
 
-- Mi explorador (`User-Agent`) es Mozilla Firefox (`Mozilla/5.0`).
-- Puede aceptar información comprimida gzip (`Accept-Encoding: gzip`).
-- Puede aceptar el conjunto de caracteres especificado (`Accept-Charset: ISO-8859-1,UTF-8;q=0.7,*;q=0.7`) y los idiomas (`Accept-Language: de,en;q=0.7,en-us;q=0.3`).
-- La linea `Referer` indica la dirección de la página web que contenía el enlace a este recurso (es decir, el origen de la petición, `https://developer.mozilla.org/en-US/`).
+- Mi navegador (`User-Agent`) es Mozilla Firefox (`Mozilla/5.0`).
+- Puede aceptar información comprimida con gzip (`Accept-Encoding: gzip`).
+- Puede aceptar los idiomas especificados (`Accept-Language: en-US,en;q=0.8,es;q=0.6`).
+- La línea `Referer` indica la dirección de la página web que contenía el enlace a este recurso (es decir, el origen de la solicitud, `https://developer.mozilla.org/en-US/`).
 
-Las peticiones HTTP también pueden tener un cuerpo, pero está vacío en este caso.
+Las solicitudes HTTP también pueden tener un cuerpo, pero en este caso está vacío.
 
 #### La respuesta
 
-La primera parte de la respuesta a esta petición se muestra abajo. La cabecera o header contiene información como la siguiente:
+La primera parte de la respuesta a esta solicitud se muestra a continuación. El encabezado contiene información como la siguiente:
 
-- La primera linea incluye el código de respuesta `200 OK`, que nos dice que la petición ha tenido éxito.
-- Podemos ver que la respuesta está formateada (`Content-Type`) en modo `text/html`.
-- Podemos ver que usa también el conjunto de caracteres UTF-8 (`Content-Type: text/html; charset=utf-8`).
-- La cabecera también nos dice lo grande que es (`Content-Length: 41823`).
+- La primera línea incluye el código de respuesta `200 OK`, que nos indica que la solicitud tuvo éxito.
+- Podemos ver que la respuesta tiene formato `text/html` (`Content-Type`).
+- También podemos ver que usa el conjunto de caracteres UTF-8 (`Content-Type: text/html; charset=utf-8`).
+- El encabezado también nos indica su tamaño (`Content-Length: 41823`).
 
-Al final del mensaje vemos el contenido del **cuerpo** (**body**) — que contiene el HTML real devuelto por la respuesta.
+Al final del mensaje vemos el contenido del **cuerpo** — que contiene el HTML real devuelto por la solicitud.
 
-```
+```http
 HTTP/1.1 200 OK
 Server: Apache
 X-Backend-Server: developer1.webapp.scl3.mozilla.com
-Vary: Accept,Cookie, Accept-Encoding
+Vary: Accept, Cookie, Accept-Encoding
 Content-Type: text/html; charset=utf-8
 Date: Wed, 07 Sep 2016 00:11:31 GMT
 Keep-Alive: timeout=5, max=999
@@ -126,41 +126,28 @@ X-Frame-Options: DENY
 Allow: GET
 X-Cache-Info: caching
 Content-Length: 41823
-```
 
-```html
 <!doctype html>
-<html
-  lang="en-US"
-  dir="ltr"
-  class="redesign no-js"
-  data-ffo-opensanslight="false"
-  data-ffo-opensans="false">
-  <head prefix="og: http://ogp.me/ns#">
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
-    <script>
-      (function (d) {
-        d.className = d.className.replace(/\bno-js/, "");
-      })(document.documentElement);
-    </script>
-    ...
-  </head>
-</html>
+<html lang="en-US" dir="ltr" class="redesign no-js" data-ffo-opensanslight=false data-ffo-opensans=false >
+<head prefix="og: http://ogp.me/ns#">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
+  …
 ```
 
-El resto de la cabecera de la respuesta incluye información sobre la respuesta (ej. cuándo se generó), el servidor, y cómo espera el explorador manejar la página (ej. la linea `X-Frame-Options: DENY` le dice que al explorador que no está permitido incrustar esta página en un {{htmlelement("iframe")}} en otro sitio).
+El resto del encabezado de la respuesta incluye información sobre la respuesta (por ejemplo, cuándo se generó), el servidor, y cómo espera que el navegador maneje la página (por ejemplo, la línea `X-Frame-Options: DENY` le indica al navegador que no permita que esta página se incruste en un {{htmlelement("iframe")}} en otro sitio).
 
-### Ejemplo de petición/respuesta POST
+### Ejemplo de solicitud/respuesta POST
 
-Un HTTP `POST` se realiza cuando se envía un formulario que contiene información para ser guardada en el servidor.
+Se hace una solicitud HTTP `POST` cuando envías un formulario con información que se debe guardar en el servidor.
 
-#### La petición
+#### La solicitud
 
-El texto de abajo muestra la petición HTTP realizada cuando un usuario envía al sitio los detalles de un nuevo perfil. El formato de la petición es casi el mismo que en la petición `GET` del ejemplo mostrado previamente, aunque la primera linea identifica esta petición como `POST`.
+El texto a continuación muestra la solicitud HTTP hecha cuando un usuario envía los datos de un nuevo perfil en este sitio. El formato de la solicitud es casi el mismo que el del ejemplo de solicitud `GET` mostrado previamente, aunque la primera línea identifica esta solicitud como un `POST`.
 
-```
-POST https://developer.mozilla.org/en-US/profiles/hamishwillee/edit HTTP/1.1
+```http
+POST /en-US/profiles/hamishwillee/edit HTTP/1.1
 Host: developer.mozilla.org
 Connection: keep-alive
 Content-Length: 432
@@ -179,13 +166,13 @@ Cookie: sessionid=6ynxs23n521lu21b1t136rhbv7ezngie; _gat=1; csrftoken=zIPUJsAZv6
 csrfmiddlewaretoken=zIPUJsAZv6pcgCBJSCj1zU6pQZbfMUAT&user-username=hamishwillee&user-fullname=Hamish+Willee&user-title=&user-organization=&user-location=Australia&user-locale=en-US&user-timezone=Australia%2FMelbourne&user-irc_nickname=&user-interests=&user-expertise=&user-twitter_url=&user-stackoverflow_url=&user-linkedin_url=&user-mozillians_url=&user-facebook_url=
 ```
 
-La principal diferencia es que la URL no tiene parámetros. Como puedes ver, la información del formulario se codifica en el cuerpo de la petición (por ejemplo, el nombre completo del nuevo usuario se establece usando: `&user-fullname=Hamish+Willee`).
+La principal diferencia es que la URL no tiene parámetros. Como puedes ver, la información del formulario se codifica en el cuerpo de la solicitud (por ejemplo, el nuevo nombre completo del usuario se establece usando: `&user-fullname=Hamish+Willee`).
 
 #### La respuesta
 
-La respuesta a la petición se muestra abajo. El código de estado "`302 Found`" le dice al explorador que el POST ha tenido éxito, y que debe realizar una segunda petición HTTP para cargar la página especificada en el campo `Location`. La información es de lo contrario similar a la respuesta a una petición `GET`.
+La respuesta a la solicitud se muestra a continuación. El código de estado `302 Found` le indica al navegador que el POST tuvo éxito, y que debe emitir una segunda solicitud HTTP para cargar la página especificada en el campo `Location`. La información es por lo demás similar a la de la respuesta a una solicitud `GET`.
 
-```
+```http
 HTTP/1.1 302 FOUND
 Server: Apache
 X-Backend-Server: developer3.webapp.scl3.mozilla.com
@@ -202,75 +189,75 @@ Content-Length: 0
 ```
 
 > [!NOTE]
-> Las repuestas y las peticiones HTTP mostradas en estos ejemplos fueron capturadas usando la aplicación [Fiddler](https://www.telerik.com/download/fiddler), pero puedes obtener información similar usando sniffers web (ej. <http://web-sniffer.net/>) o usando extensiones del explorador como [HttpFox](https://addons.mozilla.org/en-US/firefox/addon/httpfox/). Puedes probarlo por tí mismo. Usa una de las herramientas enlazadas, y a continuación navega a través de un sitio y edita información del perfil para ver las diferentes peticiones y respuestas. La mayoría de los exploradores modernos también tienen herramientas que monitorizan las peticiciones de red (Por ejemplo, la herramienta [Network Monitor](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html) en Firefox).
+> Las solicitudes y respuestas HTTP mostradas en estos ejemplos se capturaron usando la aplicación [Fiddler](https://www.telerik.com/download/fiddler), pero puedes obtener información similar usando analizadores web (por ejemplo, [WebSniffer](https://websniffer.com/)) o analizadores de paquetes como [Wireshark](https://www.wireshark.org/). Puedes probarlo tú mismo. Usa cualquiera de las herramientas enlazadas y luego navega por un sitio y edita la información de un perfil para ver las diferentes solicitudes y respuestas. La mayoría de los navegadores modernos también tienen herramientas que monitorizan las solicitudes de red (por ejemplo, la herramienta [Monitor de red](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/index.html) de Firefox).
 
 ## Sitios estáticos
 
-Un _sitio estático_ es aquél que devuelve desde el servidor el mismo contenido establecido de forma fija en el código cada vez que se solicita una página en particular. De manera que si por ejemplo tienes una página sobre un producto en `/static/myproduct1.html` , a todos los usuarios se les devolverá la misma página. Si añades otro producto similar a tu sitio necesitarás añadir otra página (ej. `myproduct2.html`) etc... Esto puede llegar a ser realmente muy poco eficiente — ¿qué sucede cuando alcanzas miles de páginas de productos? Repetirías un montón de código a lo largo de cada página (la plantilla básica de la página, la estructura, etc), y si quisieras cambiar cualquier cosa de la estructura de la página — como añadir una nueva sección de "productos relacionados" por ejemplo — tendrías que cambiar cada página individualmente.
+Un _sitio estático_ es aquel que devuelve el mismo contenido codificado de forma fija desde el servidor cada vez que se solicita un recurso en particular. Así, por ejemplo, si tienes una página sobre un producto en `/static/my-product1.html`, esta misma página se devolverá a todos los usuarios. Si añades otro producto similar a tu sitio, necesitarás añadir otra página (por ejemplo, `my-product2.html`) y así sucesivamente. Esto puede empezar a ser realmente ineficiente — ¿qué sucede cuando llegas a miles de páginas de productos? Repetirías mucho código en cada página (la plantilla básica de la página, la estructura, etc.), y si quisieras cambiar algo de la estructura de la página — como añadir una nueva sección de "productos relacionados", por ejemplo — tendrías que cambiar cada página individualmente.
 
 > [!NOTE]
-> Los sitios estáticos son excelentes cuando tienes un pequeño número de páginas y quieres enviar el mismo contenido a todos los usuarios. Sin embargo pueden tener un coste de mantenimiento significante a medida que es número de páginas se hace grande.
+> Los sitios estáticos son excelentes cuando tienes un número reducido de páginas y quieres enviar el mismo contenido a todos los usuarios. Sin embargo, pueden tener un costo de mantenimiento significativo a medida que el número de páginas se hace más grande.
 
-Recapitulemos cómo funciona ésto, mirando otra vez el diagrama de la arquitectura de un sitio estático que vimos en el anterior artículo.
+Recapitulemos cómo funciona esto, mirando de nuevo el diagrama de arquitectura de sitio estático que vimos en el artículo anterior.
 
-![A simplified diagram of a static web server.](basic_static_app_server.png)
+![Un diagrama simplificado de un servidor web estático.](basic_static_app_server.png)
 
-Cuando un usuario quiere navegar a una página, el explorador envía una petición HTTP `GET` especificando la URL de su página HTML. El servidor recupera el documento solicitado de su sistema de ficheros y devuelve una respuesta HTTP conteniendo el documento y un [código de estado de respuesta HTTP](/es/docs/Web/HTTP/Reference/Status) "`200 OK`" (indicando éxito). El servidor podría devolver un código de estado diferente, por ejemplo "`404 Not Found`" si el fichero no está presente en el servidor, o "`301 Moved Permanently`" si el fichero existe pero ha sido redirigido a una localización diferente.
+Cuando un usuario quiere navegar a una página, el navegador envía una solicitud HTTP `GET` especificando la URL de su página HTML. El servidor recupera el documento solicitado de su sistema de archivos y devuelve una respuesta HTTP que contiene el documento y un [código de estado de respuesta HTTP](/es/docs/Web/HTTP/Reference/Status) `200 OK` (que indica éxito). El servidor podría devolver un código de estado diferente, por ejemplo `404 Not Found` si el archivo no está presente en el servidor, o `301 Moved Permanently` si el archivo existe pero ha sido redirigido a otra ubicación.
 
-El servidor de un sitio estático sólo tendrá que procesar peticiones GET, ya que el servidor no almacena ningún dato modificable. Tampoco cambia sus respuestas basádonse en los datos de la petición HTTP (ej. parámetros URL o cookies).
+El servidor de un sitio estático solo necesitará procesar solicitudes GET, porque el servidor no almacena ningún dato modificable. Tampoco cambia sus respuestas basándose en los datos de la solicitud HTTP (por ejemplo, parámetros de URL o cookies).
 
-Entendiendo cómo funcionan los sitios estáticos es útil sin embargo cuando se aprende programación de lado servidor, porque los sitios dinámicos gestionan las peticiones de ficheros estáticos (CSS, JavaScript, imágenes estáticas, etc.) exactamente de la misma forma.
+Aun así, entender cómo funcionan los sitios estáticos es útil al aprender programación del lado del servidor, porque los sitios dinámicos manejan las solicitudes de archivos estáticos (CSS, JavaScript, imágenes estáticas, etc.) exactamente de la misma manera.
 
 ## Sitios dinámicos
 
-Un _sitio dinámico_ es aquél que puede generar y devolver contenido basándose en la URL y los datos específicos de la petición (en vez de devolver siempre para una URL en particular el mismo fichero especificado en el código de forma fija). Usando el ejemplo de un sitio de productos, el servidor almacenaría "datos" del producto en una base de datos en vez de ficheros HTML individuales. Cuando se reciba una petición HTTP `GET` para un producto, el servidor determina el ID del mismo, extrae los datos de la base y construye la página HTML de la respuesta insertando los datos dentro de la plantilla HTML. Esto tiene una ventaja primordial sobre un sitio estático:
+Un _sitio dinámico_ es aquel que puede generar y devolver contenido según la URL y los datos específicos de la solicitud (en lugar de devolver siempre el mismo archivo codificado de forma fija para una URL en particular). Usando el ejemplo de un sitio de productos, el servidor almacenaría los "datos" del producto en una base de datos en lugar de en archivos HTML individuales. Al recibir una solicitud HTTP `GET` para un producto, el servidor determina el ID del producto, obtiene los datos de la base de datos, y luego construye la página HTML de la respuesta insertando los datos en una plantilla HTML. Esto tiene grandes ventajas sobre un sitio estático:
 
-Usar una base de datos permite que la información del producto se almacene de forma eficiente y que se pueda ampliar, modificar y buscar fácilmente.
+Usar una base de datos permite almacenar la información del producto de forma eficiente, fácilmente ampliable, modificable y buscable.
 
-Usar plantillas HTML hace que sea muy fácil cambiar la estructura HTML, porque sólo se necesita hacer en un sólo lugar, en una única plantilla y no a lo largo de miles de páginas estáticas.
+Usar plantillas HTML hace que sea muy fácil cambiar la estructura HTML, porque esto solo debe hacerse en un lugar, en una única plantilla, y no en potencialmente miles de páginas estáticas.
 
-### Anatomía de una petición dinámica
+### Anatomía de una solicitud dinámica
 
-Esta sección proporciona una visión general paso a paso de un ciclo de petición y respuesta HTTP "dinámicas", construyendo con más detalle lo que vimos en el último artículo. Para "hacer cosas reales" usaremos el contexto del sitio web de un manager de equipos deportivos donde un entrenador puede seleccionar el nombre y tamaño de su equipo en un formulario HTML y obtener de vuelta una sugerencia de "mejor alineación" para el próximo partido.
+Esta sección ofrece una descripción general paso a paso del ciclo de solicitud y respuesta HTTP "dinámica", construyendo sobre lo que vimos en el artículo anterior con mucho más detalle. Para "mantener las cosas reales", usaremos el contexto del sitio web de un mánager de un equipo deportivo, donde un entrenador puede elegir el nombre y el tamaño de su equipo en un formulario HTML y obtener a cambio una "mejor alineación" sugerida para su próximo partido.
 
-El diagrama de abajo muestra los elementos principales del sitio web del "entrenador del equipo", junto con etiquetas numeradas de la secuencia de operaciones cuando el entrenador accede a su lista de "mejor equipo". Las partes del sitio que lo hacen dinámico son las _Aplicaciones Web_ (que es como llamaremos al código del lado servidor que procesa las peticiones HTTP y devuelve respuestas HTTP), la _Base de Datos_, que contiene la información sobre los jugadores, equipos, entrenadores y sus relaciones, y las _Plantillas HTML_.
+El siguiente diagrama muestra los elementos principales del sitio web del "entrenador de equipo", junto con etiquetas numeradas para la secuencia de operaciones cuando el entrenador accede a su lista de "mejor equipo". Las partes del sitio que lo hacen dinámico son la _aplicación web_ (así es como nos referiremos al código del lado del servidor que procesa las solicitudes HTTP y devuelve respuestas HTTP), la _base de datos_, que contiene información sobre jugadores, equipos, entrenadores y sus relaciones, y las _plantillas HTML_.
 
-![This is a diagram of a simple web server with step numbers for each of step of the client-server interaction.](web_application_with_html_and_steps.png)
+![Este es un diagrama de un servidor web simple con números de paso para cada etapa de la interacción cliente-servidor.](web_application_with_html_and_steps.png)
 
-Después de que el entrenador envíe el formulario con el nombre del equipo y el número de jugadores, la secuencia de operaciones es la siguiente:
+Después de que el entrenador envía el formulario con el nombre del equipo y el número de jugadores, la secuencia de operaciones es:
 
-1. El explorador web crea una petición HTTP `GET` al servidor usando la URL base del recurso (`/best`) y codifica el equipo y número de jugadores como parámetros URL (ej. `/best?team=my_team_name&show=11)` o formando parte de un patrón URL (ej. `/best/my_team_name/11/`). Se usa una petición `GET` porque la petición sólo recoge datos (no modifica ninguno).
-2. El S*ervidor Web* detecta que la petición es "dinámica" y la reenvía a la _Aplicación_ para que la procese (el servidor web determina como manejar diferentes URLs basándose en reglas de emparejamiento de patrones definidas en su configuración).
-3. La _Aplicación Web_ identifica que la intención de la petición es obtener la "lista del mejor equipo" basándose en la URL (`/best/`) y encuentra el nombre del equipo y el número de jugadores requeridos a partir de la URL. La _Aplicación Web_ obtiene entonces la información solicitada de la base de datos (usando parámetros "internos" adicionales que definen qué jugadores son los "mejores", y posiblemente también obteniendo la identidad del entrenador que ha iniciado sesión a partir de un cookie del lado cliente).
-4. La _Aplicación Web_ crea dinámicamente una página HTML por medio de colocar los datos (de la _base_) en marcadores de posición dentro de la plantilla HTML.
-5. La _Aplicación Web_ devuelve el HTML generado al explorador web (via el _Servidor Web_), junto con un código de estado HTTP de 200 ("éxito"). Si algo impide que se pueda devolver el HTML entonces la _Aplicación Web_ devolverá otro código — por ejemplo "404" para indicar que el equipo no existe.
-6. El Explorador Web comenzará a continuación a procesar el HTML devuelto, enviando peticiones separadas para obtener cualquier otro fichero CSS o JavaScript que sea referenciado (ver paso 7).
-7. El Servidor Web carga ficheros estáticos del sistema de ficheros y los devuelve al explorador directamente (de nuevo, la gestión correcta de los ficheros está basada en las reglas de configuración y de emparejamiento de patrones URL).
+1. El navegador web crea una solicitud HTTP `GET` al servidor usando la URL base para el recurso (`/best`) y codificando el equipo y el número de jugadores como parámetros de URL (por ejemplo, `/best?team=my_team_name&show=11`) o como parte del patrón de URL (por ejemplo, `/best/my_team_name/11/`). Se usa una solicitud `GET` porque la solicitud solo obtiene datos (no los modifica).
+2. El _servidor web_ detecta que la solicitud es "dinámica" y la reenvía a la _aplicación web_ para su procesamiento (el servidor web determina cómo manejar diferentes URL según las reglas de coincidencia de patrones definidas en su configuración).
+3. La _aplicación web_ identifica que la _intención_ de la solicitud es obtener la "lista del mejor equipo" según la URL (`/best/`) y averigua el nombre del equipo y el número de jugadores requeridos a partir de la URL. La _aplicación web_ luego obtiene la información requerida de la base de datos (usando parámetros "internos" adicionales para definir qué jugadores son los "mejores", y posiblemente también obteniendo la identidad del entrenador que inició sesión a partir de una cookie del lado del cliente).
+4. La _aplicación web_ crea dinámicamente una página HTML colocando los datos (de la _base de datos_) en marcadores de posición dentro de una plantilla HTML.
+5. La _aplicación web_ devuelve el HTML generado al navegador web (a través del _servidor web_), junto con un código de estado HTTP de 200 ("éxito"). Si algo impide que se devuelva el HTML, entonces la _aplicación web_ devolverá otro código — por ejemplo, "404" para indicar que el equipo no existe.
+6. El navegador web entonces empezará a procesar el HTML devuelto, enviando solicitudes separadas para obtener cualquier otro archivo CSS o JavaScript al que haga referencia (ver paso 7).
+7. El servidor web carga archivos estáticos desde el sistema de archivos y los devuelve al navegador directamente (de nuevo, el manejo correcto de los archivos se basa en las reglas de configuración y la coincidencia de patrones de URL).
 
-La operación de actualizar un registro de la base de datos se gestionaría de forma similar, excepto que, como para cualquier actualización de la base de datos, la petición HTTP desde el explorador debería ser codificada como petición `POST`.
+Una operación para actualizar un registro en la base de datos se manejaría de forma similar, excepto que, como con cualquier actualización de base de datos, la solicitud HTTP del navegador debería codificarse como una solicitud `POST`.
 
-### Realización de otros trabajos
+### Realizar otro trabajo
 
-La misión de una _Aplicación Web_ es recibir peticiones HTTP y devolver respuestas HTTP. Mientras que interactuar con la base datos para obtener o actualizar información son tareas muy comunes, el código puede hacer otras cosas al mismo tiempo, o no interactuar con una base de datos en absoluto.
+El trabajo de una _aplicación web_ es recibir solicitudes HTTP y devolver respuestas HTTP. Aunque interactuar con una base de datos para obtener o actualizar información son tareas muy comunes, el código puede hacer otras cosas al mismo tiempo, o no interactuar con una base de datos en absoluto.
 
-Un buen ejemplo de una tarea adicional que una _Aplicación Web_ podría realizar sería el envío de un correo electrónico a los usuarios para confirmar su registro en el sitio. El sito podría también realizar logging u otras operaciones.
+Un buen ejemplo de una tarea adicional que podría realizar una _aplicación web_ sería enviar un correo electrónico a los usuarios para confirmar su registro en el sitio. El sitio también podría realizar registro de eventos (logging) u otras operaciones.
 
-### Devolución de alguna otra cosa distinta a HTML
+### Devolver algo distinto de HTML
 
-El código lado servidor de un sitio web no tiene que devolver fragmentos/ficheros HTML en la respuesta. Puede en vez de eso crear dinámicamente y devolver otros tipos de ficheros (texto, PDF, CSV, etc.) o incluso datos (jSON, XML, etc.).
+El código del lado del servidor de un sitio web no tiene que devolver fragmentos/archivos HTML en la respuesta. En su lugar, puede crear y devolver dinámicamente otros tipos de archivos (texto, PDF, CSV, etc.) o incluso datos (JSON, XML, etc.).
 
-La idea de devolver datos a un explorador web de forma que pueda actualizar su propio contenido dinámicamente ({{glossary("AJAX")}}) ha estado dando vueltas durante bastante tiempo. Más recientemente han llegado a ser muy populares las "apps de una sola página", donde el sitio web entero está escrito con un solo fichero HTML que es actualizado dinámicamente cuando se necesita. Los sitios web creados usando este estilo de aplicación transfieren una gran parte del coste computacional desde el servidor al explorador web, y pueden dar como resultado sitios web que se comportan mucho más como aplicaciones nativas (con una respuesta rápida "highly responsive", etc.).
+Esto es especialmente relevante para los sitios web que funcionan obteniendo contenido del servidor mediante JavaScript y actualizando la página dinámicamente, en lugar de cargar siempre una nueva página cuando se debe mostrar contenido nuevo. Consulta [Hacer solicitudes de red con JavaScript](/es/docs/Learn_web_development/Core/Scripting/Network_requests) para más información sobre la motivación de este enfoque, y cómo se ve este modelo desde el punto de vista del cliente.
 
-## Los frameworks Web simplifican la programación de lado servidor
+## Los frameworks web simplifican la programación web del lado del servidor
 
-Los frameworks de lado servidor hacen mucho más fácil escribir código para gestionar las operaciones descritas más arriba.
+Los frameworks web del lado del servidor facilitan mucho la escritura de código para manejar las operaciones descritas anteriormente.
 
-Una de las operaciones más importantes que realizan es proporcionar mecanismos simples para mapear las URLs de diferentes recursos/páginas a funciones para su gestión específicas. Esto hace más fácil mantener separado el código asociado con cada recurso. Esto tiene también beneficios en términos de mantenimiento, ya que puedes cambiar la URL usada para entregar una característica particular en un sitio, sin tener que cambiar la función de gestión.
+Una de las operaciones más importantes que realizan es proporcionar mecanismos simples para asignar URL de diferentes recursos/páginas a funciones controladoras específicas. Esto facilita mantener separado el código asociado con cada tipo de recurso. También tiene beneficios en términos de mantenimiento, porque puedes cambiar la URL usada para ofrecer una característica en particular en un solo lugar, sin tener que cambiar la función controladora.
 
-Por ejemplo, considera el siguiente código Django (Python) que mapea dos patrones URL a dos funciones de visualización. El primer patrón asegura que una petición HTTP con una URL de `/best` sea pasada a la función llamada `index()` en el módulo `views`. En cambio, una petición que tiene el patrón "`/best/junior`", se pasará a la función de visualización `junior()`.
+Por ejemplo, considera el siguiente código de Django (Python) que asigna dos patrones de URL a dos funciones de vista. El primer patrón asegura que una solicitud HTTP con una URL de recurso `/best` se pase a una función llamada `index()` en el módulo `views`. Una solicitud que tenga el patrón `/best/junior` se pasará en cambio a la función de vista `junior()`.
 
 ```python
-# file: best/urls.py
+# archivo: best/urls.py
 #
 
 from django.conf.urls import url
@@ -278,19 +265,19 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    # example: /best/
+    # ejemplo: /best/
     url(r'^$', views.index),
-    # example: /best/junior/
+    # ejemplo: /best/junior/
     url(r'^junior/$', views.junior),
 ]
 ```
 
 > [!NOTE]
-> El primer parámetro en las funciones `url()` puede parecer un poco extraño (ej. `r'^junior/$'`) porque usan una técnica de emparejamiento de patrones llamada "expresiones regulares" ("regular expressions", RegEx, o RE). No necesitas saber cómo funcionan las expresiones regulares en este momento, tan sólo que nos permiten emparejar patrones en el URL (en vez de los valores insertados en el código de forma fija que veíamos más arriba) y los usan como parámetros en nuestras funciones de visualización. Como ejemplo, una RegEx simple podría decir "empareja una simple letra mayúscula, seguida de entre 4 y 7 letras minúsculas."
+> Los primeros parámetros en las funciones `url()` pueden parecer un poco extraños (por ejemplo, `r'^junior/$'`) porque usan una técnica de coincidencia de patrones llamada "expresiones regulares" (RegEx, o RE). No necesitas saber cómo funcionan las expresiones regulares en este punto, más allá de que nos permiten hacer coincidir patrones en la URL (en lugar de los valores codificados de forma fija de arriba) y usarlos como parámetros en nuestras funciones de vista. Como ejemplo, una RegEx realmente simple podría decir "coincide con una sola letra mayúscula, seguida de entre 4 y 7 letras minúsculas".
 
-El framework web también hace fácil a una función de visualización extraer información de la base de datos. La estructura de nuestros datos está definida en modelos, que son las clases Python que definen los campos que serán almacenados en la base de datos subyacente. Si tenemos un modelo llamado _Team_ con un campo de "_team_type_" podemos usar un query de sintaxis simple para recuperar todos los equipos que son de un tipo particular.
+El framework web también facilita que una función de vista obtenga información de la base de datos. La estructura de nuestros datos está definida en modelos, que son clases de Python que definen los campos que se almacenarán en la base de datos subyacente. Si tenemos un modelo llamado _Team_ con un campo "_team_type_", entonces podemos usar una sintaxis de consulta simple para obtener todos los equipos que tienen un tipo en particular.
 
-Los ejemplos de abajo recuperan una lista de todos los equipos que tienen el `team_type` de "junior" exacto (teniendo en cuenta la capitalización, mayúsculas o minúsculas) — nota de formato: el nombre del campo (`team_type`) seguido de un guión bajo doble, y a continuación el tipo de emparejamiento a usar (en este caso `exact`). Hay muchos otros tipos de emparejamiento y podemos encadenarlos fácilmente. Podemos controlar el orden y número de resultados que se devuelven.
+El siguiente ejemplo obtiene una lista de todos los equipos que tienen el `team_type` exacto (distingue mayúsculas de minúsculas) de "junior" — nota el formato: el nombre del campo (`team_type`) seguido de un doble guion bajo, y luego el tipo de coincidencia a usar (en este caso, `exact`). Hay muchos otros tipos de coincidencia y podemos encadenarlos. También podemos controlar el orden y el número de resultados devueltos.
 
 ```python
 #best/views.py
@@ -299,21 +286,20 @@ from django.shortcuts import render
 
 from .models import Team
 
-
 def junior(request):
     list_teams = Team.objects.filter(team_type__exact="junior")
     context = {'list': list_teams}
     return render(request, 'best/index.html', context)
 ```
 
-Después de que la función `junior()` obtenga la lista de equipos junior, llama a la función `render()`, pasándole el `HttpRequest` original, una plantilla HTML, y un objeto "contexto" que define la información a ser incluida en la plantilla. La función `render()` es una función de conveniencia que genera HTML usando un contexto y una plantilla HTML, y devuelve un objeto `HttpResponse`.
+Después de que la función `junior()` obtiene la lista de equipos junior, llama a la función `render()`, pasando el `HttpRequest` original, una plantilla HTML, y un objeto "contexto" que define la información que se incluirá en la plantilla. La función `render()` es una función de conveniencia que genera HTML usando un contexto y una plantilla HTML, y lo devuelve en un objeto `HttpResponse`.
 
-Obviamente los frameworks web pueden ayudarte con un monton de otras tareas. Debatiremos sobre un montón más de beneficios y opciones de frameworks web en el próximo artículo.
+Obviamente, los frameworks web pueden ayudarte con muchas otras tareas. Analizamos muchos más beneficios y algunas opciones populares de frameworks web en el próximo artículo.
 
-## Sumario
+## Resumen
 
-En este punto deberías tener una buena visión general de las operaciones que el código de lado servidor tiene que realizar, y conocer algunas de las formas en que un framework web de lado servidor las puede hacer más fáciles.
+En este punto deberías tener una buena descripción general de las operaciones que debe realizar el código del lado del servidor, y conocer algunas de las formas en que un framework web del lado del servidor puede facilitarlo.
 
-En el módulo siguiente te ayudaremos a elegir el mejor Framework Web para tu primer sitio.
+En un módulo siguiente te ayudaremos a elegir el mejor framework web para tu primer sitio.
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/First_steps/Introduction", "Learn_web_development/Extensions/Server-side/First_steps/Web_frameworks", "Learn_web_development/Extensions/Server-side/First_steps")}}


### PR DESCRIPTION
### Description

Sincroniza la página en español `Learn_web_development/Extensions/Server-side/First_steps/Client-Server_overview` con la última versión en inglés, traduciendo y reescribiendo el artículo completo para que coincida en estructura, encabezados y terminología con la fuente actual.

### Motivation

La página nunca se registró para sincronización (no tenía `l10n.sourceCommit`) y llevaba años desactualizada respecto al inglés, con terminología antigua ("petición", "explorador", "Prerequisitos", "Sumario") y macros faltantes.

### Additional details

- Front-matter reducido a `title`, `slug` y `l10n.sourceCommit` (se eliminó `original_slug`).
- `l10n.sourceCommit` establecido en `3e543cdfe8dddfb4774a64bf3decdcbab42a4111`, el último commit que tocó el archivo en inglés.
- Terminología actualizada: "solicitud"/"respuesta" (no "petición"), "navegador" (no "explorador"), "del lado del servidor"/"del lado del cliente" (no "de lado servidor"), "Requisitos previos:" (no "Prerequisitos:"), "Resumen" (no "Sumario").
- Se agregaron las macros `{{HTTPStatus(...)}}` que faltaban respecto a la fuente en inglés.
- Se removió el macro `{{LearnSidebar}}` del cuerpo, siguiendo la convención ya usada en el artículo hermano `Introduction` de este mismo módulo (el sidebar ya no se declara en el front-matter en español).
- Validaciones ejecutadas sobre el archivo: `prettier --write`, `markdownlint-cli2 --fix`, `check-url-locale.js` — todas sin errores.

### Related issues and pull requests

Fixes #37255