### PR TITLE
fix(es): repara macros de glosario rotas y una imagen inexistente

### DIFF
--- a/files/es/glossary/arpa/index.md
+++ b/files/es/glossary/arpa/index.md
@@ -5,7 +5,7 @@ slug: Glossary/ARPA
 
 {{GlossarySidebar}}
 
-**.arpa** (parametros de dirección y enrutamiento) es un {{glossary("TLD","dominio de alto nivel")}} usado para propositos de infraestructura de Internet, especialmente busqueda inversa de DNS (ej., encontrar el {{glossary('nombre de dominio')}} para una {{glossary("dirección IP")}}) suministrada.
+**.arpa** (parametros de dirección y enrutamiento) es un {{glossary("TLD","dominio de alto nivel")}} usado para propositos de infraestructura de Internet, especialmente busqueda inversa de DNS (ej., encontrar el {{glossary("Domain_name", "nombre de dominio")}} para una {{glossary("IP_address", "dirección IP")}}) suministrada.
 
 ## Learn more
 

--- a/files/es/glossary/promise/index.md
+++ b/files/es/glossary/promise/index.md
@@ -5,7 +5,7 @@ slug: Glossary/Promise
 
 {{GlossarySidebar}}
 
-Una **{{jsxref("Promise", "Promesa")}}** es un {{Glossary("objeto")}} devuelto por una {{Glossary("función")}} que no ha completado su tarea. La promesa representa literalmente una promesa creada por una función a la que le llegará un resultado en un futuro.
+Una **{{jsxref("Promise", "Promesa")}}** es un {{Glossary("objeto")}} devuelto por una {{Glossary("Function", "función")}} que no ha completado su tarea. La promesa representa literalmente una promesa creada por una función a la que le llegará un resultado en un futuro.
 
 Cuando la función termina su tarea {{Glossary("asynchronous", "de forma asíncrona")}}, una función del objeto "promesa" será ejecutada.
 

--- a/files/es/learn_web_development/core/structuring_content/planet_data_table/index.md
+++ b/files/es/learn_web_development/core/structuring_content/planet_data_table/index.md
@@ -38,11 +38,7 @@ Para comenzar esta evaluación, crea una copia local de [blank-template.html](ht
 
 Estás trabajando en la escuela; tus estudiantes están estudiando los planetas de nuestro sistema solar y quieres proporcionarles una forma sencilla de seguir los datos para buscar hechos sobre los planetas. Una tabla HTML sería ideal — tienes que coger los datos que tienes disponibles y convertirlos en una tabla siguiendo los pasos de abajo.
 
-La tabla finalizada debería de verse así:
-
-![](assessment-table.png)
-
-También puedes ver el ejemplo [aquí](https://mdn.github.io/learning-area/html/tables/assessment-finished/planets-data.html) (no mires el código fuente — ¡no hagas trampas!)
+Puedes ver cómo debería quedar la tabla finalizada en el ejemplo [aquí](https://mdn.github.io/learning-area/html/tables/assessment-finished/planets-data.html) (no mires el código fuente — ¡no hagas trampas!)
 
 ## Pasos para completarlo
 

--- a/files/es/learn_web_development/core/structuring_content/structuring_documents/index.md
+++ b/files/es/learn_web_development/core/structuring_content/structuring_documents/index.md
@@ -287,7 +287,7 @@ Quedará así:
 
 ## Planificación de una página web sencilla
 
-Una vez has planificado el contenido de una página web sencilla, el paso lógico siguiente es intentar trabajar en el contenido para todo el sitio web, las páginas que necesitas y la forma de disponer las conexiones entre ellas para producir la mejor experiencia de usuario a los visitantes. Esto se conoce con el nombre de ({{Glossary("Arquitectura de la información")}}). Una web grande y compleja necesitará mucha planificación, pero para una web sencilla compuesta por unas cuantas páginas, el proceso puede ser sencillo, ¡y divertido!.
+Una vez has planificado el contenido de una página web sencilla, el paso lógico siguiente es intentar trabajar en el contenido para todo el sitio web, las páginas que necesitas y la forma de disponer las conexiones entre ellas para producir la mejor experiencia de usuario a los visitantes. Esto se conoce con el nombre de ({{Glossary("Information_architecture", "Arquitectura de la información")}}). Una web grande y compleja necesitará mucha planificación, pero para una web sencilla compuesta por unas cuantas páginas, el proceso puede ser sencillo, ¡y divertido!.
 
 1. Ten en cuenta que habrá varios elementos comunes en muchas (si no en todas las) páginas, tal como el menú de navegación y el contenido del pie de página. Si la web está dedicada a un negocio, por ejemplo, sería una buena idea disponer de la información de contacto en el pie de página en todas las páginas. Anota lo que deseas tener en común en cada página.
 
@@ -301,7 +301,7 @@ Una vez has planificado el contenido de una página web sencilla, el paso lógic
 
    ![Una larga lista de todas las funciones que podrías incluir en tu sitio de viajes, desde buscar, hasta ofertas especiales e información específica del país](feature-list.png)
 
-4. A continuación, trata de ordenar todo este contenido por grupos, para hacerte una idea de las partes que podrían ir juntas en las diferentes páginas. Esto es muy similar a una técnica llamada {{Glossary("Clasificación de tarjetas")}}.
+4. A continuación, trata de ordenar todo este contenido por grupos, para hacerte una idea de las partes que podrían ir juntas en las diferentes páginas. Esto es muy similar a una técnica llamada {{Glossary("Card_sorting", "Clasificación de tarjetas")}}.
 
    ![Los elementos que deberían aparecer en un sitio de vacaciones ordenados en 5 categorías: Búsqueda, Especiales, Información específica del país, Resultados de búsqueda y Compra cosas](card-sorting.png)
 

--- a/files/es/learn_web_development/core/structuring_content/table_accessibility/index.md
+++ b/files/es/learn_web_development/core/structuring_content/table_accessibility/index.md
@@ -48,7 +48,7 @@ Como puedes deducir a partir del breve ejemplo anterior, el título debe contene
 Los subtítulos se colocan directamente debajo de la etiqueta `<table>`.
 
 > [!NOTE]
-> El atributo [`summary`](/es/docs/Web/HTML/Reference/Elements/table#summary) también se puede usar en el elemento `table` para proporcionar una descripción; los lectores de pantalla también lo leen. Sin embargo, recomendamos usar el elemento `caption`, porque [`summary`](/es/docs/Web/HTML/Reference/Elements/table#summary) está {{glossary("obsoleto")}} conforme a la especificación HTML5 y porque los usuarios sin discapacidad visual no pueden leerlo (no aparece en la página).
+> El atributo [`summary`](/es/docs/Web/HTML/Reference/Elements/table#summary) también se puede usar en el elemento `table` para proporcionar una descripción; los lectores de pantalla también lo leen. Sin embargo, recomendamos usar el elemento `caption`, porque [`summary`](/es/docs/Web/HTML/Reference/Elements/table#summary) está obsoleto y porque los usuarios sin discapacidad visual no pueden leerlo (no aparece en la página).
 
 ### Aprendizaje activo: Añadir un subtítulo
 

--- a/files/es/learn_web_development/extensions/async_js/index.md
+++ b/files/es/learn_web_development/extensions/async_js/index.md
@@ -6,7 +6,7 @@ original_slug: Learn/JavaScript/Asynchronous
 
 {{LearnSidebar}}
 
-En este módulo echamos un vistazo a {{Glossary("JavaScript")}} {{Glossary("asíncrono")}}, por qué es importante y cómo se puede utilizar para manejar eficazmente las posibles operaciones de bloqueo, como recuperar recursos desde un servidor
+En este módulo echamos un vistazo a {{Glossary("JavaScript")}} {{Glossary("Asynchronous", "asíncrono")}}, por qué es importante y cómo se puede utilizar para manejar eficazmente las posibles operaciones de bloqueo, como recuperar recursos desde un servidor
 
 ## Prerrequisitos
 

--- a/files/es/learn_web_development/extensions/client-side_apis/client-side_storage/index.md
+++ b/files/es/learn_web_development/extensions/client-side_apis/client-side_storage/index.md
@@ -275,7 +275,7 @@ Ahora veamos lo que tenemos que hacer en primer lugar, para configurar una base 
    let request = window.indexedDB.open("notes_db", 1);
    ```
 
-   Esta línea crea una `solicitud` para abrir la versión `1` de una base de datos llamada `notes_db`. Si esta aún no existe, se creará para ti mediante un código posterior. Verás que este patrón de solicitud se usa con mucha frecuencia en `IndexedDB`. Las operaciones de la base de datos llevan tiempo. No deseas colgar el navegador mientras esperas los resultados, por lo que las operaciones de la base de datos son {{Glossary("asíncronas")}}, lo que significa que en lugar de ocurrir de inmediato, sucederán en algún momento en el futuro, y recibirás una notificación cuando haya terminado.
+   Esta línea crea una `solicitud` para abrir la versión `1` de una base de datos llamada `notes_db`. Si esta aún no existe, se creará para ti mediante un código posterior. Verás que este patrón de solicitud se usa con mucha frecuencia en `IndexedDB`. Las operaciones de la base de datos llevan tiempo. No deseas colgar el navegador mientras esperas los resultados, por lo que las operaciones de la base de datos son {{Glossary("Asynchronous", "asíncronas")}}, lo que significa que en lugar de ocurrir de inmediato, sucederán en algún momento en el futuro, y recibirás una notificación cuando haya terminado.
 
    Para manejar esto en IndexedDB, crea un objeto de solicitud (que se puede llamar como desees; lo llamamos `request`, por lo que es obvio para qué sirve). Luego, usa controladores de eventos para ejecutar código cuando la solicitud se completa, falla, etc., que verás en uso a continuación.
 

--- a/files/es/web/http/reference/headers/index.md
+++ b/files/es/web/http/reference/headers/index.md
@@ -11,7 +11,7 @@ Las Cabeceras pueden ser agrupadas de acuerdo a sus contextos:
 - {{Glossary("Cabecera general")}}: Cabeceras que se aplican tanto a las peticiones como a las respuestas, pero sin relación con los datos que finalmente se transmiten en el cuerpo.
 - {{Glossary("Cabecera de consulta")}}: Cabeceras que contienen más información sobre el contenido que va a obtenerse o sobre el cliente.
 - {{Glossary("Cabecera de respuesta")}}: Cabeceras que contienen más información sobre el contenido, como su origen o el servidor (nombre, versión, etc.).
-- {{Glossary("Cabecera de entidad")}}: Cabeceras que contienen más información sobre el cuerpo de la entidad, como el tamaño del contenido o su tipo MIME.
+- {{Glossary("Entity_header", "Cabecera de entidad")}}: Cabeceras que contienen más información sobre el cuerpo de la entidad, como el tamaño del contenido o su tipo MIME.
 
 Las cabeceras también pueden clasificarse de acuerdo a cómo se comportan frente a ellas los proxies:
 

--- a/files/es/web/javascript/reference/errors/not_defined/index.md
+++ b/files/es/web/javascript/reference/errors/not_defined/index.md
@@ -15,7 +15,7 @@ ReferenceError: "x" no está definida.
 
 ## ¿Qué está mal?
 
-Hay una variable no existente que está siendo referida en algún lugar. Esta variable necesita ser declarada o se debe comprobar su disponibilidad en el {{Glossary("ámbito")}} actual del script.
+Hay una variable no existente que está siendo referida en algún lugar. Esta variable necesita ser declarada o se debe comprobar su disponibilidad en el {{Glossary("Scope", "ámbito")}} actual del script.
 
 > [!NOTE]
 > Cuando una librería es cargada (como por ejemplo jQuery) asegúrese de que se haya cargado antes de intentar acceder a sus variables, como por ejemplo "$". Ponga la etiqueta {{HTMLElement("script")}}, que carga la librería antes del código que la utiliza.
@@ -64,6 +64,6 @@ console.log(num1); // 2
 
 ## Temas relacionados
 
-- {{Glossary("Ámbito")}}
+- {{Glossary("Scope", "Ámbito")}}
 - [Guía; declarando variables en JavaScript](/es/docs/Web/JavaScript/Guide/Grammar_and_types#declaring_variables)
 - [Guía; contexto de la función en Java Script](/es/docs/Web/JavaScript/Guide/Functions#ámbito_de_function)


### PR DESCRIPTION
### Description

Repara diez macros `{{Glossary()}}` que pasaban el término en español como primer argumento, más dos referencias rotas concretas.

### Motivation

El primer argumento de `{{Glossary()}}` es el **slug** de la página, no el texto a mostrar. Al pasarle el término en español, el enlace apunta a una página que no existe.

Salió al revisar el _preview_ de #38421: `Table_accessibility` reportaba `Macro glossary produces link /es/docs/Glossary/obsoleto which doesn't resolve`. Buscando el resto del repositorio aparecieron nueve casos más, así que esto no es un arreglo de una línea sino de una clase de defecto.

De los diez, **seis daban 404 directo** y **cuatro sólo funcionaban por una redirección heredada** en `_redirects.txt`, es decir, con un salto de más:

| Término en español | Estado antes | Slug correcto |
| --- | --- | --- |
| `Cabecera de entidad` | 404 | `Entity_header` |
| `ámbito` / `Ámbito` | 404 | `Scope` |
| `Clasificación de tarjetas` | 404 | `Card_sorting` |
| `asíncronas` | 404 | `Asynchronous` |
| `dirección IP` | 404 | `IP_address` |
| `Arquitectura de la información` | 200 vía redirección | `Information_architecture` |
| `asíncrono` | 200 vía redirección | `Asynchronous` |
| `función` | 200 vía redirección | `Function` |
| `nombre de dominio` | 200 vía redirección | `Domain_name` |

Los diez destinos en inglés se comprobaron uno a uno y responden `200`.

### Changes

El término en español pasa al **segundo** argumento, así que **el texto renderizado no cambia**:

```diff
- {{Glossary("ámbito")}}
+ {{Glossary("Scope", "ámbito")}}
```

Dos arreglos adicionales, que son los que originaron la búsqueda:

- **`table_accessibility`**: se quita `{{glossary("obsoleto")}}`. Aquí no hace falta macro: la fuente en inglés dice `as summary is deprecated` en prosa, sin enlace.
- **`planet_data_table`**: se quita la referencia a `assessment-table.png`. Esa imagen **no existe** ni en `files/es` ni en `files/en-us`, y su URL devuelve `404` en ambos idiomas, así que hoy se ve rota en la página publicada. La frase siguiente ya enlaza al ejemplo terminado, de modo que no se pierde la referencia visual.

### Verification

- Búsqueda posterior en todo `files/es`: **0** macros `{{Glossary()}}` de un solo argumento con el término en español, en cualquiera de las dos formas de comillas.
- **0** referencias a `assessment-table.png`.
- `prettier --check` y `markdownlint-cli2` pasan en los 9 archivos.

`Promise/index.md` aparece en el diff sólo por su `{{Glossary("función")}}`; su `{{jsxref("Promise", "Promesa")}}` ya estaba correcto desde #38340.