### PR TITLE
docs(es): sincroniza font-size y <length> con la fuente en inglés

### DIFF
--- a/files/es/web/css/guides/cascade/property_value_processing/index.md
+++ b/files/es/web/css/guides/cascade/property_value_processing/index.md
@@ -152,7 +152,7 @@ El **valor inicial** de una propiedad es el valor predeterminado que figura en s
 Puedes establecer explícitamente el valor inicial usando la palabra clave {{cssxref("initial")}}.
 
 > [!NOTE]
-> El valor inicial se encuentra en la sección de sintaxis formal de la página de referencia de cada propiedad CSS. Por ejemplo, el [valor inicial de `font-size` es `medium`](/es/docs/Web/CSS/Reference/Properties/font-size). No debe confundirse con el valor especificado por la hoja de estilo del navegador.
+> El valor inicial se encuentra en la sección de sintaxis formal de la página de referencia de cada propiedad CSS. Por ejemplo, el [valor inicial de `font-size` es `medium`](/es/docs/Web/CSS/Reference/Properties/font-size#definición_formal). No debe confundirse con el valor especificado por la hoja de estilo del navegador.
 
 ### Valor calculado
 
@@ -232,7 +232,7 @@ updateAllUsedWidths();
 window.addEventListener("resize", updateAllUsedWidths);
 ```
 
-Aunque los tres valores especificados, `auto`, `50%` e `inherit`, son palabras clave y valores de {{cssxref("percentage")}}, obtener el `width` con `window.getComputedStyle(el)["width"];` devuelve un valor de [longitud absoluta](/es/docs/Web/CSS/Reference/Values/length) en `px`:
+Aunque los tres valores especificados, `auto`, `50%` e `inherit`, son palabras clave y valores de {{cssxref("percentage")}}, obtener el `width` con `window.getComputedStyle(el)["width"];` devuelve un valor de [longitud absoluta](/es/docs/Web/CSS/Reference/Values/length#unidades_de_longitud_absolutas) en `px`:
 
 {{ EmbedLiveSample('Example', '80%', 372) }}
 

--- a/files/es/web/css/reference/properties/font-size/index.md
+++ b/files/es/web/css/reference/properties/font-size/index.md
@@ -1,61 +1,257 @@
 ---
-title: font-size
+title: Propiedad CSS `font-size`
+short-title: font-size
 slug: Web/CSS/Reference/Properties/font-size
-original_slug: Web/CSS/font-size
+l10n:
+  sourceCommit: a5531a7b1fa30ab1de952ffff619a9830eb1c1a9
 ---
 
-## Resumen
+La propiedad [CSS](/es/docs/Web/CSS) **`font-size`** establece el tamaño de la fuente. Cambiar el tamaño de la fuente también actualiza el tamaño de las unidades {{cssxref("&lt;length&gt;")}} relativas a él, como `em`, `ex`, etc.
 
-La propiedad `font-size` especifica la dimensión de la letra. Este tamaño puede, a su vez, alterar el aspecto de alguna otra cosa, ya que se usa para calcular la longitud de las unidades `em` y `ex`.
+{{InteractiveExample("CSS Demo: font-size")}}
 
-{{cssinfo}}
+```css interactive-example-choice
+font-size: 1.2rem;
+```
+
+```css interactive-example-choice
+font-size: x-small;
+```
+
+```css interactive-example-choice
+font-size: smaller;
+```
+
+```css interactive-example-choice
+font-size: 12px;
+```
+
+```css interactive-example-choice
+font-size: 80%;
+```
+
+```html interactive-example
+<section id="default-example">
+  <p id="example-element">
+    London. Michaelmas term lately over, and the Lord Chancellor sitting in
+    Lincoln's Inn Hall. Implacable November weather. As much mud in the streets
+    as if the waters had but newly retired from the face of the earth, and it
+    would not be wonderful to meet a Megalosaurus, forty feet long or so,
+    waddling like an elephantine lizard up Holborn Hill.
+  </p>
+</section>
+```
 
 ## Sintaxis
 
-`font-size:` `xx-small` | `x-small` | `small` | `medium` | `large` | `x-large` | `xx-large`
+```css
+/* Valores <absolute-size> */
+font-size: xx-small;
+font-size: x-small;
+font-size: small;
+font-size: medium;
+font-size: large;
+font-size: x-large;
+font-size: xx-large;
+font-size: xxx-large;
 
-`font-size:` `smaller` | `larger`
+/* Valores <relative-size> */
+font-size: smaller;
+font-size: larger;
 
-`font-size:` \<longitud> | \<porcentaje> | {{ Cssxref("inherit") }}
+/* Valores <length> */
+font-size: 12px;
+font-size: 0.8em;
+
+/* Valores <percentage> */
+font-size: 80%;
+
+/* Valor math */
+font-size: math;
+
+/* Valores globales */
+font-size: inherit;
+font-size: initial;
+font-size: revert;
+font-size: revert-layer;
+font-size: unset;
+```
 
 ### Valores
 
-- xx-small, x-small, small, medium, large, x-large, xx-large
-  - : un grupo de palabras clave de dimensión absoluta en relación al que determina el usuario como tamaño por defecto (que es `medium`). De forma parecida a las sentencias HTML `<font size="1">` hasta `<font size="7">` donde el tamaño por defecto es `<font size="3">`.
-- larger, smaller
-  - : más grande o más pequeño que el tamaño de letra del elemento padre, con aproximadamente el mismo ratio que el mencionado anteriormente.
-- [\<longitud>](/es/docs/Web/CSS/Reference/Values/length)
-  - : una unidad positiva de [longitud](/es/docs/Web/CSS/Reference/Values/length).
+Esta propiedad se especifica con un único valor de la lista siguiente:
 
-<!---->
+- `xx-small`, `x-small`, `small`, `medium`, `large`, `x-large`, `xx-large`, `xxx-large`
+  - : Palabras clave de [tamaño absoluto](/es/docs/Web/CSS/Reference/Values/absolute-size), basadas en el tamaño de fuente predeterminado de quien usa el navegador (que es `medium`).
 
-- \<Porcentaje>
-  - : un porcentaje positivo del cuerpo de letra del elemento padre.
+- `larger`, `smaller`
+  - : Palabras clave de [tamaño relativo](/es/docs/Web/CSS/Reference/Values/relative-size). La fuente será mayor o menor con respecto al tamaño de fuente del elemento padre, aproximadamente en la misma proporción que separa las palabras clave de tamaño absoluto anteriores.
 
-Es aconsejable evitar el uso de valores que no sean relativos al tamaño por defecto definido por el usuario, tales como `longitud` absoluta en unidades distintas a `em` o `ex`. Sin embargo, si hay que usar ese tipo de valores, es preferible utilizar unidades `px` (píxel), ya que su significado no varía en función de las características del sistema operativo (casi siempre erróneas) como la resolución del monitor.
+- {{cssxref("&lt;length&gt;")}}
+  - : Un valor {{cssxref("&lt;length&gt;")}} positivo. Para la mayoría de las unidades relativas a la fuente (como `em` y `ex`), el tamaño de fuente es relativo al del elemento padre.
+
+    Para las unidades relativas a la fuente que se basan en la raíz (como `rem`), el tamaño de fuente es relativo al de la fuente que usa el elemento {{HTMLElement("html")}} (el elemento raíz).
+
+- {{cssxref("&lt;percentage&gt;")}}
+  - : Un valor {{cssxref("&lt;percentage&gt;")}} positivo, relativo al tamaño de fuente del elemento padre.
+    > [!NOTE]
+    > Para maximizar la accesibilidad, por lo general es mejor usar valores relativos al tamaño de fuente predeterminado de quien usa el navegador.
+
+- `math`
+  - : Se aplican [reglas de escalado](https://w3c.github.io/mathml-core/#the-math-script-level-property) al determinar el valor calculado de la propiedad `font-size` en los elementos matemáticos, con respecto al `font-size` del padre que los contiene.
+    Consulta la propiedad [math-depth](/es/docs/Web/CSS/Reference/Properties/math-depth) para más información.
+
+## Descripción
+
+Hay varias formas de especificar el tamaño de la fuente, con palabras clave o con valores numéricos en píxeles o en ems. Elige el método adecuado según las necesidades de cada página web.
+
+### Palabras clave
+
+Las palabras clave son una buena manera de fijar el tamaño de las fuentes en la web. Al establecer un tamaño de fuente con palabra clave en el elemento {{HTMLElement("body")}}, puedes fijar tamaños relativos en el resto de la página, lo que te permite escalar con facilidad la fuente hacia arriba o hacia abajo en toda ella.
+
+### Píxeles
+
+Fijar el tamaño de fuente en píxeles (`px`) es una buena opción cuando necesitas precisión exacta. Un valor en px es estático. Es una forma independiente del sistema operativo y del navegador de indicarle literalmente al navegador que dibuje las letras con exactamente la altura en píxeles que has especificado. Los resultados pueden variar ligeramente entre navegadores, porque pueden usar algoritmos distintos para lograr un efecto similar.
+
+Los ajustes de tamaño de fuente también se pueden combinar. Por ejemplo, si un elemento padre está fijado en `16px` y su elemento hijo en `larger`, el hijo se muestra más grande que el padre en la página.
+
+> [!NOTE]
+> Definir los tamaños de fuente en `px` _[no es accesible](https://es.wikipedia.org/wiki/Accesibilidad_web)_, porque en algunos navegadores no se puede cambiar el tamaño de la fuente. Por ejemplo, quien tenga visión reducida puede querer un tamaño de fuente mucho mayor que el elegido por quien diseñó la web. Evita usarlos para los tamaños de fuente si quieres crear un diseño inclusivo.
+
+### Ems
+
+Usar un valor `em` crea un tamaño de fuente dinámico o calculado (históricamente la unidad `em` derivaba del ancho de una «M» mayúscula en una tipografía dada). El valor numérico actúa como multiplicador de la propiedad `font-size` del elemento sobre el que se usa. Fíjate en este ejemplo:
+
+```css
+p {
+  font-size: 2em;
+}
+```
+
+En este caso, el tamaño de fuente de los elementos `<p>` será el doble del `font-size` calculado que heredan. Por extensión, un `font-size` de `1em` equivale al `font-size` calculado del elemento sobre el que se usa.
+
+Si no se ha fijado ningún `font-size` en los ancestros del `<p>`, entonces `1em` equivaldrá al `font-size` predeterminado del navegador, que suele ser `16px`. Así que, por defecto, `1em` equivale a `16px` y `2em` a `32px`. Si fijaras un `font-size` de 20px en el elemento `<body>`, entonces `1em` en los elementos `<p>` equivaldría a `20px`, y `2em` a `40px`.
+
+Para calcular el equivalente en `em` de cualquier valor en píxeles, puedes usar esta fórmula:
+
+```plain
+em = valor en píxeles deseado para el elemento / tamaño de fuente del padre en píxeles
+```
+
+Por ejemplo, supongamos que el `font-size` del `<body>` de la página está fijado en `16px`. Si el tamaño de fuente que quieres es `12px`, debes especificar `0.75em` (porque 12/16 = 0,75). De igual modo, si quieres un tamaño de fuente de `10px`, especifica `0.625em` (10/16 = 0,625); para `22px`, especifica `1.375em` (22/16).
+
+El `em` es una unidad muy útil en CSS, ya que adapta automáticamente su longitud a la fuente que elija usar quien lee.
+
+Un dato importante que conviene recordar: los valores en em se componen. Fíjate en el HTML y el CSS siguientes:
+
+```css
+html {
+  font-size: 100%;
+}
+span {
+  font-size: 1.6em;
+}
+```
+
+```html
+<div>
+  <span>Exterior <span>interior</span> exterior</span>
+</div>
+```
+
+El resultado es:
+
+{{EmbedLiveSample("Ems", 400, 100)}}
+
+Suponiendo que el `font-size` predeterminado del navegador sea 16px, las palabras «exterior» se dibujarían a 25,6px, pero la palabra «interior» se dibujaría a 40,96px. Esto se debe a que el `font-size` del {{HTMLElement("span")}} interior es de 1.6em, relativo al `font-size` de su padre, que a su vez es relativo al `font-size` del suyo. Esto es lo que se suele llamar **composición**.
+
+### Rems
+
+Los valores `rem` se inventaron para sortear el problema de la composición. Los valores `rem` son relativos al elemento raíz `html`, no al elemento padre. Dicho de otro modo, te permiten especificar un tamaño de fuente de forma relativa sin verte afectado por el tamaño del padre, lo que elimina la composición.
+
+El CSS siguiente es casi idéntico al del ejemplo anterior. La única diferencia es que la unidad ha cambiado a `rem`.
+
+```css
+html {
+  font-size: 100%;
+}
+span {
+  font-size: 1.6rem;
+}
+```
+
+Y aplicamos este CSS al mismo HTML, que queda así:
+
+```html
+<span>Exterior <span>interior</span> exterior</span>
+```
+
+{{EmbedLiveSample("Rems", 400, 100)}}
+
+En este ejemplo, las palabras «exterior interior exterior» se muestran todas a 25,6px (suponiendo que el `font-size` del navegador se haya dejado en su valor predeterminado de 16px).
+
+### Ex
+
+Igual que con la unidad `em`, el `font-size` de un elemento fijado con la unidad `ex` es calculado o dinámico. Se comporta exactamente igual, salvo que al fijar la propiedad `font-size` con unidades `ex`, el `font-size` equivale a la altura de la x de la [primera fuente disponible](https://drafts.csswg.org/css-fonts/#first-available-font) que se use en la página. El valor numérico multiplica el `font-size` heredado por el elemento, y el `font-size` se compone de forma relativa.
+
+Consulta el borrador editorial del W3C para una descripción más detallada de las [unidades de longitud relativas a la fuente](https://drafts.csswg.org/css-values-4/#font-relative-length) como `ex`.
+
+## Definición formal
+
+{{cssinfo}}
+
+## Sintaxis formal
+
+{{csssyntax}}
 
 ## Ejemplos
 
-[Ver El Ejemplo Vivo](https://mdn.dev/archives/media/samples/cssref/font-size.html)
+### Establecer tamaños de fuente
 
+#### CSS
+
+```css
+.small {
+  font-size: xx-small;
+}
+.larger {
+  font-size: larger;
+}
+.point {
+  font-size: 24pt;
+}
+.percent {
+  font-size: 200%;
+}
 ```
-/* Ajusta el texto del párrafo a un cuerpo de letra muy grande. */
-p { font-size: xx-large }
 
-/* Ajusta la cabecera de nivel 1 (h1) a 2,5 veces del tamaño
- * del texto. */
-h1 { font-size: 250% }
+#### HTML
 
-/* Ajusta el texto incluido en span a 16px */
-span { font-size: 16px; }
+```html
+<h1 class="small">H1 pequeño</h1>
+<h1 class="larger">H1 más grande</h1>
+<h1 class="point">H1 de 24 puntos</h1>
+<h1 class="percent">H1 al 200%</h1>
 ```
 
-## Notas
+#### Resultado
 
-Las unidades `em` y `ex` en la propiedad {{ Cssxref("font-size") }} son relativas al tamaño de letra del elemento padre (al contrario que todas las demás propiedades, en las que estas unidades son relativas al tamaño de letra del elemento). Esto quiere decir que las unidades `em` y los porcentajes se comportan de igual forma cuando hablamos de {{ Cssxref("font-size") }}.
+{{EmbedLiveSample('Establecer_tamaños_de_fuente', 600, 250)}}
 
 ## Especificaciones
 
-- [CSS 1](https://www.w3.org/TR/CSS1#font-size)
-- [CSS 2.1](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
-- [css3-fonts](https://www.w3.org/TR/css3-fonts/#font-size)
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
+
+## Véase también
+
+- {{cssxref("font-size-adjust")}}
+- {{cssxref("font-style")}}
+- {{cssxref("font-weight")}}
+- {{cssxref("math-depth")}}
+- {{cssxref("math-style")}}
+- Atributo SVG {{SVGAttr("font-size")}}
+- [Aprende: fundamentos del estilo de texto y fuentes](/es/docs/Learn_web_development/Core/Text_styling/Fundamentals)

--- a/files/es/web/css/reference/values/length/index.md
+++ b/files/es/web/css/reference/values/length/index.md
@@ -1,100 +1,317 @@
 ---
-title: <length>
+title: Tipo CSS `<length>`
+short-title: <length>
 slug: Web/CSS/Reference/Values/length
-original_slug: Web/CSS/length
+l10n:
+  sourceCommit: b25b4a98b757fbd05ce1fb74b1b78f3fcf917729
 ---
 
-## Resumen
+El [tipo de dato](/es/docs/Web/CSS/Reference/Values/Data_types) [CSS](/es/docs/Web/CSS) **`<length>`** representa un valor de distancia. Las longitudes se pueden usar en numerosas propiedades CSS, como {{Cssxref("width")}}, {{Cssxref("height")}}, {{Cssxref("margin")}}, {{Cssxref("padding")}}, {{Cssxref("border-width")}}, {{Cssxref("font-size")}} y {{Cssxref("text-shadow")}}.
 
-El tipo de dato [CSS](/es/docs/Web/CSS) `<length>` denota medidas de distancia. Es un valor {{cssxref("&lt;number&gt;")}} seguido por una unidad de longitud (`px`, `em`, `pc`, `in`, `mm`, …). Al igual que en cualquier dimensión CSS, no debe haber espacio entre la unidad y el número. La unidad de longitud es opcional después del valor {{cssxref("&lt;number&gt;")}} `0`.
+> [!NOTE]
+> Aunque los valores {{cssxref("&lt;percentage&gt;")}} se pueden usar en algunas de las mismas propiedades que aceptan valores `<length>`, no son en sí valores `<length>`. Consulta {{cssxref("&lt;length-percentage&gt;")}}.
 
-Muchas propiedades CSS ([CSS properties](/es/CSS_Reference)) reciben valores `<length>`, como por ejemplo {{ Cssxref("width") }}, {{ Cssxref("margin-top") }}, y {{ Cssxref("font-size") }}.
+## Sintaxis
 
-Para algunas propiedades, el uso de longitudes negativas es un error de sintaxis, mientras que para algunas propiedades está permitido. Nótese que aunque los valores {{cssxref("&lt;percentage&gt;")}} también son dimensiones CSS y son aceptadas por algunas propiedades CSS que aceptan valores `<length>`, no son valores `<length>` en sí.
+El tipo de dato `<length>` consiste en un {{cssxref("&lt;number&gt;")}} seguido de una de las unidades que se listan más abajo. Como en todas las dimensiones CSS, no hay espacio entre el número y el literal de la unidad. Especificar la unidad de longitud es opcional si el número es `0`.
+
+> [!NOTE]
+> Algunas propiedades admiten valores `<length>` negativos y otras no.
+
+### Valores especificados frente a valores calculados
+
+El [valor especificado](/es/docs/Web/CSS/Guides/Cascade/Property_value_processing#valor_especificado) de una longitud (_longitud especificada_) se representa con su cantidad y su unidad. El [valor calculado](/es/docs/Web/CSS/Guides/Cascade/Property_value_processing#valor_calculado) de una longitud (_longitud calculada_) es la longitud especificada resuelta a una longitud absoluta, y su unidad no se distingue.
+
+En algunas propiedades, como `border-width`, `outline-width`, `column-rule-width` y `outline-offset`, los valores `<length>` calculados se redondean a un número entero de {{glossary("device pixel", "píxeles de dispositivo")}} para garantizar una presentación visual razonable:
+
+- Un valor distinto de cero y menor que 1 píxel de dispositivo se redondea hacia arriba.
+- Un valor mayor que 1 píxel de dispositivo se redondea hacia abajo al píxel de dispositivo entero más cercano.
+
+Por ejemplo, en una pantalla con un {{domxref("Window.devicePixelRatio", "devicePixelRatio")}} de 3, `border-width: 1.5px` se calcula como aproximadamente `1.33px` (redondeando de 4,5 a 4 píxeles de dispositivo), y `outline-width: 0.2px` se calcula como aproximadamente `0.33px` (redondeando de 0,6 a 1 píxel de dispositivo).
+
+### Longitudes relativas frente a absolutas
+
+Las unidades de `<length>` pueden ser relativas o absolutas. Las longitudes relativas representan una medida en función de otra distancia. Según la unidad, esa distancia puede ser el tamaño de un carácter concreto, la [altura de línea](/es/docs/Web/CSS/Reference/Properties/line-height) o el tamaño del {{Glossary("viewport", "área visible")}}. Las hojas de estilo que usan unidades de longitud relativas se adaptan con más facilidad de un entorno de salida a otro.
+
+> [!NOTE]
+> Los elementos hijos no heredan los valores relativos tal como se especificaron para su padre; heredan los valores calculados.
+
+## Unidades de longitud relativas
+
+Las unidades de longitud relativas de CSS se basan en el tamaño de la fuente, del contenedor o del área visible.
+
+### Unidades de longitud relativas a la fuente
+
+Las longitudes de fuente definen el valor `<length>` en función del tamaño de un carácter concreto o de un atributo de la fuente vigente en un elemento o en su padre.
+
+> [!NOTE]
+> Estas unidades, en especial `em` y su equivalente relativa a la raíz `rem`, se usan a menudo para crear diseños escalables que mantienen el ritmo vertical de la página aunque quien lee cambie el tamaño de fuente.
+
+- `cap`
+  - : Igual a la «altura de mayúsculas» (la altura nominal de las letras mayúsculas) de la {{Cssxref("font")}} del elemento.
+- `ch`
+  - : Representa el ancho o, más exactamente, la {{Glossary("advance measure", "medida de avance")}} del glifo `0` (cero, el carácter Unicode U+0030) en la {{Cssxref("font")}} del elemento.
+    Cuando determinar la medida del glifo `0` es imposible o poco práctico, debe asumirse un ancho de `0.5em` y una altura de `1em`.
+- `em`
+  - : Representa el {{Cssxref("font-size")}} calculado del elemento. Si se usa en la propia propiedad {{Cssxref("font-size")}}, representa el tamaño de fuente _heredado_ por el elemento.
+- `ex`
+  - : Igual a la [altura de la x](https://es.wikipedia.org/wiki/Altura_x) de la {{Cssxref("font")}} del elemento. En las fuentes que tienen la letra `x`, suele ser la altura de las minúsculas; `1ex ≈ 0.5em` en muchas fuentes.
+- `ic`
+  - : Representa la {{Glossary("advance measure", "medida de avance")}} utilizada del glifo «水» (el ideograma CJK de agua, U+6C34) en la fuente con la que se dibuja.
+- `lh`
+  - : Igual al valor calculado de la propiedad {{Cssxref("line-height")}} del elemento sobre el que se usa, convertido a una longitud absoluta. Esta unidad permite calcular longitudes a partir del tamaño teórico de una línea vacía ideal. Sin embargo, el tamaño de las cajas de línea reales puede variar según su contenido.
+
+### Unidades de longitud relativas a la fuente del elemento raíz
+
+Estas unidades definen el valor `<length>` en función del tamaño de un carácter concreto o de un atributo de la fuente del elemento [raíz](/es/docs/Web/CSS/Reference/Selectors/:root):
+
+- `rcap`
+  - : Igual a la «altura de mayúsculas» (la altura nominal de las letras mayúsculas) de la {{Cssxref("font")}} del elemento raíz.
+- `rch`
+  - : Igual al ancho o a la {{Glossary("advance measure", "medida de avance")}} del glifo `0` (cero, el carácter Unicode U+0030) en la {{Cssxref("font")}} del elemento raíz.
+- `rem`
+  - : Representa el {{Cssxref("font-size")}} del elemento raíz (normalmente {{HTMLElement("html")}}). Cuando se usa dentro del {{Cssxref("font-size")}} del propio elemento raíz, representa su valor inicial. Un valor predeterminado habitual en los navegadores es `16px`, pero las preferencias de quien usa el navegador pueden modificarlo.
+- `rex`
+  - : Igual a la altura de la x de la {{Cssxref("font")}} del elemento raíz.
+- `ric`
+  - : Igual al valor de la unidad [`ic`](#ic) aplicada a la fuente del elemento raíz.
+- `rlh`
+  - : Igual al valor de la unidad [`lh`](#lh) aplicada a la fuente del elemento raíz. Esta unidad permite calcular longitudes a partir del tamaño teórico de una línea vacía ideal. Sin embargo, el tamaño de las cajas de línea reales puede variar según su contenido.
+
+### Unidades de longitud relativas al área visible
+
+Las **unidades de longitud en porcentaje del área visible** se basan en cuatro tamaños distintos del área visible: pequeño, grande, dinámico y predeterminado. La existencia de varios tamaños responde a que las interfaces de los navegadores se expanden y se contraen dinámicamente, ocultando y mostrando el contenido que hay debajo.
+
+- **Unidades de área visible pequeña**
+  - : Cuando quieras el área visible más pequeña posible frente a interfaces del navegador que se expanden dinámicamente, usa el tamaño de área visible pequeña. Ese tamaño permite que el contenido que diseñas llene toda el área visible cuando las interfaces del navegador están desplegadas. Elegirlo también puede dejar espacios vacíos cuando esas interfaces se retraen.
+
+    Por ejemplo, si un elemento se dimensiona con unidades de porcentaje basadas en el área visible pequeña, llenará la pantalla a la perfección sin que se oculte nada de su contenido mientras todas las interfaces dinámicas del navegador estén visibles. Cuando se ocultan, en cambio, puede aparecer espacio de más alrededor del elemento. Por eso las unidades de área visible pequeña son «más seguras» en general, aunque quizá no produzcan el diseño más atractivo una vez que quien lee empieza a interactuar con la página.
+
+    El tamaño de área visible pequeña se representa con el prefijo `sv` y da lugar a las unidades `sv*`. Sus tamaños son fijos y, por tanto, estables, salvo que cambie el tamaño del propio área visible.
+
+- **Unidades de área visible grande**
+  - : Cuando quieras el área visible más grande posible frente a interfaces del navegador que se retraen dinámicamente, usa el tamaño de área visible grande. Ese tamaño permite que el contenido que diseñas llene toda el área visible cuando las interfaces del navegador se están retrayendo. Ten en cuenta que el contenido puede quedar oculto cuando esas interfaces se expanden.
+
+    Por ejemplo, en los teléfonos móviles, donde el espacio en pantalla es escaso, los navegadores suelen ocultar parte o toda la barra de título y de dirección cuando quien lee empieza a desplazar la página. Si un elemento se dimensiona con una unidad basada en el área visible grande, su contenido llenará toda la página visible mientras esas interfaces estén ocultas. Sin embargo, cuando se muestran, pueden tapar el contenido dimensionado o posicionado con unidades de área visible _grande_.
+
+    La unidad de área visible grande se representa con el prefijo `lv` y da lugar a las unidades `lv*`. Sus tamaños son fijos y, por tanto, estables, salvo que cambie el tamaño del propio área visible.
+
+- **Unidades de área visible dinámica**
+  - : Cuando quieras que el área visible se dimensione automáticamente según se expandan o se retraigan las interfaces del navegador, puedes usar el tamaño de área visible dinámica. Ese tamaño permite que el contenido que diseñas encaje exactamente dentro del área visible, haya o no interfaces dinámicas del navegador.
+
+    La unidad de área visible dinámica se representa con el prefijo `dv` y da lugar a las unidades `dv*`. Sus tamaños no son estables, ni siquiera cuando el área visible no cambia.
+
+    > [!NOTE]
+    > Aunque el tamaño de área visible dinámica da más control y flexibilidad, usar unidades basadas en él puede hacer que el contenido cambie de tamaño mientras se desplaza la página. Eso puede degradar la interfaz y penalizar el rendimiento.
+
+- **Unidades de área visible predeterminada**
+  - : El tamaño de área visible predeterminado lo define el navegador. El comportamiento de la unidad resultante puede equivaler al de la unidad basada en el área visible pequeña, en la grande, en un tamaño intermedio entre ambas, o en la dinámica.
+
+    > [!NOTE]
+    > Por ejemplo, un navegador podría implementar la unidad predeterminada de altura (`vh`) de forma equivalente a la unidad de altura de área visible grande (`lvh`). Si es así, podría ocultar contenido en una presentación a página completa mientras la interfaz del navegador está desplegada. Actualmente, todas las unidades predeterminadas (`vh`, `vw`, etc.) equivalen a sus homólogas de área visible grande (`lvh`, `lvw`, etc.).
+
+Las longitudes en porcentaje del área visible definen valores `<length>` en porcentaje relativo al tamaño del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial, que a su vez se basa en el tamaño del {{Glossary("viewport", "área visible")}} o del área de la página, es decir, la porción visible del documento. Cuando cambia la altura o el ancho del bloque contenedor inicial, los elementos dimensionados a partir de ellos se escalan en consecuencia. Hay una variante de unidad de porcentaje del área visible por cada uno de los tamaños, como se describe abajo.
+
+> [!NOTE]
+> Las longitudes de área visible no son válidas en los bloques de declaración {{cssxref("@page")}}.
+
+- `vh`
+  - : Representa un porcentaje de la altura del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial del área visible. `1vh` es el 1 % de la altura del área visible. Por ejemplo, si esa altura es `300px`, un valor de `70vh` en una propiedad será `210px`.
+
+    Las unidades correspondientes a los tamaños pequeño, grande y dinámico son `svh`, `lvh` y `dvh`. `vh` equivale a `lvh`, es decir, a la unidad basada en el área visible grande.
+
+- `vw`
+  - : Representa un porcentaje del ancho del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial del área visible. `1vw` es el 1 % del ancho del área visible. Por ejemplo, si ese ancho es `800px`, un valor de `50vw` en una propiedad será `400px`.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svw`, `lvw` y `dvw`.
+    `vw` equivale a `lvw`, es decir, a la unidad basada en el área visible grande.
+
+- `vmax`
+  - : Representa en porcentaje el mayor de `vw` y `vh`.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svmax`, `lvmax` y `dvmax`.
+    `vmax` equivale a `lvmax`, es decir, a la unidad basada en el área visible grande.
+
+- `vmin`
+  - : Representa en porcentaje el menor de `vw` y `vh`.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svmin`, `lvmin` y `dvmin`.
+    `vmin` equivale a `lvmin`, es decir, a la unidad basada en el área visible grande.
+
+- `vb`
+  - : Representa el porcentaje del tamaño del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial en la dirección del [eje de bloque](/es/docs/Web/CSS/Guides/Logical_properties_and_values) del elemento raíz.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svb`, `lvb` y `dvb`.
+    `vb` equivale a `lvb`, es decir, a la unidad basada en el área visible grande.
+
+- `vi`
+  - : Representa un porcentaje del tamaño del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial en la dirección del [eje en línea](/es/docs/Web/CSS/Guides/Logical_properties_and_values) del elemento raíz.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svi`, `lvi` y `dvi`.
+    `vi` equivale a `lvi`, es decir, a la unidad basada en el área visible grande.
+
+### Unidades de longitud de consulta de contenedor
+
+Al aplicar estilos a un contenedor mediante consultas de contenedor, puedes usar unidades de longitud de consulta de contenedor.
+Estas unidades especifican una longitud relativa a las dimensiones del contenedor consultado.
+Los componentes que usan unidades relativas a su contenedor son más flexibles y se pueden reutilizar en contenedores distintos sin recalcular longitudes concretas.
+
+Si no hay ningún contenedor apto para la consulta, la unidad recurre por defecto a la [unidad de área visible pequeña](#unidades_de_área_visible_pequeña) de ese eje (`sv*`).
+
+Para más información, consulta [Consultas de contenedor](/es/docs/Web/CSS/Guides/Containment/Container_queries).
+
+- `cqw`
+  - : Representa un porcentaje del ancho del contenedor consultado. `1cqw` es el 1 % de ese ancho. Por ejemplo, si el ancho del contenedor consultado es `800px`, un valor de `50cqw` en una propiedad será `400px`.
+
+- `cqh`
+  - : Representa un porcentaje de la altura del contenedor consultado. `1cqh` es el 1 % de esa altura. Por ejemplo, si la altura del contenedor consultado es `300px`, un valor de `10cqh` en una propiedad será `30px`.
+
+- `cqi`
+  - : Representa un porcentaje del tamaño en línea del contenedor consultado. `1cqi` es el 1 % de ese tamaño. Por ejemplo, si el tamaño en línea del contenedor consultado es `800px`, un valor de `50cqi` en una propiedad será `400px`.
+
+- `cqb`
+  - : Representa un porcentaje del tamaño de bloque del contenedor consultado. `1cqb` es el 1 % de ese tamaño. Por ejemplo, si el tamaño de bloque del contenedor consultado es `300px`, un valor de `10cqb` en una propiedad será `30px`.
+
+- `cqmin`
+  - : Representa un porcentaje del menor entre el tamaño en línea y el tamaño de bloque del contenedor consultado. `1cqmin` es el 1 % de ese menor valor. Por ejemplo, si el tamaño en línea del contenedor consultado es `800px` y el de bloque `300px`, un valor de `50cqmin` en una propiedad será `150px`.
+
+- `cqmax`
+  - : Representa un porcentaje del mayor entre el tamaño en línea y el tamaño de bloque del contenedor consultado. `1cqmax` es el 1 % de ese mayor valor. Por ejemplo, si el tamaño en línea del contenedor consultado es `800px` y el de bloque `300px`, un valor de `50cqmax` en una propiedad será `400px`.
+
+## Unidades de longitud absolutas
+
+Las **unidades de longitud absolutas** representan una medida física cuando se conocen las propiedades físicas del medio de salida, como en la maquetación para impresión. Esto se consigue anclando una de las unidades a una **unidad física** o a la **unidad de ángulo visual** y definiendo las demás con respecto a ella. Las unidades físicas incluyen `cm`, `in`, `mm`, `pc`, `pt`, `px` y `Q`. El anclaje se hace de forma distinta en los dispositivos de baja resolución, como las pantallas, que en los de alta resolución, como las impresoras.
+
+En los dispositivos de pocos ppp, la unidad `px` representa el _píxel de referencia_ físico, y las demás unidades se definen con respecto a ella. Así, `1in` se define como `96px`, que equivale a `72pt`. La consecuencia de esta definición es que, en esos dispositivos, las dimensiones descritas en pulgadas (`in`), centímetros (`cm`) o milímetros (`mm`) no coinciden necesariamente con el tamaño de la unidad física del mismo nombre.
+
+En los dispositivos de muchos ppp, las pulgadas (`in`), los centímetros (`cm`) y los milímetros (`mm`) sí coinciden con sus equivalentes físicos. Por tanto, la unidad `px` se define con respecto a ellos (1/96 de `1in`).
+
+> [!NOTE]
+> Mucha gente aumenta el tamaño de fuente predeterminado de su {{Glossary("user agent", "agente de usuario")}} para que el texto se lea mejor. Las longitudes absolutas pueden causar problemas de accesibilidad porque son fijas y no se escalan según esos ajustes. Por eso conviene preferir longitudes relativas (como `em` o `rem`) al fijar el `font-size`.
+
+- `px`
+  - : Un píxel. En las pantallas representa tradicionalmente un {{glossary("device pixel", "píxel de dispositivo")}} (un punto). Sin embargo, en las _impresoras_ y las _pantallas de alta resolución_, un píxel CSS implica varios píxeles de dispositivo. `1px` = `1in / 96`.
+- `cm`
+  - : Un centímetro. `1cm` = `96px / 2.54`.
+- `mm`
+  - : Un milímetro. `1mm` = `1cm / 10`.
+- `Q`
+  - : Un cuarto de milímetro. `1Q` = `1cm / 40`.
+- `in`
+  - : Una pulgada. `1in` = `2.54cm` = `96px`.
+- `pc`
+  - : Una pica. `1pc` = `12pt` = `1in / 6`.
+- `pt`
+  - : Un punto. `1pt` = `1in / 72`.
 
 ## Interpolación
 
-Los valores de tipo `<length>` pueden ser interpolados para permitir animaciones. En este caso son interpolados como números reales, de punto flotante. La interpolación sucede en el valor calculado. La velocidad de la interpolación es definida por la función {{cssxref("&lt;timing-function&gt;")}} asociada a la animación.
+Al animarse, los valores del tipo de dato `<length>` se interpolan como números reales en coma flotante. La {{glossary("interpolation", "interpolación")}} se produce sobre el valor calculado. La velocidad de la interpolación la determina la [función de suavizado](/es/docs/Web/CSS/Reference/Values/easing-function) asociada a la animación.
 
-## Unidades
+## Ejemplos
 
-### Unidades de longitud relativa
+### Comparar distintas unidades de longitud
 
-#### Longitudes relativas a la fuente
+El ejemplo siguiente te ofrece un campo de entrada en el que puedes escribir un valor `<length>` (por ejemplo `300px`, `50%`, `30vw`) para fijar el ancho de una barra de resultado que aparecerá debajo en cuanto pulses <kbd>Intro</kbd>.
 
-- `em`
-  - : Esta unidad representa el tamaño calculado de fuente ({{Cssxref("font-size")}}) del elemento. Si se usa dentro de la propiedad {{Cssxref("font-size")}}, representa el tamaño de fuente _heredado_ por el elemento.
+Esto te permite comparar y contrastar los efectos de las distintas unidades de longitud.
 
-    > [!NOTE]
-    > Esta unidad se usa por lo general para crear interfaces escalables, que mantengan el [ritmo vertical de la página](http://24ways.org/2006/compose-to-a-vertical-rhythm), aun cuando el usuario cambie el tamaño de las fuentes. Las propiedades CSS {{cssxref("line-height")}}, {{cssxref("font-size")}}, {{cssxref("margin-bottom")}} y {{cssxref("margin-top")}} generalemente tienen valores expresados en **em**.
+#### HTML
 
-- `ex`
-  - : Esta unidad representa la [altura de la x](https://es.wikipedia.org/wiki/Altura_de_la_x) de la fuente ({{Cssxref("font")}}) del elemento. En fuentes que incluyen la letra 'x', es generalmente la altura de letras minúsculas en la fuente; `1ex ≈ 0.5em` en muchas fuentes.
-- `ch`
-  - : Esta unidad representa la anchura, o más precisamente, la medida de avance, del glifo '0' (cero, de caracter Unicode U+0030) en la fuente ({{Cssxref("font")}}) del elemento.
-- `rem`
-  - : Esta unidad representa el tamaño ({{Cssxref("font-size")}}) del elemento raíz (p.ej. el tamaño de fuente del elemento {{HTMLElement("html")}}). Cuando se aplica a {{Cssxref("font-size")}} del elemento raíz, representa su valor inicial.
+```html
+<div class="outer">
+  <div class="input-container">
+    <label for="length">Escribe un ancho:</label>
+    <input type="text" id="length" />
+  </div>
+  <div class="inner"></div>
+</div>
+<div class="results"></div>
+```
 
-    > [!NOTE]
-    > Esta unidad es práctica para crear interfaces perfectamente escalables. Si no es soportada por los navegadores, se puede recurrir a unidades **em**, aunque estas son ligeramente más complejas.
+#### CSS
 
-#### Longitudes de porcentaje del viewport
+```css
+html {
+  font-family: sans-serif;
+  font-weight: bold;
+  box-sizing: border-box;
+}
 
-Las longitudes de porcentaje del viewport definen una longitud relativa al tamaño del viewport, que es la porción visible del documento. Solamente los navegadores basados en Gecko actualizan los valores del viewport dinámicamente, cuando el tamaño de éste es modificado (al cambiar el tamaño de la ventana en una computadora de escritorio, o al girar el dispositivo, en teléfonos y tablets).
+.outer {
+  width: 100%;
+  height: 50px;
+  background-color: #eeeeee;
+  position: relative;
+}
 
-En conjunto con `overflow:auto`, el espacio tomado por barras de desplazamiento no es restado al tamaño del viewport, mientras en el caso de `overflow:scroll`, sí lo es.
+.inner {
+  height: 50px;
+  background-color: #999999;
+  box-shadow:
+    inset 3px 3px 5px rgb(255 255 255 / 50%),
+    inset -3px -3px 5px rgb(0 0 0 / 50%);
+}
 
-En un bloque de declaración de la regla-at {{cssxref("@page")}}, el uso de longitudes de viewport es inválido, y la declaración será desechada.
+.result {
+  height: 20px;
+  box-shadow:
+    inset 3px 3px 5px rgb(255 255 255 / 50%),
+    inset -3px -3px 5px rgb(0 0 0 / 50%);
+  background-color: orange;
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+}
 
-- `vh`
-  - : 1/100 de la altura del viewport.
-- `vw`
-  - : 1/100 de la anchura del viewport.
-- `vmin`
-  - : 1/100 del valor mínimo entre la altura y anchura del viewport.
-- `vmax`
-  - : 1/100 del valor máximo entre la altura y anchura del viewport.
+.result code {
+  position: absolute;
+  margin-left: 20px;
+}
 
-### Unidades de longitud absoluta
+.results {
+  margin-top: 10px;
+}
 
-Las unidades de longitud absoluta representan una medida física, y cuando las propiedades físicas del medio de salida son conocidas, como en diseño para impresión. Esto se hace anclando una de las unidades a una unidad física, y definiendo el resto con relación a ésta. La definición del ancla difiere entre dispositivos de baja resolución, como pantallas, y dispositivos de alta resolución, como impresoras.
+.input-container {
+  position: absolute;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  height: 50px;
+}
 
-Para dispositivos de ppp bajo, la unidad **px** representa el _píxel de referencia_ físico, y el resto son definidos con relación a éste. Así, `1in` es definido como `96px`, que equivalen a `72pt`. La consecuencia de esta definición es que en dichos dispositivos, las longitudes descritas en pulgadas (`in`), centrímetros (`cm`), milímetros (`mm`) no necesariamente conincidirán con la longitud de la unidad física del mismo nombre.
+label {
+  margin: 0 10px 0 20px;
+}
+```
 
-Para dispositivos de alto ppp, las pulgadas (`in`), centrímetros (`cm`), milímetros (`mm`) son definidos como su contraparte física. De esta forma, la unidad **px** es definida con relación a ellas (1/96 de 1 pulgada).
+#### JavaScript
 
-> [!NOTE]
-> Los usuarios pueden incrementar el tamaño de fuente por razones de accesibilidad. Para permitir interfaces usables sin importar el tamao de fuente, use únicamente unidades de longitud absolutas cuando las características físicas del medio de salida son conocidas, como imágenes de mapa de bits. Al establecer longitudes relacionadas al tamaño de fuente, es preferible usar unidades relativas, como `em` o `rem`.
+```js
+const inputDiv = document.querySelector(".inner");
+const inputElem = document.querySelector("input");
+const resultsDiv = document.querySelector(".results");
 
-- `px`
-  - : Relativa al dispositivo de visualización.
-    Para pantallas, generalmente es el tamaño de un píxel (punto) de la pantalla del dispositivo.
-    Para _impresoras_ y _pantallas de muy alta resolución_, un píxel CSS implica múltiples píxeles del dispositivo, de modo que el número de píxeles por pulgada se mantenga al rededor de 96.
-- `mm`
-  - : Un milímetro.
-- `q`
-  - : Un cuarto de milímetro (1/40° de centímetro).
-- `cm`
-  - : Un centímetro (10 milímetros).
-- `in`
-  - : Una pulgada (2.54 centímetros).
-- `pt`
-  - : Un punto (1/72° de pulgada).
-- `pc`
-  - : Una pica (12 puntos).
-- `mozmm` {{non-standard_inline}}
-  - : Una unidad experimental que intenta generar exactamente un milímetro, sin importar el tamaño de resolución de la pantalla. Esto raramente será lo que se desea, pero podría ser útil para dispositivos móviles, en particular.
+inputElem.addEventListener("change", () => {
+  inputDiv.style.width = inputElem.value;
 
-## Unidades CSS y puntos por pulgada (dots-per-inch)
+  const result = document.createElement("div");
+  result.className = "result";
+  result.style.width = inputElem.value;
+  const code = document.createElement("code");
+  code.textContent = `width: ${inputElem.value}`;
+  result.appendChild(code);
+  resultsDiv.appendChild(result);
 
-> [!NOTE]
-> La unidad `in` no representa una pulgada física en pantalla, sino `96px`. Esto significa que sin importar la densidad de píxeles real en pantalla, se asume que serán `96ppp`. En dispositivos con mayor densidad de píxeles, `1in` será menor que una pulgada física. De forma similar, `mm`, `cm`, y `pt` no son longitudes absolutas.
+  inputElem.value = "";
+  inputElem.focus();
+});
+```
 
-Algunos ejemplos específicos:
+#### Resultado
 
-- `1in` siempre son `96px,`
-- `3pt` siempre son `4px`,
-- `25.4mm` siempre son `96px.`
+{{EmbedLiveSample('Comparar distintas unidades de longitud', '100%', 700)}}
 
 ## Especificaciones
 
@@ -103,3 +320,9 @@ Algunos ejemplos específicos:
 ## Compatibilidad con navegadores
 
 {{Compat}}
+
+## Véase también
+
+- [Aprende: valores y unidades](/es/docs/Learn_web_development/Core/Styling_basics/Values_and_units)
+- Módulo [Valores y unidades de CSS](/es/docs/Web/CSS/Guides/Values_and_units)
+- [Modelo de caja](/es/docs/Web/CSS/Guides/Box_model)


### PR DESCRIPTION
### Description

Sincroniza dos páginas de referencia CSS que estaban muy por detrás de su fuente, y restaura de paso dos anclas que #38448 tuvo que dejar sin fragmento.

### Motivation

| Página | es antes | en | `l10n.sourceCommit` |
| --- | ---: | ---: | --- |
| `font-size` | 61 | 258 | ausente |
| `<length>` | 105 | 329 | ausente |

A `<length>` le faltaban secciones enteras: las unidades relativas a la fuente del elemento raíz (`rcap`, `rch`, `rex`, `ric`, `rlh`), las de área visible en sus cuatro tamaños (pequeña, grande, dinámica y predeterminada) y todas las de consulta de contenedor (`cqw`, `cqh`, `cqi`, `cqb`, `cqmin`, `cqmax`).

Ninguna de las dos estaba registrada para sincronización.

### Verification

| | es | en |
| --- | ---: | ---: |
| `font-size` encabezados / vallas / bloques / enlaces | 18 / 30 / 15 / 9 | 18 / 30 / 15 / 9 |
| `<length>` encabezados / vallas / bloques / enlaces | 19 / 6 / 3 / 22 | 19 / 6 / 3 / 22 |

`prettier --check` y `markdownlint-cli2` pasan.

### Anclas restauradas

#38448 dejó estos dos enlaces sin fragmento porque las secciones no existían aún en español. Ahora sí existen:

- `Reference/Properties/font-size#definición_formal`
- `Reference/Values/length#unidades_de_longitud_absolutas`

### Una decisión deliberada

El bloque JavaScript del ejemplo de `<length>` queda **sin traducir**. `mdn_review.py` lo marca como posible bloque sin traducir porque contiene texto visible:

```js
code.textContent = `width: ${inputElem.value}`;
```

Pero ese `width:` es el nombre de la propiedad CSS que el ejemplo demuestra, no texto de interfaz. Traducirlo rompería la relación con la propiedad.

Parte del trabajo de #38407: estas dos páginas eran destino de anclas que quedaron sin resolver.