### PR TITLE
chore(es): sync of `Learn_web_development/Extensions/Forms/HTML5_input_types`

### DIFF
--- a/files/es/learn_web_development/extensions/forms/html5_input_types/index.md
+++ b/files/es/learn_web_development/extensions/forms/html5_input_types/index.md
@@ -1,20 +1,21 @@
 ---
 title: Tipos de input de HTML5
 slug: Learn_web_development/Extensions/Forms/HTML5_input_types
-original_slug: Learn/Forms/HTML5_input_types
+l10n:
+  sourceCommit: 5f677b960051016819ecb3b1f40bc3d36a43156d
 ---
 
 {{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Extensions/Forms/Basic_native_form_controls", "Learn_web_development/Extensions/Forms/Other_form_controls", "Learn_web_development/Extensions/Forms")}}
 
-En el [artículo anterior](/es/docs/Learn_web_development/Extensions/Forms/Basic_native_form_controls) vimos el elemento {{htmlelement("input")}} y los valores de su atributo `type`, disponibles desde los inicios de HTML. Ahora veremos en detalle la funcionalidad de los controles de formulario más recientes, incluyendo algunos tipos de input nuevos, los cuales fueron añadidos en HTML5 para permitir la recolección de tipos de datos específicos
+En el [artículo anterior](/es/docs/Learn_web_development/Extensions/Forms/Basic_native_form_controls) vimos el elemento {{htmlelement("input")}}, donde cubrimos los valores originales del atributo `type` disponibles desde los primeros días de HTML. Ahora veremos en detalle la funcionalidad de algunos tipos de input que se añadieron más tarde.
 
 <table>
   <tbody>
     <tr>
       <th scope="row">Requisitos previos:</th>
       <td>
-        Formación básica en informática, y una
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        Una
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >comprensión básica de HTML</a
         >.
       </td>
@@ -22,168 +23,197 @@ En el [artículo anterior](/es/docs/Learn_web_development/Extensions/Forms/Basic
     <tr>
       <th scope="row">Objetivo:</th>
       <td>
-        Entender los valores de tipo input disponibles más recientes para crear
-        controles de formulario nativos, y cómo implementarlos utilizando HTML.
+        Entender los valores de tipo de input más recientes disponibles para
+        crear controles de formulario nativos, y cómo implementarlos usando
+        HTML.
       </td>
     </tr>
   </tbody>
 </table>
 
-> [!NOTE]
-> La mayoría de las características discutidas en este artículo tienen un amplio soporte en todos los navegadores, anotaremos cualquier excepción. Si quieres más detalles referente al soporte de navegadores, deberías consultar nuestra [referéncia de elementos de formulario HTML](/es/docs/Web/HTML/Reference/Elements#forms), y en particular nuestra referéncia extensiva de [Tipos de \<input>](/es/docs/Web/HTML/Reference/Elements/input).
-
-Debido a que la apariéncia de un control de formulario puede ser algo distinta con respecto a unas especificaciones del diseñador, los desarrolladores web a veces construyen sus propios controles de formulario personalizados. Cubrimos este aspecto en un tutorial avanzado: [Cómo construir widgets de formulario personalizados](/es/docs/Learn_web_development/Extensions/Forms/How_to_build_custom_form_controls).
+Debido a que la apariencia de un control de formulario HTML puede ser bastante distinta de las especificaciones de un diseñador, los desarrolladores web a veces construyen sus propios controles de formulario personalizados. Cubrimos esto en un tutorial avanzado: [Cómo construir widgets de formulario personalizados](/es/docs/Learn_web_development/Extensions/Forms/How_to_build_custom_form_controls).
 
 ## Campo de dirección de correo electrónico
 
-Este tipo de campo se define utilizando el valor `email` en el atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) del elemento \<input>:
+Este tipo de campo se establece usando el valor `email` en el atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type):
 
-```html
+```html hidden live-sample___email
+<label for="email">Introduce tu dirección de correo electrónico:</label><br />
+```
+
+```html live-sample___email
 <input type="email" id="email" name="email" />
 ```
 
-Cuando se utiliza este valor [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) , se le obliga al usuario a escribir dentro del campo una dirección de correo electrónico válida. Cualquier otro contenido ocasiona que el navegador muestre un mensaje de error cuando se envía el formulario. Puedes verlo en acción en la siguiente captura de pantalla
+{{EmbedLiveSample('email','100%','50')}}
 
-![﻿An invalid email input showing the message "Please enter an email address."](email_address_invalid.png)
+Cuando se usa este [`type`](/es/docs/Web/HTML/Reference/Elements/input#type), el valor debe ser una dirección de correo electrónico para ser válido. Cualquier otro contenido hace que el navegador muestre un error cuando se envía el formulario. Puedes ver esto en acción en la siguiente captura de pantalla.
 
-Puedes utilizar también el atributo [`multiple`](/es/docs/Web/HTML/Reference/Attributes/multiple) en combinación con el tipo input `email` para permitir que sean introducidas varias direcciones de correo electrónico separadas por comas en el mismo input:
+![Un input de correo electrónico inválido mostrando el mensaje "Please enter an email address."](email_address_invalid.png)
+
+Puedes usar el atributo [`multiple`](/es/docs/Web/HTML/Reference/Attributes/multiple) en combinación con el tipo de input `email` para permitir que se introduzcan varias direcciones de correo electrónico separadas por comas en el mismo input:
 
 ```html
 <input type="email" id="email" name="email" multiple />
 ```
 
-En algunos dispositivos, en particular dispositivos táctiles con teclados dinámicos como los smart phones, debería presentarse un teclado virtual que es más adecuado para introducir direcciones de correo electrónico, incluyendo la tecla `@`. Mira como ejemplo la siguiente captura de pantalla del teclado de Firefox para Android:
+En algunos dispositivos —especialmente los dispositivos táctiles con teclados dinámicos como los teléfonos inteligentes— puede mostrarse un teclado virtual distinto, más adecuado para introducir direcciones de correo electrónico, incluyendo la tecla `@`:
 
-![firefox for android email keyboard, with ampersand displayed by default.](fx-android-email-type-keyboard.jpg)
-
-> [!NOTE]
-> Puedes encontrar ejemplos sobre los tipos de entrada de texto básicos en [Ejemplos input básicos](https://mdn.github.io/learning-area/html/forms/basic-input-examples/) (Consulta también el [código fuente](https://github.com/mdn/learning-area/blob/master/html/forms/basic-input-examples/index.html)).
-
-Mejorar la experiéncia del usuario para usuarios con estos dispositivos, es otra buena razón para utilizar estos tipos de input más recientes.
-
-### Validación del lado cliente
-
-Como puedes haber visto anteriormente, `email`, junto con otros tipos de `input` más recientes, proporciona la validación de errores _en el lado cliente_ de forma predeterminada, realizados por el navegador antes de que los datos obtenidos se envíen al servidor. _Es_ una ayuda útil guiar a los usuarios a rellenar un formulario de forma precisa y puede ahorrar tiempo: es útil saber de inmediato que tu dato no es correcto, en vez de tener que esperar el viaje de ida y vuelta al servidor.
-
-Pero _no debería ser considerado_ una medida de seguridad exhaustiva! Tus aplicaciones siempre deben realizar comprobaciones de seguridad en cada dato, tanto en el _lado servidor_ como en el lado cliente debido a que la validación en el lado cliente es muy fácil desactivarla, por lo que usuarios malintencionados pueden enviar fácilmente datos incorrectos al servidor. Lee [Seguridad en el sitio web](/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security) para tener una idea de lo que _podría_ ocurrir; Implementar validación en el lado servidor está más allá del alcance de este módulo-guía, pero debería tenerlo en cuenta.
-
-Ten en cuenta que `a@b` es una dirección de correo electrónico válida de acuerdo a las restricciones proporcionadaas por defecto. Esto es debido a que el tipo de input `email`, permite por defecto direcciones de correo electrónico de una intranet. Para implementar un comportamiento diferente de validación puedes utilizar el atributo [`pattern`](/es/docs/Web/HTML/Attributes/pattern), y también puedes utilizar mensajes de error personalizados; Hablaremos de cómo utilizar estas características en [Validación de formularios en el lado cliente](/es/docs/Learn_web_development/Extensions/Forms/Form_validation) en un artículo posterior.
+![Teclado de Firefox para Android para correo electrónico, con el signo arroba mostrado por defecto.](fx-android-email-type-keyboard.jpg)
 
 > [!NOTE]
-> Si los datos introducidos no son una dirección de correo electrónico, habrá coincidéncia con la pseudo clase {{cssxref(':invalid')}}, y la propiedad {{domxref('validityState.typeMismatch')}} devolverá `true`.
+> Puedes encontrar ejemplos de los tipos de input de texto básicos en [ejemplos de input básicos](https://mdn.github.io/learning-area/html/forms/basic-input-examples/) (consulta también el [código fuente](https://github.com/mdn/learning-area/blob/main/html/forms/basic-input-examples/index.html)).
+
+Esta es otra buena razón para usar estos tipos de input más recientes, mejorando la experiencia de usuario para quienes utilizan estos dispositivos.
+
+### Validación del lado del cliente
+
+Como puedes ver arriba, `email` —junto con otros tipos de `input` más recientes— proporciona validación de errores integrada del _lado del cliente_, realizada por el navegador antes de que los datos se envíen al servidor. _Es_ una ayuda útil para guiar a los usuarios a completar un formulario correctamente, y puede ahorrar tiempo: es útil saber de inmediato que tus datos no son correctos, en lugar de tener que esperar un viaje de ida y vuelta al servidor.
+
+Pero _no debería considerarse_ una medida de seguridad exhaustiva. Tus aplicaciones siempre deben realizar comprobaciones de seguridad sobre cualquier dato enviado por un formulario, tanto en el _lado del servidor_ como en el lado del cliente, porque la validación del lado del cliente es demasiado fácil de desactivar, por lo que los usuarios malintencionados aún pueden enviar fácilmente datos incorrectos a tu servidor. Lee [Seguridad en sitios web](/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Website_security) para hacerte una idea de lo que _podría_ ocurrir; implementar la validación del lado del servidor está algo fuera del alcance de este módulo, pero deberías tenerlo en cuenta.
+
+Ten en cuenta que `a@b` es una dirección de correo electrónico válida según las restricciones predeterminadas. Esto se debe a que el tipo de input `email` permite direcciones de correo electrónico de intranet por defecto. Para implementar un comportamiento de validación diferente, puedes usar el atributo [`pattern`](/es/docs/Web/HTML/Reference/Attributes/pattern). También puedes personalizar los mensajes de error. Hablaremos de cómo usar estas características en el artículo [Validación de formularios del lado del cliente](/es/docs/Learn_web_development/Extensions/Forms/Form_validation), más adelante.
+
+> [!NOTE]
+> Si los datos introducidos no son una dirección de correo electrónico, la pseudoclase {{cssxref(':invalid')}} coincidirá, y la propiedad {{domxref('validityState.typeMismatch')}} devolverá `true`.
 
 ## Campo de búsqueda
 
-Los campos de búsqueda están destinados a ser utilizados para crear cajas de búsqueda en páginas y aplicaciones. Este tipo de campo se define utilizando el valor `search` en su atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type):
+Los campos de búsqueda están pensados para crear cajas de búsqueda en páginas y aplicaciones. Este tipo de campo se establece usando el valor `search` en el atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type):
+
+```html hidden
+<label for="search">Introduce un término de búsqueda:</label><br />
+```
 
 ```html
 <input type="search" id="search" name="search" />
 ```
 
-La diferéncia principal entre un campo `text` y un campo `search`, es la forma en que el navegador aplica estilo a su apariéncia. A menudo los campos `search` se muestran con bordes redondeados; y a veces también muestran una "Ⓧ", el cual despeja el campo de cualquier valor cuando se pulsa sobre él. Adicionalmente, en dispositivos con teclado dinámico, la tecla enter del teclado puede leer "**search**" o mostrar un icono de lupa.
+{{EmbedLiveSample('Campo de búsqueda','100%','50')}}
 
-La captura de pantalla siguiente muestra un campo de búsqueda con contenido, en Firefox 71, Safari 13, y Chrome 79 en macOS, y Edge 18 y Chrome 79 en Windows 10. Ten en cuenta que el icono de reseteo sólo aparece si el campo tiene un valor y, aparte de Safari, sólo se muestra cuando el campo tiene el foco.
+La diferencia principal entre un campo `text` y un campo `search` es la forma en que el navegador da estilo a su apariencia. En algunos navegadores, los campos `search` se renderizan con esquinas redondeadas. En algunos navegadores, se muestra un icono de borrado "Ⓧ", que borra el valor del campo al hacer clic en él. Este icono de borrado solo aparece si el campo tiene un valor y, aparte de Safari, solo se muestra cuando el campo tiene el foco. Además, en dispositivos con teclados dinámicos, la tecla intro del teclado puede mostrar "**search**", o un icono de lupa.
 
-![Screenshots of search fields on several platforms.](search_focus.png)
+Otra característica que vale la pena mencionar es que los valores de un campo `search` pueden guardarse automáticamente y reutilizarse para ofrecer autocompletado en varias páginas del mismo sitio web; esto suele ocurrir automáticamente en la mayoría de los navegadores modernos.
 
-Otra característica que vale la pena señalar es que se puede guardar los valores de un campo `search` automáticamente y reutilizarse en múltiples páginas del mismo sitio web para ofrecer autocompletado. Esta característica suele ocurrir de forma automática en la mayoría de navegadores modernos.
+## Campo de número de teléfono
 
-## Campo número de teléfono
+Se puede crear un campo especial para introducir números de teléfono usando `tel` como valor del atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type):
 
-Se puede crear un campo especial para introducir números de teléfono utilizando `tel` como valor del atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type):
+```html hidden
+<label for="tel">Introduce un número de teléfono:</label><br />
+```
 
 ```html
 <input type="tel" id="tel" name="tel" />
 ```
 
-Cuando se accede desde un dispositivo táctil con teclados dinámicos, muchos de ellos mostrarán un teclado numérico cuando se encuentren con `type="tel"`, lo que significa que este tipo es útil no sólo para ser utilizado para números de teléfono, sino también cuando sea útil un teclado numérico.
+{{EmbedLiveSample('Campo de número de teléfono','100%','50')}}
 
-La siguiente captura de pantalla del teclado de Firefox para Android proporciona un ejemplo:
+Cuando se accede desde un dispositivo táctil con teclado dinámico, la mayoría de los dispositivos mostrarán un teclado numérico cuando se encuentre `type="tel"`, lo que significa que este tipo es útil siempre que un teclado numérico sea útil, y no tiene que usarse solo para números de teléfono.
 
-![firefox for android email keyboard, with ampersand displayed by default.](fx-android-tel-type-keyboard.jpg)
+-![Teclado de Firefox para Android para correo electrónico, con el símbolo & mostrado por defecto.](fx-android-tel-type-keyboard.jpg)
 
-Debido a la gran variedad de formatos de número de teléfono existentes, este tipo de campo no cumple con ningún tipo de restricción sobre el valor introducido por el usuario. (Esto significa que puede incluir letras, etc...).
+Debido a la amplia variedad de formatos de números de teléfono en todo el mundo, este tipo de campo no impone ninguna restricción sobre el valor introducido por un usuario (esto significa que puede incluir letras, etc.).
 
-Como mencionamos anteriormente, se puede utilizar el atributo [`pattern`](/es/docs/Web/HTML/Attributes/pattern) para que asuma restricciones, sobre el cuál aprenderemos en [Validación de formulario en el lado cliente](/es/docs/Learn_web_development/Extensions/Forms/Form_validation).
+Como mencionamos antes, el atributo [`pattern`](/es/docs/Web/HTML/Reference/Attributes/pattern) puede usarse para imponer restricciones, lo cual aprenderás en [Validación de formularios del lado del cliente](/es/docs/Learn_web_development/Extensions/Forms/Form_validation).
 
 ## Campo URL
 
-Se puede crear un tipo especial de campo para introducir URLs utilizando el valor `url` para el atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type):
+Se puede crear un tipo especial de campo para introducir URLs usando el valor `url` en el atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type):
+
+```html hidden
+<label for="url">Introduce una URL:</label><br />
+```
 
 ```html
 <input type="url" id="url" name="url" />
 ```
 
-Este tipo añade restricciones de validación en el campo. El navegador informará de un error si no se introdujo el protocolo (como `http:`), o si de algún modo el URL está mal formado. En dispositivos con teclados dinámicos a menudo mostrará por defecto algunas o todas las teclas como los dos puntos, el punto, y la barra inclinada.
+{{EmbedLiveSample('Campo URL','100%','50')}}
 
-Mira el siguiente ejemplo tomado de Firefox para Android:
-
-![firefox for android email keyboard, with ampersand displayed by default.](fx-android-url-type-keyboard.jpg)
+Agrega restricciones de validación especiales al campo. El navegador informará un error si no se introduce ningún protocolo (como `http:`), o si la URL está mal formada de alguna otra manera. En dispositivos con teclados dinámicos, el teclado predeterminado a menudo mostrará algunos o todos los dos puntos, el punto y la barra inclinada como teclas predeterminadas.
 
 > [!NOTE]
-> Solo porque el URL esté bien formado no significa necesariamente que la dirección al que hace referéncia exista!
+> El hecho de que la URL esté bien formada no significa necesariamente que haga referencia a una ubicación que realmente exista.
 
 ## Campo numérico
 
-Se pueden crear controles para introducir números con el [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) `number` de {{HTMLElement("input")}}. Este control se parece a un campo de texto pero solo permite números de punto flotante, y normalmente proporciona botones deslizadores para incrementar o reducir el valor del control. En dispositivos con teclados dinámicos generalmente se muestra el teclado numérico.
+Se pueden crear controles para introducir números con un [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) de {{HTMLElement("input")}} igual a `number`. Este control se parece a un campo de texto, pero solo permite números de punto flotante, y generalmente proporciona botones en forma de selector giratorio para aumentar y disminuir el valor del control. En dispositivos con teclados dinámicos, generalmente se muestra el teclado numérico.
 
-La siguiente captura de pantalla tomada de Firefox para Android proporciona un ejemplo:
+```html hidden live-sample___number
+<label for="number">Introduce un número:</label><br />
+```
 
-![firefox for android email keyboard, with ampersand displayed by default.](fx-android-number-type-keyboard.jpg)
+```html live-sample___number
+<input type="number" id="number" name="number" />
+```
 
-Con el tipo de input `number` puedes limitar los valores mínimo y máximo permitidos definiendo los atributos [`min`](/es/docs/Web/HTML/Reference/Elements/input#min) y [`max`](/es/docs/Web/HTML/Reference/Elements/input#max).
+{{EmbedLiveSample('number','100%','50')}}
 
-También puedes utilizar el atributo `step` para cambiar el incremento y decremento causado por los botones deslizadores. Por defecto, el tipo de input number sólo valida si el número es un entero. Para permitir números decimales, especifica [`step="any"`](/es/docs/Web/HTML/Attributes/step). Si se omite, su valor por defecto es `1`, lo que significa que solo son válidos números enteros.
+Con el tipo de input `number`, puedes restringir los valores mínimo y máximo permitidos configurando los atributos [`min`](/es/docs/Web/HTML/Reference/Elements/input#min) y [`max`](/es/docs/Web/HTML/Reference/Elements/input#max).
 
-Miremos algunos ejemplos. El primero de los siguientes crea un control numérico cuyo valor está restringido a cualquier valor entre `1` y `10`, y sus botones cambian su valor en incrementos o decrementos de `2`.
+También puedes usar el atributo `step` para establecer el incremento de aumento y disminución que provocan los botones del selector giratorio. Por defecto, el tipo de input number solo valida si el número es un entero, ya que el atributo [`step`](/es/docs/Web/HTML/Reference/Attributes/step) tiene por defecto el valor `1`. Para permitir números decimales, especifica `step="any"` o un valor específico, como `step="0.01"` para restringir el punto flotante. Si se omite, como el valor de `step` es `1` por defecto, solo son válidos los números enteros.
 
-```html
+Veamos algunos ejemplos:
+
+Este ejemplo crea un control numérico cuyo valor válido está restringido a un valor impar entre `1` y `10`. Los botones de aumento y disminución cambian el valor en `2`, comenzando por el valor de `min`.
+
+```html hidden live-sample___number2
+<label for="number">Introduce un número impar entre 1 y 10:</label><br />
+```
+
+```html live-sample___number2
 <input type="number" name="age" id="age" min="1" max="10" step="2" />
 ```
 
-El segundo crea un control numérico cuyo valor está restringido a cualquier valor entre el `0` y `1` ambos inclusive, y sus botones cambian su valor en incrementos o decrementos de `0.01`.
+{{EmbedLiveSample('number2','100%','50')}}
 
-```html
+Este ejemplo crea un control numérico cuyo valor está restringido a cualquier valor entre `0` y `1` inclusive, y cuyos botones de aumento y disminución cambian su valor en `0.01`.
+
+```html hidden live-sample___number3
+<label for="number">Introduce un número entre 0 y 1, inclusive:</label><br />
+```
+
+```html live-sample___number3
 <input type="number" name="change" id="pennies" min="0" max="1" step="0.01" />
 ```
 
-El tipo de input `number` tiene sentido cuando esté limitado el rango de valores válidos, por ejemplo la edad de una persona o su altura. Si el rango es demasiado grande para que los cambios de incremento tengan sentido ( por ejemplo los códigos postales de USA, cuyo rango va de `00001` a `99999`), entonces sería una mejor opción utilizar el tipo `tel`: proporciona el teclado numérico mientras que omite el componente de interfaz de usuario de los deslizadores de número.
+{{EmbedLiveSample('number3','100%','50')}}
 
-> [!NOTE]
-> En versiones inferiores a la 10 de Internet Explorer no se soportan las entradas `number`
+El tipo de input `number` tiene sentido cuando el rango de valores válidos es limitado, como la edad o la estatura de una persona. Si el rango es demasiado grande para que los incrementos tengan sentido (como los códigos postales de EE. UU., que van de `00001` a `99999`), el tipo `tel` podría ser una mejor opción; proporciona el teclado numérico sin incluir la función de selector giratorio de los números.
 
-## Slider controls
+## Controles deslizantes
 
-Otra forma de tomar un número es usando un **slider**. Podrás observar cómo son bastantes parecidas a los sitios inmobiliarios, dónde quieres determinar un máximo de precio por propiedad y filtrar tu búsqueda en el. Observaremos un ejemplo en vivo.
+Otra forma de elegir un número es usando un **control deslizante**. Los ves con bastante frecuencia en sitios como los de compras, donde quieres establecer un precio máximo de propiedad para filtrar. Veamos un ejemplo en vivo para ilustrar esto:
 
-{{EmbedGHLiveSample("learning-area/html/forms/range-example/index.html", '100%', 200)}}
+{{EmbedLiveSample('Controles deslizantes','100%','50')}}
 
-Usage-wise, sliders are less accurate than text fields. Therefore, they are used to pick a number whose _precise_ value is not necessarily important.
+En cuanto al uso, los controles deslizantes son menos precisos que los campos de texto. Por eso se utilizan para elegir un número cuyo valor _preciso_ no es necesariamente importante.
 
-A slider is created using the {{HTMLElement("input")}} with its [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) attribute set to the value `range`. The slider-thumb can be moved via mouse or touch, or with the arrows of the keypad.
+Un control deslizante se crea usando {{HTMLElement("input")}} con su atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) establecido en el valor `range`. El control deslizante se puede mover con el ratón o el tacto, o con las flechas del teclado.
 
-It's important to properly configure your slider. To that end, it's highly recommended that you set the [`min`](/es/docs/Web/HTML/Reference/Attributes/min), [`max`](/es/docs/Web/HTML/Attributes/max), and [`step`](/es/docs/Web/HTML/Attributes/step) attributes which set the minimum, maximum and increment values, respectively.
+Es importante configurar correctamente tu control deslizante. Para ello, se recomienda encarecidamente establecer los atributos [`min`](/es/docs/Web/HTML/Reference/Attributes/min), [`max`](/es/docs/Web/HTML/Reference/Attributes/max) y [`step`](/es/docs/Web/HTML/Reference/Attributes/step), que establecen los valores mínimo, máximo e incremental, respectivamente.
 
-Let's look at the code behind the above example, so you can see how its done. First of all, the basic HTML:
+Veamos el código detrás del ejemplo anterior, para que puedas ver cómo se hace. En primer lugar, el HTML básico:
 
 ```html
-<label for="price">Choose a maximum house price: </label>
+<label for="price">Elige un precio máximo de vivienda: </label>
 <input
   type="range"
   name="price"
   id="price"
   min="50000"
   max="500000"
-  step="100"
+  step="1000"
   value="250000" />
 <output class="price-output" for="price"></output>
 ```
 
-This example creates a slider whose value may range between `50000` and `500000`, which increments/decrements by 100 at a time. We've given it default value of `250000`, using the `value` attribute.
+Este ejemplo crea un control deslizante cuyo valor puede oscilar entre `50000` y `500000`, con incrementos/decrementos de 1000 a la vez. Le hemos dado un valor predeterminado de `250000`, usando el atributo `value`.
 
-One problem with sliders is that they don't offer any kind of visual feedback as to what the current value is. This is why we've included an {{htmlelement("output")}} element — to contain the current value (we'll also look at this element in the next article). You could display an input value or the output of a calculation inside any element, but `<output>` is special — like `<label>`, it can take a `for` attribute that allows you to associate it with the element or elements that the output value came from.
+Un problema con los controles deslizantes es que no ofrecen ningún tipo de retroalimentación visual sobre cuál es el valor actual. Por eso hemos incluido un elemento {{htmlelement("output")}} para contener el valor actual. Podrías mostrar un valor de input o el resultado de un cálculo dentro de cualquier elemento, pero `<output>` es especial —al igual que `<label>`— y puede tomar un atributo `for` que te permite asociarlo con el elemento o elementos de los que proviene el valor de salida.
 
-To actually display the current value, and update it as it changed, you must use JavaScript, but this is relatively easy to do:
+Para mostrar realmente el valor actual, y actualizarlo a medida que cambia, debes usar JavaScript, lo cual se puede lograr con algunas instrucciones:
 
 ```js
 const price = document.querySelector("#price");
@@ -191,114 +221,160 @@ const output = document.querySelector(".price-output");
 
 output.textContent = price.value;
 
-price.addEventListener("input", function () {
+price.addEventListener("input", () => {
   output.textContent = price.value;
 });
 ```
 
-Here we store references to the `range` input and the `output` in two variables. Then we immediately set the `output`'s [`textContent`](/es/docs/Web/API/Node/textContent) to the current `value` of the input. Finally, an event listener is set to ensure that whenever the range slider is moved, the `output`'s `textContent` is updated to the new value.
+```css hidden
+body {
+  text-align: center;
+}
+label,
+output {
+  display: block;
+}
+```
 
-> [!NOTE]
-> `range` inputs are not supported in versions of Internet Explorer below 10.
+Aquí almacenamos referencias al input `range` y al `output` en dos variables. Luego establecemos inmediatamente el [`textContent`](/es/docs/Web/API/Node/textContent) del `output` con el `value` actual del input. Finalmente, se configura un detector de eventos para asegurar que, cada vez que se mueve el control deslizante, el `textContent` del `output` se actualice al nuevo valor.
 
-## Date and time pickers
+## Selectores de fecha y hora
 
-Gathering date and time values has traditionally been a nightmare for web developers. For good user experience, it is important to provide a calendar selection UI, enabling users to select dates without necessating context switching to a native calendar application or potentially entering them in differing formats that are hard to parse. The last minute of the previous millenium can be expressed in the following different ways, for example: 1999/12/31, 23:59 or 12/31/99T11:59PM.
+Generalmente, para una buena experiencia de usuario al recopilar valores de fecha y hora, es importante proporcionar una interfaz de selección de calendario. Estas permiten a los usuarios seleccionar fechas sin necesidad de cambiar de contexto a una aplicación de calendario nativa, o de introducirlas en formatos distintos que son difíciles de interpretar. El último minuto del milenio anterior se puede expresar de las siguientes formas: `1999/12/31`, `23:59`, o `12/31/99T11:59PM`.
 
-HTML date controls are available to handle this specific kind of data, providing calendar widgets and making the data uniform.
+Los controles de fecha de HTML están disponibles para manejar este tipo específico de datos, proporcionando widgets de calendario y uniformando los datos.
 
-A date and time control is created using the {{HTMLElement("input")}} element and an appropriate value for the [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) attribute, depending on whether you wish to collect dates, times, or both. Here's a live example that falls back to {{htmlelement("select")}} elements in non-supporting browsers:
+Un control de fecha y hora se crea usando el elemento {{HTMLElement("input")}} y un valor apropiado para el atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type), dependiendo de si deseas recopilar fechas, horas, o ambas. Aquí tienes un ejemplo en vivo:
 
-{{EmbedGHLiveSample("learning-area/html/forms/datetime-local-picker-fallback/index.html", '100%', 200)}}
+```html hidden live-sample___date1
+<label for="party">Elige una fecha y hora para tu fiesta:</label>
+<input type="datetime-local" id="party" name="bday" />
+<span class="validity"></span>
+```
 
-Let's look at the different available types in brief. Note that the usage of these types is quite complex, especially considering browser support (see below); to find out the full details, follow the links below to the reference pages for each type, including detailed examples.
+```css hidden live-sample___date1
+input:invalid + span::after {
+  content: " ✖";
+}
+
+input:valid + span::after {
+  content: " ✓";
+}
+```
+
+{{EmbedLiveSample('date1','100%','50')}}
+
+Veamos brevemente los distintos tipos disponibles. Ten en cuenta que el uso de estos tipos es bastante complejo, especialmente si consideramos la compatibilidad con navegadores (ver más abajo); para conocer todos los detalles, sigue los enlaces de abajo a las páginas de referencia de cada tipo, que incluyen ejemplos detallados.
+
+### `date`
+
+[`<input type="date">`](/es/docs/Web/HTML/Reference/Elements/input/date) crea un widget para mostrar y elegir una fecha (año, mes y día, sin hora).
+
+```html hidden
+<label for="date">Introduce la fecha:</label><br />
+```
+
+```html
+<input type="date" name="date" id="date" />
+```
+
+{{EmbedLiveSample('date','100%','50')}}
 
 ### `datetime-local`
 
-[`<input type="datetime-local">`](/es/docs/Web/HTML/Reference/Elements/input/datetime-local) creates a widget to display and pick a date with time with no specific time zone information.
+[`<input type="datetime-local">`](/es/docs/Web/HTML/Reference/Elements/input/datetime-local) crea un widget para mostrar y elegir una fecha con hora, sin información de zona horaria específica.
+
+```html hidden
+<label for="month">Introduce la fecha y hora:</label><br />
+```
 
 ```html
 <input type="datetime-local" name="datetime" id="datetime" />
 ```
 
+{{EmbedLiveSample('datetime-local','100%','50')}}
+
 ### `month`
 
-[`<input type="month">`](/es/docs/Web/HTML/Element/input/month) creates a widget to display and pick a month with a year.
+[`<input type="month">`](/es/docs/Web/HTML/Reference/Elements/input/month) crea un widget para mostrar y elegir un mes junto con un año.
+
+```html hidden
+<label for="month">Introduce el mes:</label><br />
+```
 
 ```html
 <input type="month" name="month" id="month" />
 ```
 
+{{EmbedLiveSample('month','100%','50')}}
+
 ### `time`
 
-[`<input type="time">`](/es/docs/Web/HTML/Element/input/time) creates a widget to display and pick a time value. While time may _display_ in 12-hour format, the _value returned_ is in 24-hour format.
+[`<input type="time">`](/es/docs/Web/HTML/Reference/Elements/input/time) crea un widget para mostrar y elegir un valor de hora. Aunque la hora puede _mostrarse_ en formato de 12 horas, el _valor devuelto_ está en formato de 24 horas.
+
+```html hidden
+<label for="time">Introduce una hora:</label><br />
+```
 
 ```html
 <input type="time" name="time" id="time" />
 ```
 
+{{EmbedLiveSample('time','100%','50')}}
+
 ### `week`
 
-[`<input type="week">`](/es/docs/Web/HTML/Element/input/week) creates a widget to display and pick a week number and its year.
+[`<input type="week">`](/es/docs/Web/HTML/Reference/Elements/input/week) crea un widget para mostrar y elegir un número de semana junto con su año.
 
-Weeks start on Monday and run to Sunday. Additionally, the first week 1 of each year contains the first Thursday of that year—which may not include the first day of the year, or may include the last few days of the previous year.
+Las semanas comienzan el lunes y terminan el domingo. Además, la primera semana del año contiene el primer jueves de ese año, lo cual puede no incluir el primer día del año, o puede incluir los últimos días del año anterior.
+
+```html hidden
+<label for="week">Introduce la semana:</label><br />
+```
 
 ```html
 <input type="week" name="week" id="week" />
 ```
 
-### Constraining date/time values
+{{EmbedLiveSample('week','100%','50')}}
 
-All date and time controls can be constrained using the [`min`](/es/docs/Web/HTML/Reference/Attributes/min) and [`max`](/es/docs/Web/HTML/Attributes/max) attributes, with further constraining possible via the [`step`](/es/docs/Web/HTML/Attributes/step) attribute (whose value varies according to input type).
+### Restricción de valores de fecha y hora
+
+Todos los controles de fecha y hora pueden restringirse usando los atributos [`min`](/es/docs/Web/HTML/Reference/Attributes/min) y [`max`](/es/docs/Web/HTML/Reference/Attributes/max), con restricciones adicionales posibles mediante el atributo [`step`](/es/docs/Web/HTML/Reference/Attributes/step) (cuyo valor varía según el tipo de input).
 
 ```html
-<label for="myDate">When are you available this summer?</label>
+<label for="myDate">¿Cuándo estás disponible este verano?</label><br />
 <input
   type="date"
   name="myDate"
-  min="2013-06-01"
-  max="2013-08-31"
+  min="2025-06-01"
+  max="2025-08-31"
   step="7"
   id="myDate" />
 ```
 
-### Browser support for date/time inputs
+{{EmbedLiveSample('Restricción de valores de fecha y hora','100%','50')}}
 
-You should be warned that the date and time widgets don't have the best browser support. At the moment, Chrome, Edge, and Opera support them well, but there is no support in Internet Explorer, Safari has some mobile support (but no desktop support), and Firefox supports `time` and `date` only.
+## Control de selector de color
 
-The reference pages linked to above provide suggestions on how to program fallbacks for non-supporting browsers; another option is to consider using a JavaScript library to provide a date picker. Most modern frameworks have good components available to provide this functionality, and there are standalone libraries available to (see [Top date picker javascript plugins and libraries](https://flatlogic.com/blog/best-javascript-date-picker-libraries/) for some suggestions).
+Los colores siempre son un poco difíciles de manejar. Hay muchas formas de expresarlos: valores RGB (decimales o hexadecimales), valores HSL, palabras clave, etc.
 
-## Color picker control
+Se puede crear un control `color` usando el elemento {{HTMLElement("input")}} con su atributo [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) establecido en el valor `color`:
 
-Colors are always a bit difficult to handle. There are many ways to express them: RGB values (decimal or hexadecimal), HSL values, keywords, etc.
-
-A `color` control can be created using the {{HTMLElement("input")}} element with its [`type`](/es/docs/Web/HTML/Reference/Elements/input#type) attribute set to the value `color`:
+```html hidden
+<label for="color">Elige un color:</label><br />
+```
 
 ```html
 <input type="color" name="color" id="color" />
 ```
 
-When supported, clicking a color control will tend to display the operating system's default color picking functionality for you to actually make your choice with. The following screenshot taken on Firefox for macOS provides an example:
+{{EmbedLiveSample('Control de selector de color','100%','50')}}
 
-![firefox for android email keyboard, with ampersand displayed by default.](fx-macos-color.jpg)
+Al hacer clic en un control de color, generalmente se muestra la funcionalidad predeterminada de selección de color del sistema operativo para que puedas elegir. El valor devuelto siempre es un color hexadecimal de 6 valores en minúsculas.
 
-And here is a live example for you to try out:
+## Resumen
 
-{{EmbedGHLiveSample("learning-area/html/forms/color-example/index.html", '100%', 200)}}
-
-The value returned is always a lowercase 6-value hexidecimal color.
-
-> [!NOTE]
-> `color` inputs are not supported in Internet Explorer.
-
-## Summary
-
-That brings us to the end of our tour of the HTML5 form input types. There are a few other control types that cannot be easily grouped together due to their very specific behaviors, but which are still essential to know about. We cover those in the next article.
+Con esto llegamos al final de nuestro recorrido por los tipos de input de formularios de HTML5. Hay algunos otros tipos de control que no se pueden agrupar fácilmente debido a sus comportamientos muy específicos, pero que siguen siendo esenciales de conocer. Los veremos en el próximo artículo.
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Forms/Basic_native_form_controls", "Learn_web_development/Extensions/Forms/Other_form_controls", "Learn_web_development/Extensions/Forms")}}
-
-### Advanced Topics
-
-- [How to build custom form controls](/es/docs/Learn_web_development/Extensions/Forms/How_to_build_custom_form_controls)
-- [Sending forms through JavaScript](/es/docs/Learn/Forms/Sending_forms_through_JavaScript)
-- [Property compatibility table for form widgets](/es/docs/Learn_web_development/Extensions/Forms)


### PR DESCRIPTION
### Description

Sincroniza la traducción al español de `Learn_web_development/Extensions/Forms/HTML5_input_types` con la última versión en inglés (commit `5f677b960051016819ecb3b1f40bc3d36a43156d`). El artículo nunca se había registrado para sincronización, así que se comparó y reescribió el documento completo.

### Motivation

La página llevaba años desactualizada frente a la versión en inglés: le faltaban ejemplos en vivo (`{{EmbedLiveSample}}`) y tenía secciones obsoletas (por ejemplo, la de soporte de navegadores para inputs de fecha/hora, que ya no existe en inglés).

### Additional details

- Front-matter reducido a `title`, `slug` y `l10n.sourceCommit`, eliminando `original_slug`.
- Se agregaron los `{{EmbedLiveSample}}` que faltaban, y se alinearon los 16 encabezados con el orden y jerarquía del inglés actual.
- Terminología modernizada (por ejemplo, "detector de eventos", "del lado del cliente/servidor", "Requisitos previos:", "navegador").
- Formateado con Prettier y validado con `markdownlint-cli2` y `check-url-locale.js`.

### Related issues and pull requests

Fixes #37253