### PR TITLE
docs(es): sincroniza planet_data_table y table_accessibility

### DIFF
--- a/files/es/learn_web_development/core/structuring_content/planet_data_table/index.md
+++ b/files/es/learn_web_development/core/structuring_content/planet_data_table/index.md
@@ -1,65 +1,312 @@
 ---
-title: "Evaluación: Estructurando datos planetarios"
+title: "Desafío: estructurar una tabla de datos planetarios"
+short-title: "Desafío: tabla de datos planetarios"
 slug: Learn_web_development/Core/Structuring_content/Planet_data_table
-original_slug: Learn/HTML/Tables/Structuring_planet_data
+l10n:
+  sourceCommit: ee677b2c4d4a226fe4aedf05b2b156cae8a2bb95
 ---
 
-{{LearnSidebar}}{{PreviousMenu("Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content/HTML_forms", "Learn_web_development/Core/Structuring_content")}}
 
-En nuestra evaluación te proporcionamos datos sobre los planetas de nuestro sistema solar y tu los estructurarás en una tabla HTML.
+En este desafío te damos datos sobre los planetas de nuestro sistema solar. Tu tarea es estructurarlos en una tabla HTML accesible.
+
+## Punto de partida
+
+1. Crea una carpeta nueva llamada `planet-data-table` en un lugar adecuado de tu equipo (o abre un editor en línea y da los pasos necesarios para crear un proyecto nuevo).
+2. Guarda el listado HTML siguiente en un archivo llamado `index.html` dentro de tu carpeta (o pégalo en el panel HTML de tu editor en línea).
+
+   ```html
+   <!doctype html>
+   <html lang="es">
+     <head>
+       <meta charset="utf-8" />
+       <meta name="viewport" content="width=device-width" />
+       <title>Tabla de datos planetarios</title>
+       <link href="style.css" rel="stylesheet" type="text/css" />
+     </head>
+     <body>
+       <h1>Tabla de datos planetarios</h1>
+     </body>
+   </html>
+   ```
+
+3. Guarda el listado CSS siguiente en un archivo llamado `style.css` dentro de tu carpeta (o pégalo en el panel CSS de tu editor en línea).
+
+   ```css live-sample___planet-data-table
+   html {
+     font-family: sans-serif;
+   }
+
+   table {
+     border-collapse: collapse;
+     border: 2px solid rgb(200 200 200);
+     letter-spacing: 1px;
+     font-size: 0.8rem;
+   }
+
+   td,
+   th {
+     border: 1px solid rgb(190 190 190);
+     padding: 10px 20px;
+   }
+
+   th {
+     background-color: rgb(235 235 235);
+   }
+
+   td {
+     text-align: center;
+   }
+
+   tr:nth-child(even) td {
+     background-color: rgb(250 250 250);
+   }
+
+   tr:nth-child(odd) td {
+     background-color: rgb(245 245 245);
+   }
+
+   caption {
+     padding: 10px;
+   }
+
+   .column-border {
+     border: 2px solid black;
+   }
+   ```
+
+4. Ten a mano los datos siguientes; tendrás que convertirlos en una tabla de datos HTML dentro de tu HTML.
+
+   ```plain
+   Filas
+
+   Planetas terrestres
+
+   Mercurio 0,330 4.879 5.427 3,7 4.222,6 57,9 167 0 El más cercano al Sol
+   Venus 4,87 12.104 5.243 8,9 2.802,0 108,2 464 0
+   La Tierra 5,97 12.756 5.514 9,8 24,0 149,6 15 1 Nuestro mundo
+   Marte 0,642 6.792 3.933 3,7 24,7 227,9 -65 2 El planeta rojo
+
+   Planetas jovianos
+
+   Los gigantes de gas
+
+   Júpiter 1.898 142.984 1.326 23,1 9,9 778,6 -110 67 El planeta más grande
+   Saturno 568 120.536 687 9,0 10,7 1.433,5 -140 62
+
+   Los gigantes de hielo
+
+   Urano 86,8 51.118 1.271 8,7 17,2 2.872,5 -195 27
+   Neptuno 102 49.528 1.638 11,0 16,1 4.495,1 -200 14
+
+   Planetas enanos*
+
+   Plutón 0,0146 2.370 2.095 0,7 153,3 5.906,4 -225 5 Dejó de considerarse un planeta en 2006, aunque esto <a href="https://www.usatoday.com/story/tech/2014/10/02/pluto-planet-solar-system/16578959/">sigue siendo objeto de debate</a>.
+
+   Columnas
+
+   Nombre
+   Masa (10<sup>24</sup>kg)
+   Diámetro (km)
+   Densidad (kg/m<sup>3</sup>)
+   Gravedad (m/s<sup>2</sup>)
+   Duración del día (horas)
+   Distancia del Sol (10<sup>6</sup>km)
+   Temperatura media (°C)
+   Número de lunas
+   Observaciones
+
+   Subtítulo
+
+   Datos sobre los planetas de nuestro sistema solar (datos planetarios tomados de la <a href="https://nssdc.gsfc.nasa.gov/planetary/factsheet/">hoja técnica de datos planetarios de la NASA, en unidades métricas</a>).
+   ```
+
+## Resumen del proyecto
+
+Trabajas en una escuela; ahora mismo tu alumnado está estudiando los planetas de nuestro sistema solar y quieres darle un conjunto de datos fácil de consultar para buscar cifras y hechos sobre los planetas. Una tabla de datos HTML sería ideal: tienes que coger los datos en bruto de los que dispones y convertirlos en una tabla, siguiendo los pasos de abajo.
+
+Todos los datos que necesitas están en el listado de arriba. Si te cuesta visualizarlos, echa un vistazo al ejemplo en vivo de más abajo, o prueba a dibujar un esquema.
+
+1. Empieza la tabla dándole un contenedor exterior, una cabecera de tabla y un cuerpo de tabla. Para este ejemplo no necesitas pie de tabla.
+2. Añade a tu tabla el subtítulo que se proporciona.
+3. Añade a la cabecera de la tabla una fila que contenga todos los encabezados de columna.
+4. Crea todas las filas de contenido dentro del cuerpo de la tabla, recordando marcar semánticamente como encabezados todos los encabezados de fila.
+5. Asegúrate de que todo el contenido queda en la celda correcta: en los datos en bruto, cada fila de datos aparece junto al planeta al que corresponde.
+6. Añade los atributos necesarios para que los encabezados de fila y de columna queden asociados sin ambigüedad a las filas, columnas o grupos de filas de los que son encabezado.
+7. Añade un [borde](/es/docs/Web/CSS/Reference/Properties/border) negro alrededor únicamente de la columna que contiene los encabezados de fila con el nombre de cada planeta. Hazlo con una estructura `<colgroup>`/`<col>` adecuada y la clase `.column-border` que se proporciona en el CSS.
+
+## Pistas y consejos
+
+- La primera celda de la fila de cabecera tiene que estar vacía y abarcar dos columnas.
+- Los encabezados de grupo de filas (por ejemplo, _Planetas jovianos_) que van a la izquierda de los encabezados con el nombre del planeta (por ejemplo, _Saturno_) son algo más difíciles de resolver: tienes que asegurarte de que cada uno abarque el número correcto de filas y columnas.
+- Una de las dos formas de asociar los encabezados con sus filas o columnas es bastante más sencilla que la otra.
+
+## Ejemplo
+
+Una vez marcada correctamente, la tabla debería verse así. Si te atascas, consulta la solución que hay debajo del ejemplo en vivo.
+
+{{embedlivesample("planet-data-table", "100%", 650)}}
+
+<details>
+<summary>Haz clic aquí para ver la solución</summary>
+
+Tu HTML terminado debería verse así:
+
+```html live-sample___planet-data-table
+<h1>Tabla de datos planetarios</h1>
 
 <table>
+  <caption>
+    Datos sobre los planetas de nuestro sistema solar (datos planetarios tomados
+    de la
+    <a href="https://nssdc.gsfc.nasa.gov/planetary/factsheet/"
+      >hoja técnica de datos planetarios de la NASA, en unidades métricas</a
+    >).
+  </caption>
+  <colgroup>
+    <col span="2" />
+    <col class="column-border" />
+    <col span="9" />
+  </colgroup>
+  <thead>
+    <tr>
+      <td colspan="2"></td>
+      <th scope="col">Nombre</th>
+      <th scope="col">Masa (10<sup>24</sup>kg)</th>
+      <th scope="col">Diámetro (km)</th>
+      <th scope="col">Densidad (kg/m<sup>3</sup>)</th>
+      <th scope="col">Gravedad (m/s<sup>2</sup>)</th>
+      <th scope="col">Duración del día (horas)</th>
+      <th scope="col">Distancia del Sol (10<sup>6</sup>km)</th>
+      <th scope="col">Temperatura media (°C)</th>
+      <th scope="col">Número de lunas</th>
+      <th scope="col">Observaciones</th>
+    </tr>
+  </thead>
   <tbody>
     <tr>
-      <th scope="row">Requisitos previos:</th>
-      <td>
-        Antes de comenzar esta evaluación deberías de haber leído los artículos
-        de este módulo.
-      </td>
+      <th rowspan="4" colspan="2" scope="rowgroup">Planetas terrestres</th>
+      <th scope="row">Mercurio</th>
+      <td>0,330</td>
+      <td>4.879</td>
+      <td>5.427</td>
+      <td>3,7</td>
+      <td>4.222,6</td>
+      <td>57,9</td>
+      <td>167</td>
+      <td>0</td>
+      <td>El más cercano al Sol</td>
     </tr>
     <tr>
-      <th scope="row">Objetivo:</th>
+      <th scope="row">Venus</th>
+      <td>4,87</td>
+      <td>12.104</td>
+      <td>5.243</td>
+      <td>8,9</td>
+      <td>2.802,0</td>
+      <td>108,2</td>
+      <td>464</td>
+      <td>0</td>
+      <td></td>
+    </tr>
+    <tr>
+      <th scope="row">La Tierra</th>
+      <td>5,97</td>
+      <td>12.756</td>
+      <td>5.514</td>
+      <td>9,8</td>
+      <td>24,0</td>
+      <td>149,6</td>
+      <td>15</td>
+      <td>1</td>
+      <td>Nuestro mundo</td>
+    </tr>
+    <tr>
+      <th scope="row">Marte</th>
+      <td>0,642</td>
+      <td>6.792</td>
+      <td>3.933</td>
+      <td>3,7</td>
+      <td>24,7</td>
+      <td>227,9</td>
+      <td>-65</td>
+      <td>2</td>
+      <td>El planeta rojo</td>
+    </tr>
+    <tr>
+      <th rowspan="4" scope="rowgroup">Planetas jovianos</th>
+      <th rowspan="2" scope="rowgroup">Los gigantes de gas</th>
+      <th scope="row">Júpiter</th>
+      <td>1.898</td>
+      <td>142.984</td>
+      <td>1.326</td>
+      <td>23,1</td>
+      <td>9,9</td>
+      <td>778,6</td>
+      <td>-110</td>
+      <td>67</td>
+      <td>El planeta más grande</td>
+    </tr>
+    <tr>
+      <th scope="row">Saturno</th>
+      <td>568</td>
+      <td>120.536</td>
+      <td>687</td>
+      <td>9,0</td>
+      <td>10,7</td>
+      <td>1.433,5</td>
+      <td>-140</td>
+      <td>62</td>
+      <td></td>
+    </tr>
+    <tr>
+      <th rowspan="2" scope="rowgroup">Los gigantes de hielo</th>
+      <th scope="row">Urano</th>
+      <td>86,8</td>
+      <td>51.118</td>
+      <td>1.271</td>
+      <td>8,7</td>
+      <td>17,2</td>
+      <td>2.872,5</td>
+      <td>-195</td>
+      <td>27</td>
+      <td></td>
+    </tr>
+    <tr>
+      <th scope="row">Neptuno</th>
+      <td>102</td>
+      <td>49.528</td>
+      <td>1.638</td>
+      <td>11,0</td>
+      <td>16,1</td>
+      <td>4.495,1</td>
+      <td>-200</td>
+      <td>14</td>
+      <td></td>
+    </tr>
+    <tr>
+      <th colspan="2" scope="rowgroup">Planetas enanos</th>
+      <th scope="row">Plutón</th>
+      <td>0,0146</td>
+      <td>2.370</td>
+      <td>2.095</td>
+      <td>0,7</td>
+      <td>153,3</td>
+      <td>5.906,4</td>
+      <td>-225</td>
+      <td>5</td>
       <td>
-        Comprobar si has comprendido las tablas HTML y las características
-        asociadas.
+        Dejó de considerarse un planeta en 2006, aunque esto
+        <a
+          href="https://www.usatoday.com/story/tech/2014/10/02/pluto-planet-solar-system/16578959/"
+          >sigue siendo objeto de debate</a
+        >.
       </td>
     </tr>
   </tbody>
 </table>
+```
 
-## Punto de incio
+</details>
 
-Para comenzar esta evaluación, crea una copia local de [blank-template.html](https://github.com/mdn/learning-area/blob/master/html/tables/assessment-start/blank-template.html), [minimal-table.css](https://github.com/mdn/learning-area/blob/master/html/tables/assessment-start/minimal-table.css), y [planets-data.txt](https://github.com/mdn/learning-area/blob/master/html/tables/assessment-start/planets-data.txt) en una nueva carpeta de tu ordenador.
-
-> [!NOTE]
-> Como alternativa, puedes usar una web como [JSBin](https://jsbin.com/) o [Glitch](https://glitch.com/) para realizar tu evaluación. Puedes pegar el HTML, CSS y JavaScript en uno de estos editores online. Si el editor online que estas usando no tiene paneles separados para JavaScript/CSS, sientete libre de ponerlos en línea dentro del mismo HTML mediante el uso de `<script>`/`<style>`.
-
-## Resumen del proyecto
-
-Estás trabajando en la escuela; tus estudiantes están estudiando los planetas de nuestro sistema solar y quieres proporcionarles una forma sencilla de seguir los datos para buscar hechos sobre los planetas. Una tabla HTML sería ideal — tienes que coger los datos que tienes disponibles y convertirlos en una tabla siguiendo los pasos de abajo.
-
-Puedes ver cómo debería quedar la tabla finalizada en el ejemplo [aquí](https://mdn.github.io/learning-area/html/tables/assessment-finished/planets-data.html) (no mires el código fuente — ¡no hagas trampas!)
-
-## Pasos para completarlo
-
-Los siguientes pasos describen lo que necesitas para completar el ejemplo de la tabla. Todos los datos que necesitarás están en el archivo `planets-data.txt`. Si tienes problemas para visualizar los datos, mira el ejemplo de arriba o intentalo dibujando un diagrama.
-
-1. Abre tu copia de `blank-template.html`, y comienza la tabla dándole un contenedor exterior, una cabecera y un cuerpo. No necesitas un pie de tabla en este ejemplo.
-2. Añade el subtítulo proporcionado a tu tabla.
-3. Añade una línea a la cabecera que contenga todos los encabezados de columna.
-4. Crea todas las líneas con su contenido, asegurandote marcar como cabecera aquellas celdas que lo sean.
-5. Asegurate de que el contenido esta insertado en las celdas correctas — en los datos del .txt, cada línea del planeta esta al lado de su planeta asociado.
-6. Añade atributos para que las líneas y columnas del encabezado no se puedan confundir con las líneas, columnas o grupos de líneas a las que encabezan.
-7. Añade un borde negro alrededor de la columna que contiene los nombres de los planetas y sus encabezados.
-
-## Pistas y consejos
-
-- La primera celda de la línea de enbezado tiene que estar en blanco y unir dos columnas.
-- Los encabezados de la filas agrupadas (p. ej. _Jovian planets_) que están a la izquierda de los encabezados de nombres de planetas (p. ej. _Saturn_) son algo complicados de resolver — asegurate de que cada uno agrupa el número correcto de líneas y columnas
-- Una manera de asociar encabezados con sus líneas/columnas es mucha más fácil que la otra.
-
-## Evaluación
-
-Si estas siguiendo esta evaluación como parte de un curso organizado, deberías de ser capaz de entregar tu trabajo a tu profesor(a)/mentor para ver la puntuación. Si estas aprendiendo por tu cuenta, puedes obtener la guía de puntuación preguntando en [Learning Area Discourse thread](https://discourse.mozilla-community.org/t/learning-web-development-marking-guides-and-questions/16294) o en el canal IRC [#mdn](irc://irc.mozilla.org/mdn) en [Mozilla IRC](https://wiki.mozilla.org/IRC). Intenta hacer el ejercicio primero — ¡haciendo trampas no aprenderás nada!
-
-{{PreviousMenu("Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Table_accessibility", "Learn_web_development/Core/Structuring_content/HTML_forms", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/table_accessibility/index.md
+++ b/files/es/learn_web_development/core/structuring_content/table_accessibility/index.md
@@ -1,321 +1,61 @@
 ---
-title: Funciones avanzadas de las tablas HTML y accesibilidad
+title: Accesibilidad de las tablas HTML
+short-title: Accesibilidad de tablas
 slug: Learn_web_development/Core/Structuring_content/Table_accessibility
-original_slug: Learn/HTML/Tables/Advanced
+l10n:
+  sourceCommit: 754b68246f4e69e404309fee4a1699e047e43994
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_table_basics", "Learn_web_development/Core/Structuring_content/Planet_data_table", "Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_table_basics", "Learn_web_development/Core/Structuring_content/Planet_data_table", "Learn_web_development/Core/Structuring_content")}}
 
-En el segundo artículo de este módulo, analizamos algunas características más avanzadas de las tablas HTML, como los subtítulos/resúmenes, la agrupación de filas en las secciones del encabezado, el cuerpo y el pie de página; y también analizamos la accesibilidad de las tablas para usuarios con discapacidad visual.
+En el artículo anterior vimos una de las funcionalidades más importantes para hacer accesibles las tablas HTML a las personas con discapacidad visual: el elemento {{htmlelement("th")}}. En este artículo seguimos por ese camino y vemos más funcionalidades de accesibilidad de las tablas HTML, como los subtítulos y resúmenes, agrupar las filas en secciones de cabecera, cuerpo y pie, y delimitar el ámbito de columnas y filas.
 
 <table>
   <tbody>
     <tr>
       <th scope="row">Prerrequisitos:</th>
       <td>
-        Conceptos básicos de HTML (ver
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
-          >Introducción al HTML</a
+        Los fundamentos de HTML (consulta
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content/Basic_HTML_syntax"
+          >Primeros pasos con HTML</a
         >).
       </td>
     </tr>
     <tr>
-      <th scope="row">Objetivo:</th>
+      <th scope="row">Resultados del aprendizaje:</th>
       <td>
-        Aprender las características más avanzadas de las tablas HTML y la
-        accesibilidad de las tablas.
+        <ul>
+          <li>Entender los problemas de accesibilidad asociados a las tablas.</li>
+          <li>Añadir subtítulos a las tablas.</li>
+          <li>Estructurar mejor las tablas con cabecera, cuerpo y pie.</li>
+          <li>Crear asociaciones adicionales entre encabezados y celdas con los atributos <code>scope</code>, <code>id</code> y <code>headers</code>.</li>
+        </ul>
       </td>
     </tr>
   </tbody>
 </table>
 
-## Añadir un subtítulo a tu tabla con \<caption>
+## Repaso: las tablas para personas con discapacidad visual
 
-Puedes dar un título a tu tabla colocándolo dentro de un elemento {{htmlelement ("caption")}} y anidándolo dentro del elemento {{htmlelement ("table")}}. Debes ponerlo justo debajo de la etiqueta de apertura `<table>`.
-
-```html
-<table>
-  <caption>
-    Dinosaurios en el período Jurásico
-  </caption>
-
-  ...
-</table>
-```
-
-Como puedes deducir a partir del breve ejemplo anterior, el título debe contener una descripción del contenido de la tabla. Esto es útil para todos los lectores que deseen descubrir de un vistazo si la tabla les resulta útil mientras ojean la página, pero es útil especialmente para usuarios ciegos. En lugar de que un lector de pantalla lea el contenido de muchas celdas solo para averiguar de qué trata la tabla, el lector puede contar con el título para luego decidir si leer la tabla con mayor detalle.
-
-Los subtítulos se colocan directamente debajo de la etiqueta `<table>`.
-
-> [!NOTE]
-> El atributo [`summary`](/es/docs/Web/HTML/Reference/Elements/table#summary) también se puede usar en el elemento `table` para proporcionar una descripción; los lectores de pantalla también lo leen. Sin embargo, recomendamos usar el elemento `caption`, porque [`summary`](/es/docs/Web/HTML/Reference/Elements/table#summary) está obsoleto y porque los usuarios sin discapacidad visual no pueden leerlo (no aparece en la página).
-
-### Aprendizaje activo: Añadir un subtítulo
-
-Vamos a probarlo con un ejemplo del artículo anterior.
-
-1. Abre el ejemplo del horario de clases de la profesora de idiomas del final de [conocimientos básicos de las tablas HTML](/es/docs/Learn/HTML/Tablas/Conceptos_b%C3%A1sicos_de_las_tablas_HTML#Aprendizaje_activo_colgroup_y_col), o haz una copia local de nuestro archivo [timetable-fixed.html](https://github.com/mdn/learning-area/blob/master/html/tables/basic/timetable-fixed.html).
-2. Añade un título adecuado a la tabla.
-3. Guarda tu código, ábrelo en un navegador y observa qué aspecto presenta.
-
-> [!NOTE]
-> Puedes encontrar nuestra versión en GitHub: consulta [timetable-caption.html](https://github.com/mdn/learning-area/blob/master/html/tables/advanced/timetable-caption.html) ([mirar en vivo](https://mdn.github.io/learning-area/html/tables/advanced/timetable-caption.html)).
-
-## Añadir estructura con \<thead>, \<tfoot> y \<tbody>
-
-A medida que la estructura de las tablas se vuelve más compleja, es útil darles una estructura más definida. Una forma clara de hacerlo es con {{htmlelement ("thead")}}, {{htmlelement ("tfoot")}} y {{htmlelement ("tbody")}}, que te permiten marcar un encabezado, un pie de página y una sección del cuerpo de la tabla.
-
-Estos elementos no mejoran las características de accesibilidad de la tabla para los usuarios de lectores de pantalla ni su aspecto visual en sí. Sin embargo, son muy útiles para la aplicación de estilo y la compaginación, porque actúan como soportes útiles para añadir CSS a tu tabla. Como ejemplos interesantes, en el caso de una tabla extensa, puedes hacer que el encabezado y el pie de página se repitan en cada página impresa, y también que el cuerpo de la tabla se muestre en una sola página y desplazarte por los contenidos arriba y abajo con la barra de desplazamiento.
-
-Para utilizarlos:
-
-- El elemento `<thead>` debe delimitar el encabezado de la tabla; esta suele ser la primera fila, que contiene los encabezados de las columnas, pero no siempre es así. Si utilizas los elementos {{htmlelement ("col")}}/{{htmlelement ("colgroup")}}, el encabezado de la tabla debe estar justo debajo.
-- El elemento `<tfoot>` delimita la parte de la tabla correspondiente al pie de página; esta podría ser una fila final con elementos en las filas anteriores. Puedes incluir el pie de página de la tabla justo en la parte inferior de la tabla, donde esperarías que esté, o justo debajo del encabezado (y el navegador lo mostrará aun así en la parte inferior de la tabla).
-- El elemento `<tbody>` delimita las otras partes del contenido de la tabla que no están en el encabezado o en el pie de página de la tabla. Aparecerá debajo del encabezado de la tabla o, a veces, en el pie de página, según cómo hayas decidido estructurarlo.
-
-> [!NOTE]
-> `<tbody>` se incluye siempre en todas las tablas de forma implícita si no lo especificas en tu código. Para comprobarlo, abre uno de tus ejemplos anteriores que no incluya `<tbody>` y mira el código HTML en las [herramientas de desarrollo de tu navegador](/es/docs/Learn_web_development/Howto/Tools_and_setup/What_are_browser_developer_tools); verás que el navegador ha añadido esta etiqueta. Quizás te preguntes por qué deberías molestarte en incluirlo. Debes hacerlo para tener más control sobre la estructura y el estilo de la tabla.
-
-### Aprendizaje activo: Añadir estructura a la tabla
-
-Pongamos en acción estos elementos nuevos.
-
-1. En primer lugar, haz una copia local de [spending-record.html](https://github.com/mdn/learning-area/blob/master/html/tables/advanced/spending-record.html) y [minimal-table.css](https://github.com/mdn/learning-area/blob/master/html/tables/advanced/minimal-table.css) en una carpeta nueva de tu ordenador.
-2. Intenta abrirlo en un navegador: observarás que se ve bien, pero podría mejorarse. La fila «SUM», que contiene una suma de las cantidades gastadas, parece estar en el lugar equivocado, y faltan algunos detalles del código.
-3. Coloca la fila de encabezados dentro de un elemento `<thead>`, la fila «SUM» dentro de un elemento `<tfoot>`, y el resto del contenido dentro de un elemento `<tbody>`.
-4. Guarda y actualiza, y observa que añadir el elemento `<tfoot>` ha provocado que la fila «SUM» pase al final de la tabla.
-5. Luego, añade un atributo [`colspan`](/es/docs/Web/HTML/Reference/Elements/td#colspan) para que la celda «SUM» abarque las primeras cuatro columnas, de modo que el número aparezca en la parte inferior de la columna «Costes».
-6. Vamos a añadir un estilo adicional sencillo a la tabla para que veas cuán útiles son estos elementos para aplicar CSS. Dentro del encabezado del documento HTML hay un elemento {{htmlelement ("style")}} vacío. Añade a este elemento las líneas de código CSS siguientes:
-
-   ```css
-   tbody {
-     font-size: 95%;
-     font-style: italic;
-   }
-
-   tfoot {
-     font-weight: bold;
-   }
-   ```
-
-7. Guarda, actualiza, y échale un vistazo al resultado. Si los elementos `<tbody>` y `<tfoot>` no estuvieran en su lugar, tendrías que escribir selectores/reglas mucho más complicados para obtener la misma aplicación de estilo.
-
-> [!NOTE]
-> No esperamos que comprendas completamente el CSS en este momento. Aprenderás más sobre el tema cuando llegues a nuestros módulos CSS ([Introducción al CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics) es un buen lugar para comenzar; también tenemos un artículo específico sobre [Aplicar estilo a las tablas](/es/docs/Learn_web_development/Core/Styling_basics/Tables)).
-
-Tu tabla final debería tener un aspecto similar al siguiente:
-
-```html hidden
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Mi historial de gastos</title>
-    <style>
-      html {
-        font-family: sans-serif;
-      }
-
-      table {
-        border-collapse: collapse;
-        border: 4px solid rgb(200, 200, 200);
-        letter-spacing: 1px;
-        font-size: 0.8rem;
-      }
-
-      td,
-      th {
-        border: 2px solid rgb(190, 190, 190);
-        padding: 10px 20px;
-      }
-
-      th {
-        background-color: rgb(235, 235, 235);
-      }
-
-      td {
-        text-align: center;
-      }
-
-      tr:nth-child(even) td {
-        background-color: rgb(250, 250, 250);
-      }
-
-      tr:nth-child(odd) td {
-        background-color: rgb(245, 245, 245);
-      }
-
-      caption {
-        padding: 10px;
-      }
-
-      tbody {
-        font-size: 90%;
-        font-style: italic;
-      }
-
-      tfoot {
-        font-weight: bold;
-      }
-    </style>
-  </head>
-  <body>
-    <table>
-      <caption>
-        Cómo elegí gastar mi dinero
-      </caption>
-      <thead>
-        <tr>
-          <th>Compra</th>
-
-          <th>Ubicación</th>
-          <th>Fecha</th>
-          <th>Revisión</th>
-
-          <th>Coste (€)</th>
-        </tr>
-      </thead>
-      <tfoot>
-        <tr>
-          <td colspan="4">SUM</td>
-          <td>118</td>
-        </tr>
-      </tfoot>
-      <tbody>
-        <tr>
-          <td>Corte de pelo</td>
-
-          <td>Peluquería</td>
-          <td>12/09</td>
-
-          <td>Gran idea</td>
-          <td>30</td>
-        </tr>
-        <tr>
-          <td>Lasaña</td>
-
-          <td>Restaurante</td>
-          <td>12/09</td>
-          <td>Arrepentimiento</td>
-          <td>18</td>
-        </tr>
-        <tr>
-          <td>Zapatos</td>
-          <td>Zapatería</td>
-          <td>13/09</td>
-
-          <td>Mucho arrepentimiento</td>
-          <td>65</td>
-        </tr>
-        <tr>
-          <td>Pasta de dientes</td>
-          <td>Supermercado</td>
-          <td>13/09</td>
-
-          <td>Bien</td>
-          <td>5</td>
-        </tr>
-      </tbody>
-    </table>
-  </body>
-</html>
-```
-
-{{ EmbedLiveSample('Hidden_example', '100%', 300, "", "", "hide-codepen-jsfiddle") }}
-
-> [!NOTE]
-> También puedes encontrarlo en GitHub como [spending-record-finished.html](https://github.com/mdn/learning-area/blob/master/html/tables/advanced/spending-record-finished.html) (o consultarlo también [en vivo](https://mdn.github.io/learning-area/html/tables/advanced/spending-record-finished.html)).
-
-## Anidar tablas
-
-Es posible anidar una tabla dentro de otra, siempre que incluyas la estructura completa, incluido el elemento `<table>`. Por lo general, esto no se recomienda, porque se obtiene un marcado más confuso y menos accesible para los usuarios que usan lectores de pantalla, y además, en muchos casos sería posible sencillamente insertar celdas/filas/columnas adicionales en la tabla. Sin embargo, a veces es necesario, por ejemplo, si deseas importar contenido de forma sencilla desde otras fuentes.
-
-El marcado siguiente muestra una tabla anidada simple:
-
-```html
-<table id="tabla1">
-  <tr>
-    <th>título1</th>
-    <th>título2</th>
-    <th>título3</th>
-  </tr>
-  <tr>
-    <td id="nested">
-      <table id="tabla2">
-        <tr>
-          <td>celda1</td>
-          <td>celda2</td>
-          <td>celda3</td>
-        </tr>
-      </table>
-    </td>
-    <td>celda2</td>
-    <td>celda3</td>
-  </tr>
-  <tr>
-    <td>celda4</td>
-    <td>celda5</td>
-    <td>celda6</td>
-  </tr>
-</table>
-```
-
-La salida se verá así:
-
-<table id="table1">
-  <tbody>
-    <tr>
-      <th>título1</th>
-      <th>título2</th>
-      <th>título3</th>
-    </tr>
-    <tr>
-      <td id="nested">
-        <table id="table2">
-          <tbody>
-            <tr>
-              <td>celda1</td>
-              <td>celda2</td>
-              <td>celda3</td>
-            </tr>
-          </tbody>
-        </table>
-      </td>
-      <td>celda2</td>
-      <td>celda3</td>
-    </tr>
-    <tr>
-      <td>celda4</td>
-      <td>celda5</td>
-      <td>celda6</td>
-    </tr>
-  </tbody>
-</table>
-
-## Tablas para usuarios con discapacidad visual
-
-Repasemos brevemente cómo usamos las tablas de datos. Una tabla puede ser una herramienta útil porque nos proporciona un acceso rápido a unos datos y nos permite buscar entre valores diferentes. Por ejemplo, echa un vistazo a la tabla siguiente para saber cuántos anillos se vendieron en Gante en agosto pasado. Para comprender la información que contiene la tabla, establecemos asociaciones visuales entre los datos de la tabla y sus encabezados de columna y/o fila.
+Repasemos brevemente cómo usamos las tablas de datos. Una tabla puede ser una herramienta muy práctica para acceder rápido a los datos y consultar valores distintos. Por ejemplo, basta un vistazo a la tabla siguiente para averiguar cuántos anillos se vendieron en Gante durante agosto de 2016. Para entender su información hacemos asociaciones visuales entre los datos de la tabla y los encabezados de su columna o de su fila.
 
 <table>
-  <caption>
-    Artículos vendidos en agosto de 2016
-  </caption>
-  <tbody>
+  <caption>Artículos vendidos en agosto de 2016</caption>
+  <thead>
     <tr>
-      <td></td>
-      <td></td>
+      <td colspan="2" rowspan="2"></td>
       <th colspan="3" scope="colgroup">Ropa</th>
       <th colspan="2" scope="colgroup">Accesorios</th>
     </tr>
     <tr>
-      <td></td>
-      <td></td>
       <th scope="col">Pantalones</th>
       <th scope="col">Faldas</th>
       <th scope="col">Vestidos</th>
       <th scope="col">Pulseras</th>
       <th scope="col">Anillos</th>
     </tr>
+  </thead>
+  <tbody>
     <tr>
       <th rowspan="3" scope="rowgroup">Bélgica</th>
       <th scope="row">Amberes</th>
@@ -342,7 +82,7 @@ Repasemos brevemente cómo usamos las tablas de datos. Una tabla puede ser una h
       <td>28</td>
     </tr>
     <tr>
-      <th rowspan="2" scope="rowgroup">Los países bajos</th>
+      <th rowspan="2" scope="rowgroup">Países Bajos</th>
       <th scope="row">Ámsterdam</th>
       <td>89</td>
       <td>34</td>
@@ -361,101 +101,544 @@ Repasemos brevemente cómo usamos las tablas de datos. Una tabla puede ser una h
   </tbody>
 </table>
 
-Pero, ¿y si no puedes hacer esas asociaciones visuales? ¿Cómo podrías leer una tabla como la anterior? Las personas con discapacidad visual a menudo usan un lector de pantalla que les lee la información de las páginas web. Esto no resulta un problema cuando lees un texto sin formato, pero interpretar una tabla puede ser un gran desafío para una persona ciega. Sin embargo, con el marcado adecuado podemos reemplazar las asociaciones visuales por otras asociaciones de tipo programático.
+Pero ¿y si no puedes hacer esas asociaciones visuales? ¿Cómo se lee entonces una tabla como la anterior? Las personas con discapacidad visual suelen usar un [lector de pantalla](/es/docs/Glossary/Screen_reader) que les lee en voz alta la información de las páginas web. Eso no supone ningún problema con el texto corriente, pero interpretar una tabla puede ser todo un reto para una persona ciega. Aun así, con el marcado adecuado podemos sustituir las asociaciones visuales por asociaciones programáticas.
 
 > [!NOTE]
-> Hay en torno a 253 millones de personas con discapacidad visual según los [datos de la OMS de 2017](https://www.who.int/es/news-room/fact-sheets/detail/blindness-and-visual-impairment).
+> Según los [datos de la OMS de 2017](https://www.who.int/en/news-room/fact-sheets/detail/blindness-and-visual-impairment), unos 253 millones de personas viven con alguna discapacidad visual.
 
-Esta sección del artículo proporciona técnicas adicionales para conferir a las tablas la mayor accesibilidad posible.
+### Usar encabezados de columna y de fila
 
-### Usar encabezados de columna y fila
+Los lectores de pantalla identifican todos los encabezados y los usan para crear asociaciones programáticas entre ellos y las celdas con las que se relacionan. La combinación de encabezados de columna y de fila identifica e interpreta los datos de cada celda, de modo que quien usa un lector de pantalla pueda interpretar la tabla de forma parecida a como lo hace quien la ve.
 
-Los lectores de pantalla identificarán todos los encabezados y los usarán para hacer asociaciones programáticas entre esos encabezados y las celdas con las que se relacionan. La combinación de encabezados por columna y fila identificará e interpretará los datos de cada celda para que los usuarios que usan lectores de pantalla puedan interpretar la tabla de manera similar a como lo hace un usuario sin discapacidad visual.
+Ya tratamos los encabezados en el artículo anterior; consulta [Añadir encabezados con elementos \<th>](/es/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics#añadir_encabezados_con_elementos_th).
 
-Ya expusimos los encabezados en nuestro artículo anterior; consulta [Añadir encabezados con elementos \<th>](/es/docs/Learn/HTML/Tablas/Conceptos_b%C3%A1sicos_de_las_tablas_HTML#A%C3%B1adir_encabezados_con_elementos_%3Cth%3E).
+## Añadir un subtítulo a tu tabla con \<caption>
 
-### El atributo scope
+Puedes darle un subtítulo a tu tabla metiéndolo en un elemento {{htmlelement("caption")}} y anidándolo dentro del elemento {{htmlelement("table")}}. Debes ponerlo justo debajo de la etiqueta de apertura `<table>`.
 
-Un nuevo tema para este artículo es el atributo [`scope`](/es/docs/Web/HTML/Reference/Elements/th#scope), que se puede añadir al elemento `<th>` para indicar a los lectores de pantalla exactamente para qué celdas es el encabezado. Volviendo a nuestro ejemplo anterior de registro de gastos, podrías definir los encabezados de columna inequívocamente como encabezados de columna de este modo:
+```html
+<table>
+  <caption>
+    Dinosaurios del período jurásico
+  </caption>
+  <!-- … -->
+</table>
+```
+
+Como puedes deducir del breve ejemplo anterior, el subtítulo está pensado para contener una descripción del contenido de la tabla. Resulta útil para cualquiera que quiera hacerse una idea rápida de si la tabla le sirve mientras hojea la página, pero sobre todo para las personas ciegas. En vez de tener que escuchar el contenido de muchas celdas sólo para averiguar de qué trata la tabla, se puede apoyar en el subtítulo y decidir entonces si la lee con más detalle.
+
+El subtítulo se coloca justo debajo de la etiqueta `<table>`.
+
+> [!NOTE]
+> El atributo [`summary`](/es/docs/Web/HTML/Reference/Elements/table#summary) también se puede usar en el elemento `<table>` para proporcionar una descripción, y los lectores de pantalla también lo leen. Aun así, recomendamos usar el elemento `<caption>`, porque `summary` está obsoleto y quien ve la página no puede leerlo (no aparece en ella).
+
+### Practicar con el subtítulo de una tabla
+
+Llegados aquí vamos a pedirte que pruebes a añadir un subtítulo a una tabla HTML, usando el horario escolar que viste en el artículo anterior.
+
+1. Copia el primer bloque HTML de [Agrupar columnas con `<colgroup>` y `<col>`](/es/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics#agrupar_columnas_con_colgroup_y_col) en un archivo HTML de tu equipo, o en un editor en línea como [CodePen](https://codepen.io/) o [JSBin](https://jsbin.com/).
+2. Añade un subtítulo adecuado a la tabla.
+3. Guarda tu código y mira cómo queda.
+
+<details>
+<summary>Haz clic aquí para ver la solución</summary>
+
+Tu HTML terminado debería verse más o menos así:
+
+```html
+<table>
+  <caption>
+    Horario semanal de clases de idiomas de St. Winnifred
+  </caption>
+  <colgroup>
+    <col span="2" />
+    <col class="column-background" />
+    <col class="column-fixed-width" />
+    <col class="column-background" />
+    <col class="column-background-border" />
+    <col span="2" class="column-fixed-width" />
+  </colgroup>
+
+  <!-- Resto del código omitido por brevedad -->
+</table>
+```
+
+</details>
+
+## Añadir estructura con \<thead>, \<tbody> y \<tfoot>
+
+A medida que tus tablas se vuelven algo más complejas, conviene darles más definición estructural. Una forma clara de hacerlo es con {{htmlelement("thead")}}, {{htmlelement("tbody")}} y {{htmlelement("tfoot")}}, que te permiten marcar una sección de cabecera, otra de cuerpo y otra de pie.
+
+Estos elementos no hacen necesariamente que la tabla sea más accesible para quien usa un lector de pantalla, ni suponen por sí solos ninguna mejora visual, pero son muy útiles para aplicar mejoras de estilo y de maquetación con CSS, lo que sí puede mejorar la accesibilidad. Por poner algún ejemplo interesante: en una tabla larga podrías hacer que la cabecera y el pie se repitieran en cada página impresa, o que el cuerpo se mostrara en una sola página y su contenido estuviera disponible desplazándose arriba y abajo.
+
+Para usarlos, deben incluirse en este orden:
+
+- El elemento `<thead>` debe envolver la parte de la tabla que es la cabecera, que suele ser la primera fila con los encabezados de columna, aunque no siempre tiene por qué serlo. Si usas elementos {{htmlelement("col")}} o {{htmlelement("colgroup")}}, la cabecera de la tabla debe ir justo debajo de ellos.
+- El elemento `<tbody>` tiene que envolver la parte principal del contenido de la tabla, la que no es cabecera ni pie, y debe ir después del `<thead>`.
+- El elemento `<tfoot>` tiene que envolver la parte de la tabla que es el pie, que podría ser, por ejemplo, una fila final con la suma de los elementos de las filas anteriores. El `<tfoot>` debe ir después del `<tbody>`.
+
+> [!NOTE]
+> El `<tbody>` se incluye siempre de forma implícita en toda tabla aunque no lo especifiques en tu código. Para comprobarlo, abre uno de tus ejemplos anteriores que no lo incluya y mira el código HTML en las [herramientas de desarrollo del navegador](/es/docs/Learn_web_development/Howto/Tools_and_setup/What_are_browser_developer_tools): verás que el navegador ha añadido esa etiqueta por ti. Quizá te preguntes por qué molestarse en incluirla: conviene hacerlo porque te da más control sobre la estructura y el estilo de tu tabla.
+
+### Añadir estructura a una tabla de registro de gastos
+
+Vamos a poner en práctica estos elementos nuevos.
+
+1. Antes que nada, crea un archivo HTML nuevo llamado `spending-record.html` y pon el HTML siguiente dentro del `<body>`:
+
+   ```html
+   <h1>Mi registro de gastos</h1>
+
+   <table>
+     <caption>
+       En qué decidí gastar mi dinero
+     </caption>
+     <tr>
+       <th>Compra</th>
+       <th>Lugar</th>
+       <th>Fecha</th>
+       <th>Valoración</th>
+       <th>Coste (€)</th>
+     </tr>
+     <tr>
+       <td>Corte de pelo</td>
+       <td>Peluquería</td>
+       <td>12/09</td>
+       <td>Buena idea</td>
+       <td>30</td>
+     </tr>
+     <tr>
+       <td>Lasaña</td>
+       <td>Restaurante</td>
+       <td>12/09</td>
+       <td>Me arrepiento</td>
+       <td>18</td>
+     </tr>
+     <tr>
+       <td>Zapatos</td>
+       <td>Zapatería</td>
+       <td>13/09</td>
+       <td>Me arrepiento mucho</td>
+       <td>65</td>
+     </tr>
+     <tr>
+       <td>Pasta de dientes</td>
+       <td>Supermercado</td>
+       <td>13/09</td>
+       <td>Bien</td>
+       <td>5</td>
+     </tr>
+     <tr>
+       <td>SUMA</td>
+       <td>118</td>
+     </tr>
+   </table>
+   ```
+
+2. A continuación, crea un archivo CSS llamado `minimal-table.css` en el mismo directorio que tu archivo HTML y rellénalo con este contenido:
+
+   ```css live-sample___finished-table-structure
+   html {
+     font-family: sans-serif;
+   }
+
+   table {
+     border-collapse: collapse;
+     border: 2px solid rgb(200 200 200);
+     letter-spacing: 1px;
+     font-size: 0.8rem;
+   }
+
+   td,
+   th {
+     border: 1px solid rgb(190 190 190);
+     padding: 10px 20px;
+   }
+
+   th {
+     background-color: rgb(235 235 235);
+   }
+
+   td {
+     text-align: center;
+   }
+
+   tr:nth-child(even) td {
+     background-color: rgb(250 250 250);
+   }
+
+   tr:nth-child(odd) td {
+     background-color: rgb(245 245 245);
+   }
+
+   caption {
+     padding: 10px;
+   }
+   ```
+
+3. Añade un elemento `<link>` al `<head>` de tu HTML para aplicarle el CSS (consulta [Aplicar CSS y JavaScript al HTML](/es/docs/Learn_web_development/Core/Structuring_content/Webpage_metadata#aplicando_css_y_javascript_al_html) si necesitas ayuda).
+
+4. Prueba a meter la fila evidente de encabezados dentro de un elemento `<thead>`, la fila «SUMA» dentro de un `<tfoot>` y el resto del contenido dentro de un `<tbody>`.
+5. Después, añade un atributo [`colspan`](/es/docs/Web/HTML/Reference/Elements/td#colspan) para que la celda «SUMA» abarque las cuatro primeras columnas, de modo que el número aparezca al pie de la columna «Coste».
+6. Vamos a añadir algo de estilo sencillo a la tabla, para que te hagas una idea de lo útiles que resultan estos elementos al aplicar CSS. Añade lo siguiente a tu archivo CSS:
+
+   ```css live-sample___finished-table-structure
+   tbody {
+     font-size: 95%;
+     font-style: italic;
+   }
+
+   tfoot {
+     font-weight: bold;
+   }
+   ```
+
+   > [!NOTE]
+   > No esperamos que entiendas del todo el CSS ahora mismo. Aprenderás más cuando recorras nuestros módulos de CSS (empezando por [Fundamentos de estilo con CSS](/es/docs/Learn_web_development/Core/Styling_basics), que incluye un artículo dedicado a [dar estilo a tablas](/es/docs/Learn_web_development/Core/Styling_basics/Tables)).
+
+7. Guarda, recarga y mira el resultado. Si los elementos `<tbody>` y `<tfoot>` no estuvieran, tendrías que escribir selectores y reglas mucho más complicados para aplicar el mismo estilo.
+
+El ejemplo terminado debería verse así:
+
+{{embedlivesample("finished-table-structure", "100%", "300")}}
+
+<details>
+<summary>Haz clic aquí para ver la solución</summary>
+
+Tu HTML terminado debería verse más o menos así:
+
+```html live-sample___finished-table-structure
+<table>
+  <caption>
+    En qué decidí gastar mi dinero
+  </caption>
+  <thead>
+    <tr>
+      <th>Compra</th>
+      <th>Lugar</th>
+      <th>Fecha</th>
+      <th>Valoración</th>
+      <th>Coste (€)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Corte de pelo</td>
+      <td>Peluquería</td>
+      <td>12/09</td>
+      <td>Buena idea</td>
+      <td>30</td>
+    </tr>
+    <tr>
+      <td>Lasaña</td>
+      <td>Restaurante</td>
+      <td>12/09</td>
+      <td>Me arrepiento</td>
+      <td>18</td>
+    </tr>
+    <tr>
+      <td>Zapatos</td>
+      <td>Zapatería</td>
+      <td>13/09</td>
+      <td>Me arrepiento mucho</td>
+      <td>65</td>
+    </tr>
+    <tr>
+      <td>Pasta de dientes</td>
+      <td>Supermercado</td>
+      <td>13/09</td>
+      <td>Bien</td>
+      <td>5</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="4">SUMA</td>
+      <td>118</td>
+    </tr>
+  </tfoot>
+</table>
+```
+
+</details>
+
+## El atributo `scope`
+
+El atributo [`scope`](/es/docs/Web/HTML/Reference/Elements/th#scope) se puede añadir al elemento `<th>` para indicar a los lectores de pantalla exactamente de qué celdas es encabezado: ¿lo es de la fila en la que está, o de la columna? Volviendo a nuestro ejemplo del registro de gastos, podrías definir sin ambigüedad los encabezados de columna como tales de esta forma:
 
 ```html
 <thead>
   <tr>
     <th scope="col">Compra</th>
-    <th scope="col">Ubicación</th>
+    <th scope="col">Lugar</th>
     <th scope="col">Fecha</th>
-    <th scope="col">Revisión</th>
+    <th scope="col">Valoración</th>
     <th scope="col">Coste (€)</th>
   </tr>
 </thead>
 ```
 
-Y también cada fila podría tener un encabezado definido de esta manera (si añadimos encabezados de fila y encabezados de columna):
+Y cada fila podría tener un encabezado definido así (si añadiéramos encabezados de fila además de los de columna):
 
 ```html
 <tr>
   <th scope="row">Corte de pelo</th>
-
   <td>Peluquería</td>
   <td>12/09</td>
-
-  <td>Gran idea</td>
+  <td>Buena idea</td>
   <td>30</td>
 </tr>
 ```
 
-Los lectores de pantalla reconocerán el marcado estructurado de esta manera y permitirán a tus usuarios, por ejemplo, leer toda la columna o fila a la vez.
+Los lectores de pantalla reconocen un marcado estructurado así, y permiten por ejemplo leer de una vez toda la columna o toda la fila.
 
-El atributo `scope` tiene dos valores posibles más: `colgroup` y `rowgroup`. Se utilizan para encabezados que se encuentran sobre la parte superior de varias columnas o filas. Si vuelves a echar un vistazo a la tabla «Artículos vendidos en agosto de 2016» al comienzo de esta sección, verás que la celda «Ropa» se encuentra encima de las celdas «Pantalones», «Faldas» y «Vestidos» Todas estas celdas deben estar marcadas como encabezados (`<th>`), pero «Ropa» es un encabezado que está por encima y define los otros tres subencabezados. Por lo tanto, «Ropa» debería incluir un atributo `scope="colgroup"`, mientras que los demás tendrían un atributo `scope="col"`.
-
-### Los atributos de id y encabezados
-
-Una alternativa al uso del atributo `scope` es usar los atributos [`id`](/es/docs/Web/HTML/Reference/Global_attributes#id) y [`headers`](/es/docs/Web/HTML/Reference/Elements/td#headers) para crear asociaciones entre encabezados y celdas. La forma en que se usan es la siguiente:
-
-1. Añades un `id` único a cada elemento `<th>`.
-2. Añades un atributo `headers` a cada elemento `<td>`. Cada atributo `headers` debe contener una lista de los `id` de todos los elementos `<th>` que actúan como encabezado de esa celda, separados por espacios.
-
-Esto le da a tu tabla HTML una definición explícita de la posición de cada celda en la tabla definida por los encabezados de cada columna y fila de la que forma parte, como en una hoja de cálculo. Para que funcione bien, la tabla necesita tanto encabezados de columna como encabezados de fila.
-
-Volviendo a nuestro ejemplo de gastos, los dos fragmentos anteriores podrían reescribirse así:
+`scope` tiene dos valores posibles más: `colgroup` y `rowgroup`. Se usan en los encabezados que se sitúan por encima de varias columnas o filas. Si vuelves a la tabla «Artículos vendidos en agosto de 2016» del principio de esta sección, verás que la celda «Ropa» está por encima de las celdas «Pantalones», «Faldas» y «Vestidos». Todas ellas deben marcarse como encabezados (`<th>`), pero «Ropa» es un encabezado que está por encima y define los otros tres subencabezados. Por eso «Ropa» debe llevar el atributo `scope="colgroup"`, mientras que los demás llevarían `scope="col"`:
 
 ```html
 <thead>
   <tr>
-    <th id="purchase">Compra</th>
-    <th id="location">Ubicación</th>
-    <th id="date">Fecha</th>
-    <th id="evaluation">Revisión</th>
-    <th id="cost">Coste (€)</th>
+    <th colspan="3" scope="colgroup">Ropa</th>
+  </tr>
+  <tr>
+    <th scope="col">Pantalones</th>
+    <th scope="col">Faldas</th>
+    <th scope="col">Vestidos</th>
+  </tr>
+</thead>
+```
+
+Lo mismo aplica a los encabezados de varias filas agrupadas. Mira otra vez la tabla «Artículos vendidos en agosto de 2016», fijándote esta vez en las filas con los encabezados «Ámsterdam» y «Utrecht» (`<th>`). Verás que el encabezado «Países Bajos», también marcado como `<th>`, abarca ambas filas y es el encabezado de los otros dos subencabezados. Por tanto, hay que especificar `scope="rowgroup"` en esa celda de encabezado para ayudar a los lectores de pantalla a crear las asociaciones correctas:
+
+```html
+<tr>
+  <th rowspan="2" scope="rowgroup">Países Bajos</th>
+  <th scope="row">Ámsterdam</th>
+  <td>89</td>
+  <td>34</td>
+  <td>69</td>
+</tr>
+<tr>
+  <th scope="row">Utrecht</th>
+  <td>80</td>
+  <td>12</td>
+  <td>43</td>
+</tr>
+```
+
+## Los atributos `id` y `headers`
+
+Una alternativa al atributo `scope` es usar los atributos [`id`](/es/docs/Web/HTML/Reference/Global_attributes/id) y [`headers`](/es/docs/Web/HTML/Reference/Elements/td#headers) para crear asociaciones entre las celdas de datos y las de encabezado.
+
+Un elemento `<th>` puede servir de encabezado para una celda de datos (`<td>`) o, en tablas más complejas, para otra celda de encabezado (`<th>`). Esto te permite crear encabezados por capas o agrupados, en los que un encabezado describe a varios otros.
+
+El atributo `headers` sirve para enlazar una celda, `<td>` o `<th>`, con una o varias celdas de encabezado. Toma una lista de {{Glossary("string", "cadenas")}} separadas por espacios; el orden de las cadenas no importa. Cada cadena debe coincidir con el `id` único de un elemento `<th>` con el que la celda está asociada.
+
+Este método le da a tu tabla HTML una definición más explícita de la posición de cada celda, a partir de los encabezados de la columna y la fila a las que pertenece, algo parecido a una hoja de cálculo. Para que funcione bien, tu tabla debería incluir encabezados tanto de columna como de fila.
+
+Veamos una parte del ejemplo «Artículos vendidos en agosto de 2016» para entender cómo se usan los atributos `id` y `headers`:
+
+1. Añade un `id` único a cada elemento `<th>` de la tabla.
+2. Para las celdas de encabezado: añade un atributo `headers` a cada `<th>` que actúe como subencabezado, es decir, a toda celda de encabezado que tenga otro encabezado por encima. El valor es el `id` del encabezado de nivel superior. En nuestro ejemplo, `"clothes"` para los encabezados de columna y `"belgium"` para el de fila.
+3. Para las celdas de datos: añade un atributo `headers` a cada `<td>` y pon los `id` de los `<th>` asociados en una lista separada por espacios. Puedes proceder como en una hoja de cálculo: localiza la celda de datos y después los encabezados de fila y de columna que la describen. El orden de los `id` no importa, pero mantenerlo constante ayuda a organizarse y mejora la legibilidad del código.
+
+```html
+<thead>
+  <tr>
+    <th></th>
+    <th></th>
+    <th id="clothes" colspan="3">Ropa</th>
+  </tr>
+  <tr>
+    <th></th>
+    <th></th>
+    <th id="trousers" headers="clothes">Pantalones</th>
+    <th id="skirts" headers="clothes">Faldas</th>
+    <th id="dresses" headers="clothes">Vestidos</th>
   </tr>
 </thead>
 <tbody>
   <tr>
-    <th id="haircut">Corte de pelo</th>
-    <td headers="location haircut">Peluquería</td>
-    <td headers="date haircut">12/09</td>
-    <td headers="evaluation haircut">Gran idea</td>
-    <td headers="cost haircut">30</td>
+    <th id="belgium" rowspan="2">Bélgica</th>
+    <th id="antwerp" headers="belgium">Amberes</th>
+    <td headers="belgium antwerp clothes trousers">56</td>
+    <td headers="belgium antwerp clothes skirts">22</td>
+    <td headers="belgium antwerp clothes dresses">43</td>
   </tr>
-
-  ...
+  <tr>
+    <th id="ghent" headers="belgium">Gante</th>
+    <td headers="belgium ghent clothes trousers">41</td>
+    <td headers="belgium ghent clothes skirts">17</td>
+    <td headers="belgium ghent clothes dresses">35</td>
+  </tr>
 </tbody>
 ```
 
-> [!NOTE]
-> Este método crea asociaciones muy precisas entre los encabezados y las celdas de datos, pero utiliza **un montón** más de código de marcado y no permite errores. El enfoque `scope` suele bastar para la mayoría de las tablas.
+En este ejemplo:
 
-### Aprendizaje activo: jugar con scope y headers
-
-1. Para este ejercicio final, te proponemos que primero hagas copias locales de [items-sold.html](https://github.com/mdn/learning-area/blob/master/html/tables/advanced/items-sold.html) y [minimal-table.css](https://github.com/mdn/learning-area/blob/master/html/tables/advanced/minimal-table.css) en un directorio nuevo.
-2. Ahora intenta añadir los atributos `scope` adecuados para hacer que esta tabla sea más accesible.
-3. Por último, haz otra copia de los archivos originales, y esta vez añade accesibilidad a la tabla utilizando los atributos `id` y `headers`.
+- El `<th>` de `"Bélgica"` usa `rowspan="2"` para abarcar tanto `"Amberes"` como `"Gante"`.
+- Las celdas de encabezado de ciudad (`"Amberes"` y `"Gante"`) usan el atributo `headers` para referirse a `"belgium"` y mostrar así que pertenecen al grupo de Bélgica.
+- Cada `<td>` incluye un atributo `headers` con el país (`belgium`), la ciudad (`antwerp` o `ghent`), el grupo (`clothes`) y la prenda concreta (`trousers`, `skirts` o `dresses`).
 
 > [!NOTE]
-> Puedes verificar tu trabajo con nuestros ejemplos terminados: consulta [items-sold-scope.html](https://github.com/mdn/learning-area/blob/master/html/tables/advanced/items-sold-scope.html) ([consúltalo en vivo](https://mdn.github.io/learning-area/html/tables/advanced/items-sold-scope.html)) y [items-sold-headers.html](https://github.com/mdn/learning-area/blob/master/html/tables/advanced/items-sold-headers.html) ([consúltalo en vivo](https://mdn.github.io/learning-area/html/tables/advanced/items-sold-headers.html)).
+> Este método crea asociaciones muy precisas entre encabezados y celdas de datos, pero usa **mucho** más marcado y no deja margen para errores. El enfoque de `scope` suele ser suficiente para la mayoría de las tablas.
+
+## Jugar con scope y headers
+
+En este último ejercicio te pediremos que pruebes a usar `scope` y `headers` en la tabla de ejemplo que presentamos más arriba.
+
+1. Primero haz copias locales de [items-sold.html](https://github.com/mdn/learning-area/blob/main/html/tables/advanced/items-sold.html) y [minimal-table.css](https://github.com/mdn/learning-area/blob/main/html/tables/advanced/minimal-table.css) en un directorio nuevo.
+2. Prueba a añadir los atributos `scope` adecuados para hacer esta tabla más accesible.
+3. Haz otra copia de los archivos iniciales en otro directorio local.
+4. Esta vez haz la tabla más accesible creando asociaciones precisas y explícitas con los atributos `id` y `headers`.
+
+<details>
+<summary>Haz clic aquí para ver la solución</summary>
+
+El primer ejemplo HTML terminado debería verse más o menos así:
+
+```html
+<table>
+  <caption>
+    Artículos vendidos en agosto de 2016
+  </caption>
+  <thead>
+    <tr>
+      <td colspan="2" rowspan="2"></td>
+      <th colspan="3" scope="colgroup">Ropa</th>
+      <th colspan="2" scope="colgroup">Accesorios</th>
+    </tr>
+    <tr>
+      <th scope="col">Pantalones</th>
+      <th scope="col">Faldas</th>
+      <th scope="col">Vestidos</th>
+      <th scope="col">Pulseras</th>
+      <th scope="col">Anillos</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="3" scope="rowgroup">Bélgica</th>
+      <th scope="row">Amberes</th>
+      <td>56</td>
+      <td>22</td>
+      <td>43</td>
+      <td>72</td>
+      <td>23</td>
+    </tr>
+    <tr>
+      <th scope="row">Gante</th>
+      <td>46</td>
+      <td>18</td>
+      <td>50</td>
+      <td>61</td>
+      <td>15</td>
+    </tr>
+    <tr>
+      <th scope="row">Bruselas</th>
+      <td>51</td>
+      <td>27</td>
+      <td>38</td>
+      <td>69</td>
+      <td>28</td>
+    </tr>
+    <tr>
+      <th rowspan="2" scope="rowgroup">Países Bajos</th>
+      <th scope="row">Ámsterdam</th>
+      <td>89</td>
+      <td>34</td>
+      <td>69</td>
+      <td>85</td>
+      <td>38</td>
+    </tr>
+    <tr>
+      <th scope="row">Utrecht</th>
+      <td>80</td>
+      <td>12</td>
+      <td>43</td>
+      <td>36</td>
+      <td>19</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+Y el segundo debería verse así:
+
+```html
+<table>
+  <caption>
+    Artículos vendidos en agosto de 2016
+  </caption>
+  <thead>
+    <tr>
+      <td colspan="2" rowspan="2"></td>
+      <th colspan="3" id="clothes">Ropa</th>
+      <th colspan="2" id="accessories">Accesorios</th>
+    </tr>
+    <tr>
+      <th id="trousers" headers="clothes">Pantalones</th>
+      <th id="skirts" headers="clothes">Faldas</th>
+      <th id="dresses" headers="clothes">Vestidos</th>
+      <th id="bracelets" headers="accessories">Pulseras</th>
+      <th id="rings" headers="accessories">Anillos</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="3" id="belgium">Bélgica</th>
+      <th id="antwerp" headers="belgium">Amberes</th>
+      <td headers="antwerp belgium clothes trousers">56</td>
+      <td headers="antwerp belgium clothes skirts">22</td>
+      <td headers="antwerp belgium clothes dresses">43</td>
+      <td headers="antwerp belgium accessories bracelets">72</td>
+      <td headers="antwerp belgium accessories rings">23</td>
+    </tr>
+    <tr>
+      <th id="ghent" headers="belgium">Gante</th>
+      <td headers="ghent belgium clothes trousers">46</td>
+      <td headers="ghent belgium clothes skirts">18</td>
+      <td headers="ghent belgium clothes dresses">50</td>
+      <td headers="ghent belgium accessories bracelets">61</td>
+      <td headers="ghent belgium accessories rings">15</td>
+    </tr>
+    <tr>
+      <th id="brussels" headers="belgium">Bruselas</th>
+      <td headers="brussels belgium clothes trousers">51</td>
+      <td headers="brussels belgium clothes skirts">27</td>
+      <td headers="brussels belgium clothes dresses">38</td>
+      <td headers="brussels belgium accessories bracelets">69</td>
+      <td headers="brussels belgium accessories rings">28</td>
+    </tr>
+    <tr>
+      <th rowspan="2" id="netherlands">Países Bajos</th>
+      <th id="amsterdam" headers="netherlands">Ámsterdam</th>
+      <td headers="amsterdam netherlands clothes trousers">89</td>
+      <td headers="amsterdam netherlands clothes skirts">34</td>
+      <td headers="amsterdam netherlands clothes dresses">69</td>
+      <td headers="amsterdam netherlands accessories bracelets">85</td>
+      <td headers="amsterdam netherlands accessories rings">38</td>
+    </tr>
+    <tr>
+      <th id="utrecht" headers="netherlands">Utrecht</th>
+      <td headers="utrecht netherlands clothes trousers">80</td>
+      <td headers="utrecht netherlands clothes skirts">12</td>
+      <td headers="utrecht netherlands clothes dresses">43</td>
+      <td headers="utrecht netherlands accessories bracelets">36</td>
+      <td headers="utrecht netherlands accessories rings">19</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+También puedes encontrar los ejemplos terminados en GitHub:
+
+- Para el primero, consulta [items-sold-scope.html](https://github.com/mdn/learning-area/blob/main/html/tables/advanced/items-sold-scope.html) ([míralo también en vivo](https://mdn.github.io/learning-area/html/tables/advanced/items-sold-scope.html)).
+- Para el segundo, consulta [items-sold-headers.html](https://github.com/mdn/learning-area/blob/main/html/tables/advanced/items-sold-headers.html) ([míralo también en vivo](https://mdn.github.io/learning-area/html/tables/advanced/items-sold-headers.html)).
+
+</details>
 
 ## Resumen
 
-Podrías aprender algo más sobre las tablas en HTML, pero en realidad te hemos proporcionado toda la información que necesitas saber en este momento. En este punto, es posible que desees ir y aprender sobre la aplicación de estilo a tablas HTML: consulta [Aplicar estilo a las tablas](/es/docs/Learn_web_development/Core/Styling_basics/Tables).
+Hay algunas cosas más que podrías aprender sobre las tablas en HTML, pero con esto tienes todo lo que necesitas por ahora. A continuación puedes ponerte a prueba con nuestro desafío de tablas HTML. ¡Que lo disfrutes!
 
 {{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_table_basics", "Learn_web_development/Core/Structuring_content/Planet_data_table", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/web/css/guides/cascade/property_value_processing/index.md
+++ b/files/es/web/css/guides/cascade/property_value_processing/index.md
@@ -152,7 +152,7 @@ El **valor inicial** de una propiedad es el valor predeterminado que figura en s
 Puedes establecer explícitamente el valor inicial usando la palabra clave {{cssxref("initial")}}.
 
 > [!NOTE]
-> El valor inicial se encuentra en la sección de sintaxis formal de la página de referencia de cada propiedad CSS. Por ejemplo, el [valor inicial de `font-size` es `medium`](/es/docs/Web/CSS/Reference/Properties/font-size). No debe confundirse con el valor especificado por la hoja de estilo del navegador.
+> El valor inicial se encuentra en la sección de sintaxis formal de la página de referencia de cada propiedad CSS. Por ejemplo, el [valor inicial de `font-size` es `medium`](/es/docs/Web/CSS/Reference/Properties/font-size#definición_formal). No debe confundirse con el valor especificado por la hoja de estilo del navegador.
 
 ### Valor calculado
 
@@ -232,7 +232,7 @@ updateAllUsedWidths();
 window.addEventListener("resize", updateAllUsedWidths);
 ```
 
-Aunque los tres valores especificados, `auto`, `50%` e `inherit`, son palabras clave y valores de {{cssxref("percentage")}}, obtener el `width` con `window.getComputedStyle(el)["width"];` devuelve un valor de [longitud absoluta](/es/docs/Web/CSS/Reference/Values/length) en `px`:
+Aunque los tres valores especificados, `auto`, `50%` e `inherit`, son palabras clave y valores de {{cssxref("percentage")}}, obtener el `width` con `window.getComputedStyle(el)["width"];` devuelve un valor de [longitud absoluta](/es/docs/Web/CSS/Reference/Values/length#unidades_de_longitud_absolutas) en `px`:
 
 {{ EmbedLiveSample('Example', '80%', 372) }}
 

--- a/files/es/web/css/reference/properties/font-size/index.md
+++ b/files/es/web/css/reference/properties/font-size/index.md
@@ -1,61 +1,257 @@
 ---
-title: font-size
+title: Propiedad CSS `font-size`
+short-title: font-size
 slug: Web/CSS/Reference/Properties/font-size
-original_slug: Web/CSS/font-size
+l10n:
+  sourceCommit: a5531a7b1fa30ab1de952ffff619a9830eb1c1a9
 ---
 
-## Resumen
+La propiedad [CSS](/es/docs/Web/CSS) **`font-size`** establece el tamaño de la fuente. Cambiar el tamaño de la fuente también actualiza el tamaño de las unidades {{cssxref("&lt;length&gt;")}} relativas a él, como `em`, `ex`, etc.
 
-La propiedad `font-size` especifica la dimensión de la letra. Este tamaño puede, a su vez, alterar el aspecto de alguna otra cosa, ya que se usa para calcular la longitud de las unidades `em` y `ex`.
+{{InteractiveExample("CSS Demo: font-size")}}
 
-{{cssinfo}}
+```css interactive-example-choice
+font-size: 1.2rem;
+```
+
+```css interactive-example-choice
+font-size: x-small;
+```
+
+```css interactive-example-choice
+font-size: smaller;
+```
+
+```css interactive-example-choice
+font-size: 12px;
+```
+
+```css interactive-example-choice
+font-size: 80%;
+```
+
+```html interactive-example
+<section id="default-example">
+  <p id="example-element">
+    London. Michaelmas term lately over, and the Lord Chancellor sitting in
+    Lincoln's Inn Hall. Implacable November weather. As much mud in the streets
+    as if the waters had but newly retired from the face of the earth, and it
+    would not be wonderful to meet a Megalosaurus, forty feet long or so,
+    waddling like an elephantine lizard up Holborn Hill.
+  </p>
+</section>
+```
 
 ## Sintaxis
 
-`font-size:` `xx-small` | `x-small` | `small` | `medium` | `large` | `x-large` | `xx-large`
+```css
+/* Valores <absolute-size> */
+font-size: xx-small;
+font-size: x-small;
+font-size: small;
+font-size: medium;
+font-size: large;
+font-size: x-large;
+font-size: xx-large;
+font-size: xxx-large;
 
-`font-size:` `smaller` | `larger`
+/* Valores <relative-size> */
+font-size: smaller;
+font-size: larger;
 
-`font-size:` \<longitud> | \<porcentaje> | {{ Cssxref("inherit") }}
+/* Valores <length> */
+font-size: 12px;
+font-size: 0.8em;
+
+/* Valores <percentage> */
+font-size: 80%;
+
+/* Valor math */
+font-size: math;
+
+/* Valores globales */
+font-size: inherit;
+font-size: initial;
+font-size: revert;
+font-size: revert-layer;
+font-size: unset;
+```
 
 ### Valores
 
-- xx-small, x-small, small, medium, large, x-large, xx-large
-  - : un grupo de palabras clave de dimensión absoluta en relación al que determina el usuario como tamaño por defecto (que es `medium`). De forma parecida a las sentencias HTML `<font size="1">` hasta `<font size="7">` donde el tamaño por defecto es `<font size="3">`.
-- larger, smaller
-  - : más grande o más pequeño que el tamaño de letra del elemento padre, con aproximadamente el mismo ratio que el mencionado anteriormente.
-- [\<longitud>](/es/docs/Web/CSS/Reference/Values/length)
-  - : una unidad positiva de [longitud](/es/docs/Web/CSS/Reference/Values/length).
+Esta propiedad se especifica con un único valor de la lista siguiente:
 
-<!---->
+- `xx-small`, `x-small`, `small`, `medium`, `large`, `x-large`, `xx-large`, `xxx-large`
+  - : Palabras clave de [tamaño absoluto](/es/docs/Web/CSS/Reference/Values/absolute-size), basadas en el tamaño de fuente predeterminado de quien usa el navegador (que es `medium`).
 
-- \<Porcentaje>
-  - : un porcentaje positivo del cuerpo de letra del elemento padre.
+- `larger`, `smaller`
+  - : Palabras clave de [tamaño relativo](/es/docs/Web/CSS/Reference/Values/relative-size). La fuente será mayor o menor con respecto al tamaño de fuente del elemento padre, aproximadamente en la misma proporción que separa las palabras clave de tamaño absoluto anteriores.
 
-Es aconsejable evitar el uso de valores que no sean relativos al tamaño por defecto definido por el usuario, tales como `longitud` absoluta en unidades distintas a `em` o `ex`. Sin embargo, si hay que usar ese tipo de valores, es preferible utilizar unidades `px` (píxel), ya que su significado no varía en función de las características del sistema operativo (casi siempre erróneas) como la resolución del monitor.
+- {{cssxref("&lt;length&gt;")}}
+  - : Un valor {{cssxref("&lt;length&gt;")}} positivo. Para la mayoría de las unidades relativas a la fuente (como `em` y `ex`), el tamaño de fuente es relativo al del elemento padre.
+
+    Para las unidades relativas a la fuente que se basan en la raíz (como `rem`), el tamaño de fuente es relativo al de la fuente que usa el elemento {{HTMLElement("html")}} (el elemento raíz).
+
+- {{cssxref("&lt;percentage&gt;")}}
+  - : Un valor {{cssxref("&lt;percentage&gt;")}} positivo, relativo al tamaño de fuente del elemento padre.
+    > [!NOTE]
+    > Para maximizar la accesibilidad, por lo general es mejor usar valores relativos al tamaño de fuente predeterminado de quien usa el navegador.
+
+- `math`
+  - : Se aplican [reglas de escalado](https://w3c.github.io/mathml-core/#the-math-script-level-property) al determinar el valor calculado de la propiedad `font-size` en los elementos matemáticos, con respecto al `font-size` del padre que los contiene.
+    Consulta la propiedad [math-depth](/es/docs/Web/CSS/Reference/Properties/math-depth) para más información.
+
+## Descripción
+
+Hay varias formas de especificar el tamaño de la fuente, con palabras clave o con valores numéricos en píxeles o en ems. Elige el método adecuado según las necesidades de cada página web.
+
+### Palabras clave
+
+Las palabras clave son una buena manera de fijar el tamaño de las fuentes en la web. Al establecer un tamaño de fuente con palabra clave en el elemento {{HTMLElement("body")}}, puedes fijar tamaños relativos en el resto de la página, lo que te permite escalar con facilidad la fuente hacia arriba o hacia abajo en toda ella.
+
+### Píxeles
+
+Fijar el tamaño de fuente en píxeles (`px`) es una buena opción cuando necesitas precisión exacta. Un valor en px es estático. Es una forma independiente del sistema operativo y del navegador de indicarle literalmente al navegador que dibuje las letras con exactamente la altura en píxeles que has especificado. Los resultados pueden variar ligeramente entre navegadores, porque pueden usar algoritmos distintos para lograr un efecto similar.
+
+Los ajustes de tamaño de fuente también se pueden combinar. Por ejemplo, si un elemento padre está fijado en `16px` y su elemento hijo en `larger`, el hijo se muestra más grande que el padre en la página.
+
+> [!NOTE]
+> Definir los tamaños de fuente en `px` _[no es accesible](https://es.wikipedia.org/wiki/Accesibilidad_web)_, porque en algunos navegadores no se puede cambiar el tamaño de la fuente. Por ejemplo, quien tenga visión reducida puede querer un tamaño de fuente mucho mayor que el elegido por quien diseñó la web. Evita usarlos para los tamaños de fuente si quieres crear un diseño inclusivo.
+
+### Ems
+
+Usar un valor `em` crea un tamaño de fuente dinámico o calculado (históricamente la unidad `em` derivaba del ancho de una «M» mayúscula en una tipografía dada). El valor numérico actúa como multiplicador de la propiedad `font-size` del elemento sobre el que se usa. Fíjate en este ejemplo:
+
+```css
+p {
+  font-size: 2em;
+}
+```
+
+En este caso, el tamaño de fuente de los elementos `<p>` será el doble del `font-size` calculado que heredan. Por extensión, un `font-size` de `1em` equivale al `font-size` calculado del elemento sobre el que se usa.
+
+Si no se ha fijado ningún `font-size` en los ancestros del `<p>`, entonces `1em` equivaldrá al `font-size` predeterminado del navegador, que suele ser `16px`. Así que, por defecto, `1em` equivale a `16px` y `2em` a `32px`. Si fijaras un `font-size` de 20px en el elemento `<body>`, entonces `1em` en los elementos `<p>` equivaldría a `20px`, y `2em` a `40px`.
+
+Para calcular el equivalente en `em` de cualquier valor en píxeles, puedes usar esta fórmula:
+
+```plain
+em = valor en píxeles deseado para el elemento / tamaño de fuente del padre en píxeles
+```
+
+Por ejemplo, supongamos que el `font-size` del `<body>` de la página está fijado en `16px`. Si el tamaño de fuente que quieres es `12px`, debes especificar `0.75em` (porque 12/16 = 0,75). De igual modo, si quieres un tamaño de fuente de `10px`, especifica `0.625em` (10/16 = 0,625); para `22px`, especifica `1.375em` (22/16).
+
+El `em` es una unidad muy útil en CSS, ya que adapta automáticamente su longitud a la fuente que elija usar quien lee.
+
+Un dato importante que conviene recordar: los valores en em se componen. Fíjate en el HTML y el CSS siguientes:
+
+```css
+html {
+  font-size: 100%;
+}
+span {
+  font-size: 1.6em;
+}
+```
+
+```html
+<div>
+  <span>Exterior <span>interior</span> exterior</span>
+</div>
+```
+
+El resultado es:
+
+{{EmbedLiveSample("Ems", 400, 100)}}
+
+Suponiendo que el `font-size` predeterminado del navegador sea 16px, las palabras «exterior» se dibujarían a 25,6px, pero la palabra «interior» se dibujaría a 40,96px. Esto se debe a que el `font-size` del {{HTMLElement("span")}} interior es de 1.6em, relativo al `font-size` de su padre, que a su vez es relativo al `font-size` del suyo. Esto es lo que se suele llamar **composición**.
+
+### Rems
+
+Los valores `rem` se inventaron para sortear el problema de la composición. Los valores `rem` son relativos al elemento raíz `html`, no al elemento padre. Dicho de otro modo, te permiten especificar un tamaño de fuente de forma relativa sin verte afectado por el tamaño del padre, lo que elimina la composición.
+
+El CSS siguiente es casi idéntico al del ejemplo anterior. La única diferencia es que la unidad ha cambiado a `rem`.
+
+```css
+html {
+  font-size: 100%;
+}
+span {
+  font-size: 1.6rem;
+}
+```
+
+Y aplicamos este CSS al mismo HTML, que queda así:
+
+```html
+<span>Exterior <span>interior</span> exterior</span>
+```
+
+{{EmbedLiveSample("Rems", 400, 100)}}
+
+En este ejemplo, las palabras «exterior interior exterior» se muestran todas a 25,6px (suponiendo que el `font-size` del navegador se haya dejado en su valor predeterminado de 16px).
+
+### Ex
+
+Igual que con la unidad `em`, el `font-size` de un elemento fijado con la unidad `ex` es calculado o dinámico. Se comporta exactamente igual, salvo que al fijar la propiedad `font-size` con unidades `ex`, el `font-size` equivale a la altura de la x de la [primera fuente disponible](https://drafts.csswg.org/css-fonts/#first-available-font) que se use en la página. El valor numérico multiplica el `font-size` heredado por el elemento, y el `font-size` se compone de forma relativa.
+
+Consulta el borrador editorial del W3C para una descripción más detallada de las [unidades de longitud relativas a la fuente](https://drafts.csswg.org/css-values-4/#font-relative-length) como `ex`.
+
+## Definición formal
+
+{{cssinfo}}
+
+## Sintaxis formal
+
+{{csssyntax}}
 
 ## Ejemplos
 
-[Ver El Ejemplo Vivo](https://mdn.dev/archives/media/samples/cssref/font-size.html)
+### Establecer tamaños de fuente
 
+#### CSS
+
+```css
+.small {
+  font-size: xx-small;
+}
+.larger {
+  font-size: larger;
+}
+.point {
+  font-size: 24pt;
+}
+.percent {
+  font-size: 200%;
+}
 ```
-/* Ajusta el texto del párrafo a un cuerpo de letra muy grande. */
-p { font-size: xx-large }
 
-/* Ajusta la cabecera de nivel 1 (h1) a 2,5 veces del tamaño
- * del texto. */
-h1 { font-size: 250% }
+#### HTML
 
-/* Ajusta el texto incluido en span a 16px */
-span { font-size: 16px; }
+```html
+<h1 class="small">H1 pequeño</h1>
+<h1 class="larger">H1 más grande</h1>
+<h1 class="point">H1 de 24 puntos</h1>
+<h1 class="percent">H1 al 200%</h1>
 ```
 
-## Notas
+#### Resultado
 
-Las unidades `em` y `ex` en la propiedad {{ Cssxref("font-size") }} son relativas al tamaño de letra del elemento padre (al contrario que todas las demás propiedades, en las que estas unidades son relativas al tamaño de letra del elemento). Esto quiere decir que las unidades `em` y los porcentajes se comportan de igual forma cuando hablamos de {{ Cssxref("font-size") }}.
+{{EmbedLiveSample('Establecer_tamaños_de_fuente', 600, 250)}}
 
 ## Especificaciones
 
-- [CSS 1](https://www.w3.org/TR/CSS1#font-size)
-- [CSS 2.1](https://www.w3.org/TR/CSS21/fonts.html#propdef-font-size)
-- [css3-fonts](https://www.w3.org/TR/css3-fonts/#font-size)
+{{Specifications}}
+
+## Compatibilidad con navegadores
+
+{{Compat}}
+
+## Véase también
+
+- {{cssxref("font-size-adjust")}}
+- {{cssxref("font-style")}}
+- {{cssxref("font-weight")}}
+- {{cssxref("math-depth")}}
+- {{cssxref("math-style")}}
+- Atributo SVG {{SVGAttr("font-size")}}
+- [Aprende: fundamentos del estilo de texto y fuentes](/es/docs/Learn_web_development/Core/Text_styling/Fundamentals)

--- a/files/es/web/css/reference/values/length/index.md
+++ b/files/es/web/css/reference/values/length/index.md
@@ -1,100 +1,317 @@
 ---
-title: <length>
+title: Tipo CSS `<length>`
+short-title: <length>
 slug: Web/CSS/Reference/Values/length
-original_slug: Web/CSS/length
+l10n:
+  sourceCommit: b25b4a98b757fbd05ce1fb74b1b78f3fcf917729
 ---
 
-## Resumen
+El [tipo de dato](/es/docs/Web/CSS/Reference/Values/Data_types) [CSS](/es/docs/Web/CSS) **`<length>`** representa un valor de distancia. Las longitudes se pueden usar en numerosas propiedades CSS, como {{Cssxref("width")}}, {{Cssxref("height")}}, {{Cssxref("margin")}}, {{Cssxref("padding")}}, {{Cssxref("border-width")}}, {{Cssxref("font-size")}} y {{Cssxref("text-shadow")}}.
 
-El tipo de dato [CSS](/es/docs/Web/CSS) `<length>` denota medidas de distancia. Es un valor {{cssxref("&lt;number&gt;")}} seguido por una unidad de longitud (`px`, `em`, `pc`, `in`, `mm`, …). Al igual que en cualquier dimensión CSS, no debe haber espacio entre la unidad y el número. La unidad de longitud es opcional después del valor {{cssxref("&lt;number&gt;")}} `0`.
+> [!NOTE]
+> Aunque los valores {{cssxref("&lt;percentage&gt;")}} se pueden usar en algunas de las mismas propiedades que aceptan valores `<length>`, no son en sí valores `<length>`. Consulta {{cssxref("&lt;length-percentage&gt;")}}.
 
-Muchas propiedades CSS ([CSS properties](/es/CSS_Reference)) reciben valores `<length>`, como por ejemplo {{ Cssxref("width") }}, {{ Cssxref("margin-top") }}, y {{ Cssxref("font-size") }}.
+## Sintaxis
 
-Para algunas propiedades, el uso de longitudes negativas es un error de sintaxis, mientras que para algunas propiedades está permitido. Nótese que aunque los valores {{cssxref("&lt;percentage&gt;")}} también son dimensiones CSS y son aceptadas por algunas propiedades CSS que aceptan valores `<length>`, no son valores `<length>` en sí.
+El tipo de dato `<length>` consiste en un {{cssxref("&lt;number&gt;")}} seguido de una de las unidades que se listan más abajo. Como en todas las dimensiones CSS, no hay espacio entre el número y el literal de la unidad. Especificar la unidad de longitud es opcional si el número es `0`.
+
+> [!NOTE]
+> Algunas propiedades admiten valores `<length>` negativos y otras no.
+
+### Valores especificados frente a valores calculados
+
+El [valor especificado](/es/docs/Web/CSS/Guides/Cascade/Property_value_processing#valor_especificado) de una longitud (_longitud especificada_) se representa con su cantidad y su unidad. El [valor calculado](/es/docs/Web/CSS/Guides/Cascade/Property_value_processing#valor_calculado) de una longitud (_longitud calculada_) es la longitud especificada resuelta a una longitud absoluta, y su unidad no se distingue.
+
+En algunas propiedades, como `border-width`, `outline-width`, `column-rule-width` y `outline-offset`, los valores `<length>` calculados se redondean a un número entero de {{glossary("device pixel", "píxeles de dispositivo")}} para garantizar una presentación visual razonable:
+
+- Un valor distinto de cero y menor que 1 píxel de dispositivo se redondea hacia arriba.
+- Un valor mayor que 1 píxel de dispositivo se redondea hacia abajo al píxel de dispositivo entero más cercano.
+
+Por ejemplo, en una pantalla con un {{domxref("Window.devicePixelRatio", "devicePixelRatio")}} de 3, `border-width: 1.5px` se calcula como aproximadamente `1.33px` (redondeando de 4,5 a 4 píxeles de dispositivo), y `outline-width: 0.2px` se calcula como aproximadamente `0.33px` (redondeando de 0,6 a 1 píxel de dispositivo).
+
+### Longitudes relativas frente a absolutas
+
+Las unidades de `<length>` pueden ser relativas o absolutas. Las longitudes relativas representan una medida en función de otra distancia. Según la unidad, esa distancia puede ser el tamaño de un carácter concreto, la [altura de línea](/es/docs/Web/CSS/Reference/Properties/line-height) o el tamaño del {{Glossary("viewport", "área visible")}}. Las hojas de estilo que usan unidades de longitud relativas se adaptan con más facilidad de un entorno de salida a otro.
+
+> [!NOTE]
+> Los elementos hijos no heredan los valores relativos tal como se especificaron para su padre; heredan los valores calculados.
+
+## Unidades de longitud relativas
+
+Las unidades de longitud relativas de CSS se basan en el tamaño de la fuente, del contenedor o del área visible.
+
+### Unidades de longitud relativas a la fuente
+
+Las longitudes de fuente definen el valor `<length>` en función del tamaño de un carácter concreto o de un atributo de la fuente vigente en un elemento o en su padre.
+
+> [!NOTE]
+> Estas unidades, en especial `em` y su equivalente relativa a la raíz `rem`, se usan a menudo para crear diseños escalables que mantienen el ritmo vertical de la página aunque quien lee cambie el tamaño de fuente.
+
+- `cap`
+  - : Igual a la «altura de mayúsculas» (la altura nominal de las letras mayúsculas) de la {{Cssxref("font")}} del elemento.
+- `ch`
+  - : Representa el ancho o, más exactamente, la {{Glossary("advance measure", "medida de avance")}} del glifo `0` (cero, el carácter Unicode U+0030) en la {{Cssxref("font")}} del elemento.
+    Cuando determinar la medida del glifo `0` es imposible o poco práctico, debe asumirse un ancho de `0.5em` y una altura de `1em`.
+- `em`
+  - : Representa el {{Cssxref("font-size")}} calculado del elemento. Si se usa en la propia propiedad {{Cssxref("font-size")}}, representa el tamaño de fuente _heredado_ por el elemento.
+- `ex`
+  - : Igual a la [altura de la x](https://es.wikipedia.org/wiki/Altura_x) de la {{Cssxref("font")}} del elemento. En las fuentes que tienen la letra `x`, suele ser la altura de las minúsculas; `1ex ≈ 0.5em` en muchas fuentes.
+- `ic`
+  - : Representa la {{Glossary("advance measure", "medida de avance")}} utilizada del glifo «水» (el ideograma CJK de agua, U+6C34) en la fuente con la que se dibuja.
+- `lh`
+  - : Igual al valor calculado de la propiedad {{Cssxref("line-height")}} del elemento sobre el que se usa, convertido a una longitud absoluta. Esta unidad permite calcular longitudes a partir del tamaño teórico de una línea vacía ideal. Sin embargo, el tamaño de las cajas de línea reales puede variar según su contenido.
+
+### Unidades de longitud relativas a la fuente del elemento raíz
+
+Estas unidades definen el valor `<length>` en función del tamaño de un carácter concreto o de un atributo de la fuente del elemento [raíz](/es/docs/Web/CSS/Reference/Selectors/:root):
+
+- `rcap`
+  - : Igual a la «altura de mayúsculas» (la altura nominal de las letras mayúsculas) de la {{Cssxref("font")}} del elemento raíz.
+- `rch`
+  - : Igual al ancho o a la {{Glossary("advance measure", "medida de avance")}} del glifo `0` (cero, el carácter Unicode U+0030) en la {{Cssxref("font")}} del elemento raíz.
+- `rem`
+  - : Representa el {{Cssxref("font-size")}} del elemento raíz (normalmente {{HTMLElement("html")}}). Cuando se usa dentro del {{Cssxref("font-size")}} del propio elemento raíz, representa su valor inicial. Un valor predeterminado habitual en los navegadores es `16px`, pero las preferencias de quien usa el navegador pueden modificarlo.
+- `rex`
+  - : Igual a la altura de la x de la {{Cssxref("font")}} del elemento raíz.
+- `ric`
+  - : Igual al valor de la unidad [`ic`](#ic) aplicada a la fuente del elemento raíz.
+- `rlh`
+  - : Igual al valor de la unidad [`lh`](#lh) aplicada a la fuente del elemento raíz. Esta unidad permite calcular longitudes a partir del tamaño teórico de una línea vacía ideal. Sin embargo, el tamaño de las cajas de línea reales puede variar según su contenido.
+
+### Unidades de longitud relativas al área visible
+
+Las **unidades de longitud en porcentaje del área visible** se basan en cuatro tamaños distintos del área visible: pequeño, grande, dinámico y predeterminado. La existencia de varios tamaños responde a que las interfaces de los navegadores se expanden y se contraen dinámicamente, ocultando y mostrando el contenido que hay debajo.
+
+- **Unidades de área visible pequeña**
+  - : Cuando quieras el área visible más pequeña posible frente a interfaces del navegador que se expanden dinámicamente, usa el tamaño de área visible pequeña. Ese tamaño permite que el contenido que diseñas llene toda el área visible cuando las interfaces del navegador están desplegadas. Elegirlo también puede dejar espacios vacíos cuando esas interfaces se retraen.
+
+    Por ejemplo, si un elemento se dimensiona con unidades de porcentaje basadas en el área visible pequeña, llenará la pantalla a la perfección sin que se oculte nada de su contenido mientras todas las interfaces dinámicas del navegador estén visibles. Cuando se ocultan, en cambio, puede aparecer espacio de más alrededor del elemento. Por eso las unidades de área visible pequeña son «más seguras» en general, aunque quizá no produzcan el diseño más atractivo una vez que quien lee empieza a interactuar con la página.
+
+    El tamaño de área visible pequeña se representa con el prefijo `sv` y da lugar a las unidades `sv*`. Sus tamaños son fijos y, por tanto, estables, salvo que cambie el tamaño del propio área visible.
+
+- **Unidades de área visible grande**
+  - : Cuando quieras el área visible más grande posible frente a interfaces del navegador que se retraen dinámicamente, usa el tamaño de área visible grande. Ese tamaño permite que el contenido que diseñas llene toda el área visible cuando las interfaces del navegador se están retrayendo. Ten en cuenta que el contenido puede quedar oculto cuando esas interfaces se expanden.
+
+    Por ejemplo, en los teléfonos móviles, donde el espacio en pantalla es escaso, los navegadores suelen ocultar parte o toda la barra de título y de dirección cuando quien lee empieza a desplazar la página. Si un elemento se dimensiona con una unidad basada en el área visible grande, su contenido llenará toda la página visible mientras esas interfaces estén ocultas. Sin embargo, cuando se muestran, pueden tapar el contenido dimensionado o posicionado con unidades de área visible _grande_.
+
+    La unidad de área visible grande se representa con el prefijo `lv` y da lugar a las unidades `lv*`. Sus tamaños son fijos y, por tanto, estables, salvo que cambie el tamaño del propio área visible.
+
+- **Unidades de área visible dinámica**
+  - : Cuando quieras que el área visible se dimensione automáticamente según se expandan o se retraigan las interfaces del navegador, puedes usar el tamaño de área visible dinámica. Ese tamaño permite que el contenido que diseñas encaje exactamente dentro del área visible, haya o no interfaces dinámicas del navegador.
+
+    La unidad de área visible dinámica se representa con el prefijo `dv` y da lugar a las unidades `dv*`. Sus tamaños no son estables, ni siquiera cuando el área visible no cambia.
+
+    > [!NOTE]
+    > Aunque el tamaño de área visible dinámica da más control y flexibilidad, usar unidades basadas en él puede hacer que el contenido cambie de tamaño mientras se desplaza la página. Eso puede degradar la interfaz y penalizar el rendimiento.
+
+- **Unidades de área visible predeterminada**
+  - : El tamaño de área visible predeterminado lo define el navegador. El comportamiento de la unidad resultante puede equivaler al de la unidad basada en el área visible pequeña, en la grande, en un tamaño intermedio entre ambas, o en la dinámica.
+
+    > [!NOTE]
+    > Por ejemplo, un navegador podría implementar la unidad predeterminada de altura (`vh`) de forma equivalente a la unidad de altura de área visible grande (`lvh`). Si es así, podría ocultar contenido en una presentación a página completa mientras la interfaz del navegador está desplegada. Actualmente, todas las unidades predeterminadas (`vh`, `vw`, etc.) equivalen a sus homólogas de área visible grande (`lvh`, `lvw`, etc.).
+
+Las longitudes en porcentaje del área visible definen valores `<length>` en porcentaje relativo al tamaño del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial, que a su vez se basa en el tamaño del {{Glossary("viewport", "área visible")}} o del área de la página, es decir, la porción visible del documento. Cuando cambia la altura o el ancho del bloque contenedor inicial, los elementos dimensionados a partir de ellos se escalan en consecuencia. Hay una variante de unidad de porcentaje del área visible por cada uno de los tamaños, como se describe abajo.
+
+> [!NOTE]
+> Las longitudes de área visible no son válidas en los bloques de declaración {{cssxref("@page")}}.
+
+- `vh`
+  - : Representa un porcentaje de la altura del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial del área visible. `1vh` es el 1 % de la altura del área visible. Por ejemplo, si esa altura es `300px`, un valor de `70vh` en una propiedad será `210px`.
+
+    Las unidades correspondientes a los tamaños pequeño, grande y dinámico son `svh`, `lvh` y `dvh`. `vh` equivale a `lvh`, es decir, a la unidad basada en el área visible grande.
+
+- `vw`
+  - : Representa un porcentaje del ancho del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial del área visible. `1vw` es el 1 % del ancho del área visible. Por ejemplo, si ese ancho es `800px`, un valor de `50vw` en una propiedad será `400px`.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svw`, `lvw` y `dvw`.
+    `vw` equivale a `lvw`, es decir, a la unidad basada en el área visible grande.
+
+- `vmax`
+  - : Representa en porcentaje el mayor de `vw` y `vh`.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svmax`, `lvmax` y `dvmax`.
+    `vmax` equivale a `lvmax`, es decir, a la unidad basada en el área visible grande.
+
+- `vmin`
+  - : Representa en porcentaje el menor de `vw` y `vh`.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svmin`, `lvmin` y `dvmin`.
+    `vmin` equivale a `lvmin`, es decir, a la unidad basada en el área visible grande.
+
+- `vb`
+  - : Representa el porcentaje del tamaño del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial en la dirección del [eje de bloque](/es/docs/Web/CSS/Guides/Logical_properties_and_values) del elemento raíz.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svb`, `lvb` y `dvb`.
+    `vb` equivale a `lvb`, es decir, a la unidad basada en el área visible grande.
+
+- `vi`
+  - : Representa un porcentaje del tamaño del [bloque contenedor](/es/docs/Web/CSS/Guides/Display/Containing_block) inicial en la dirección del [eje en línea](/es/docs/Web/CSS/Guides/Logical_properties_and_values) del elemento raíz.
+
+    Para los tamaños pequeño, grande y dinámico, las unidades correspondientes son `svi`, `lvi` y `dvi`.
+    `vi` equivale a `lvi`, es decir, a la unidad basada en el área visible grande.
+
+### Unidades de longitud de consulta de contenedor
+
+Al aplicar estilos a un contenedor mediante consultas de contenedor, puedes usar unidades de longitud de consulta de contenedor.
+Estas unidades especifican una longitud relativa a las dimensiones del contenedor consultado.
+Los componentes que usan unidades relativas a su contenedor son más flexibles y se pueden reutilizar en contenedores distintos sin recalcular longitudes concretas.
+
+Si no hay ningún contenedor apto para la consulta, la unidad recurre por defecto a la [unidad de área visible pequeña](#unidades_de_área_visible_pequeña) de ese eje (`sv*`).
+
+Para más información, consulta [Consultas de contenedor](/es/docs/Web/CSS/Guides/Containment/Container_queries).
+
+- `cqw`
+  - : Representa un porcentaje del ancho del contenedor consultado. `1cqw` es el 1 % de ese ancho. Por ejemplo, si el ancho del contenedor consultado es `800px`, un valor de `50cqw` en una propiedad será `400px`.
+
+- `cqh`
+  - : Representa un porcentaje de la altura del contenedor consultado. `1cqh` es el 1 % de esa altura. Por ejemplo, si la altura del contenedor consultado es `300px`, un valor de `10cqh` en una propiedad será `30px`.
+
+- `cqi`
+  - : Representa un porcentaje del tamaño en línea del contenedor consultado. `1cqi` es el 1 % de ese tamaño. Por ejemplo, si el tamaño en línea del contenedor consultado es `800px`, un valor de `50cqi` en una propiedad será `400px`.
+
+- `cqb`
+  - : Representa un porcentaje del tamaño de bloque del contenedor consultado. `1cqb` es el 1 % de ese tamaño. Por ejemplo, si el tamaño de bloque del contenedor consultado es `300px`, un valor de `10cqb` en una propiedad será `30px`.
+
+- `cqmin`
+  - : Representa un porcentaje del menor entre el tamaño en línea y el tamaño de bloque del contenedor consultado. `1cqmin` es el 1 % de ese menor valor. Por ejemplo, si el tamaño en línea del contenedor consultado es `800px` y el de bloque `300px`, un valor de `50cqmin` en una propiedad será `150px`.
+
+- `cqmax`
+  - : Representa un porcentaje del mayor entre el tamaño en línea y el tamaño de bloque del contenedor consultado. `1cqmax` es el 1 % de ese mayor valor. Por ejemplo, si el tamaño en línea del contenedor consultado es `800px` y el de bloque `300px`, un valor de `50cqmax` en una propiedad será `400px`.
+
+## Unidades de longitud absolutas
+
+Las **unidades de longitud absolutas** representan una medida física cuando se conocen las propiedades físicas del medio de salida, como en la maquetación para impresión. Esto se consigue anclando una de las unidades a una **unidad física** o a la **unidad de ángulo visual** y definiendo las demás con respecto a ella. Las unidades físicas incluyen `cm`, `in`, `mm`, `pc`, `pt`, `px` y `Q`. El anclaje se hace de forma distinta en los dispositivos de baja resolución, como las pantallas, que en los de alta resolución, como las impresoras.
+
+En los dispositivos de pocos ppp, la unidad `px` representa el _píxel de referencia_ físico, y las demás unidades se definen con respecto a ella. Así, `1in` se define como `96px`, que equivale a `72pt`. La consecuencia de esta definición es que, en esos dispositivos, las dimensiones descritas en pulgadas (`in`), centímetros (`cm`) o milímetros (`mm`) no coinciden necesariamente con el tamaño de la unidad física del mismo nombre.
+
+En los dispositivos de muchos ppp, las pulgadas (`in`), los centímetros (`cm`) y los milímetros (`mm`) sí coinciden con sus equivalentes físicos. Por tanto, la unidad `px` se define con respecto a ellos (1/96 de `1in`).
+
+> [!NOTE]
+> Mucha gente aumenta el tamaño de fuente predeterminado de su {{Glossary("user agent", "agente de usuario")}} para que el texto se lea mejor. Las longitudes absolutas pueden causar problemas de accesibilidad porque son fijas y no se escalan según esos ajustes. Por eso conviene preferir longitudes relativas (como `em` o `rem`) al fijar el `font-size`.
+
+- `px`
+  - : Un píxel. En las pantallas representa tradicionalmente un {{glossary("device pixel", "píxel de dispositivo")}} (un punto). Sin embargo, en las _impresoras_ y las _pantallas de alta resolución_, un píxel CSS implica varios píxeles de dispositivo. `1px` = `1in / 96`.
+- `cm`
+  - : Un centímetro. `1cm` = `96px / 2.54`.
+- `mm`
+  - : Un milímetro. `1mm` = `1cm / 10`.
+- `Q`
+  - : Un cuarto de milímetro. `1Q` = `1cm / 40`.
+- `in`
+  - : Una pulgada. `1in` = `2.54cm` = `96px`.
+- `pc`
+  - : Una pica. `1pc` = `12pt` = `1in / 6`.
+- `pt`
+  - : Un punto. `1pt` = `1in / 72`.
 
 ## Interpolación
 
-Los valores de tipo `<length>` pueden ser interpolados para permitir animaciones. En este caso son interpolados como números reales, de punto flotante. La interpolación sucede en el valor calculado. La velocidad de la interpolación es definida por la función {{cssxref("&lt;timing-function&gt;")}} asociada a la animación.
+Al animarse, los valores del tipo de dato `<length>` se interpolan como números reales en coma flotante. La {{glossary("interpolation", "interpolación")}} se produce sobre el valor calculado. La velocidad de la interpolación la determina la [función de suavizado](/es/docs/Web/CSS/Reference/Values/easing-function) asociada a la animación.
 
-## Unidades
+## Ejemplos
 
-### Unidades de longitud relativa
+### Comparar distintas unidades de longitud
 
-#### Longitudes relativas a la fuente
+El ejemplo siguiente te ofrece un campo de entrada en el que puedes escribir un valor `<length>` (por ejemplo `300px`, `50%`, `30vw`) para fijar el ancho de una barra de resultado que aparecerá debajo en cuanto pulses <kbd>Intro</kbd>.
 
-- `em`
-  - : Esta unidad representa el tamaño calculado de fuente ({{Cssxref("font-size")}}) del elemento. Si se usa dentro de la propiedad {{Cssxref("font-size")}}, representa el tamaño de fuente _heredado_ por el elemento.
+Esto te permite comparar y contrastar los efectos de las distintas unidades de longitud.
 
-    > [!NOTE]
-    > Esta unidad se usa por lo general para crear interfaces escalables, que mantengan el [ritmo vertical de la página](http://24ways.org/2006/compose-to-a-vertical-rhythm), aun cuando el usuario cambie el tamaño de las fuentes. Las propiedades CSS {{cssxref("line-height")}}, {{cssxref("font-size")}}, {{cssxref("margin-bottom")}} y {{cssxref("margin-top")}} generalemente tienen valores expresados en **em**.
+#### HTML
 
-- `ex`
-  - : Esta unidad representa la [altura de la x](https://es.wikipedia.org/wiki/Altura_de_la_x) de la fuente ({{Cssxref("font")}}) del elemento. En fuentes que incluyen la letra 'x', es generalmente la altura de letras minúsculas en la fuente; `1ex ≈ 0.5em` en muchas fuentes.
-- `ch`
-  - : Esta unidad representa la anchura, o más precisamente, la medida de avance, del glifo '0' (cero, de caracter Unicode U+0030) en la fuente ({{Cssxref("font")}}) del elemento.
-- `rem`
-  - : Esta unidad representa el tamaño ({{Cssxref("font-size")}}) del elemento raíz (p.ej. el tamaño de fuente del elemento {{HTMLElement("html")}}). Cuando se aplica a {{Cssxref("font-size")}} del elemento raíz, representa su valor inicial.
+```html
+<div class="outer">
+  <div class="input-container">
+    <label for="length">Escribe un ancho:</label>
+    <input type="text" id="length" />
+  </div>
+  <div class="inner"></div>
+</div>
+<div class="results"></div>
+```
 
-    > [!NOTE]
-    > Esta unidad es práctica para crear interfaces perfectamente escalables. Si no es soportada por los navegadores, se puede recurrir a unidades **em**, aunque estas son ligeramente más complejas.
+#### CSS
 
-#### Longitudes de porcentaje del viewport
+```css
+html {
+  font-family: sans-serif;
+  font-weight: bold;
+  box-sizing: border-box;
+}
 
-Las longitudes de porcentaje del viewport definen una longitud relativa al tamaño del viewport, que es la porción visible del documento. Solamente los navegadores basados en Gecko actualizan los valores del viewport dinámicamente, cuando el tamaño de éste es modificado (al cambiar el tamaño de la ventana en una computadora de escritorio, o al girar el dispositivo, en teléfonos y tablets).
+.outer {
+  width: 100%;
+  height: 50px;
+  background-color: #eeeeee;
+  position: relative;
+}
 
-En conjunto con `overflow:auto`, el espacio tomado por barras de desplazamiento no es restado al tamaño del viewport, mientras en el caso de `overflow:scroll`, sí lo es.
+.inner {
+  height: 50px;
+  background-color: #999999;
+  box-shadow:
+    inset 3px 3px 5px rgb(255 255 255 / 50%),
+    inset -3px -3px 5px rgb(0 0 0 / 50%);
+}
 
-En un bloque de declaración de la regla-at {{cssxref("@page")}}, el uso de longitudes de viewport es inválido, y la declaración será desechada.
+.result {
+  height: 20px;
+  box-shadow:
+    inset 3px 3px 5px rgb(255 255 255 / 50%),
+    inset -3px -3px 5px rgb(0 0 0 / 50%);
+  background-color: orange;
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+}
 
-- `vh`
-  - : 1/100 de la altura del viewport.
-- `vw`
-  - : 1/100 de la anchura del viewport.
-- `vmin`
-  - : 1/100 del valor mínimo entre la altura y anchura del viewport.
-- `vmax`
-  - : 1/100 del valor máximo entre la altura y anchura del viewport.
+.result code {
+  position: absolute;
+  margin-left: 20px;
+}
 
-### Unidades de longitud absoluta
+.results {
+  margin-top: 10px;
+}
 
-Las unidades de longitud absoluta representan una medida física, y cuando las propiedades físicas del medio de salida son conocidas, como en diseño para impresión. Esto se hace anclando una de las unidades a una unidad física, y definiendo el resto con relación a ésta. La definición del ancla difiere entre dispositivos de baja resolución, como pantallas, y dispositivos de alta resolución, como impresoras.
+.input-container {
+  position: absolute;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  height: 50px;
+}
 
-Para dispositivos de ppp bajo, la unidad **px** representa el _píxel de referencia_ físico, y el resto son definidos con relación a éste. Así, `1in` es definido como `96px`, que equivalen a `72pt`. La consecuencia de esta definición es que en dichos dispositivos, las longitudes descritas en pulgadas (`in`), centrímetros (`cm`), milímetros (`mm`) no necesariamente conincidirán con la longitud de la unidad física del mismo nombre.
+label {
+  margin: 0 10px 0 20px;
+}
+```
 
-Para dispositivos de alto ppp, las pulgadas (`in`), centrímetros (`cm`), milímetros (`mm`) son definidos como su contraparte física. De esta forma, la unidad **px** es definida con relación a ellas (1/96 de 1 pulgada).
+#### JavaScript
 
-> [!NOTE]
-> Los usuarios pueden incrementar el tamaño de fuente por razones de accesibilidad. Para permitir interfaces usables sin importar el tamao de fuente, use únicamente unidades de longitud absolutas cuando las características físicas del medio de salida son conocidas, como imágenes de mapa de bits. Al establecer longitudes relacionadas al tamaño de fuente, es preferible usar unidades relativas, como `em` o `rem`.
+```js
+const inputDiv = document.querySelector(".inner");
+const inputElem = document.querySelector("input");
+const resultsDiv = document.querySelector(".results");
 
-- `px`
-  - : Relativa al dispositivo de visualización.
-    Para pantallas, generalmente es el tamaño de un píxel (punto) de la pantalla del dispositivo.
-    Para _impresoras_ y _pantallas de muy alta resolución_, un píxel CSS implica múltiples píxeles del dispositivo, de modo que el número de píxeles por pulgada se mantenga al rededor de 96.
-- `mm`
-  - : Un milímetro.
-- `q`
-  - : Un cuarto de milímetro (1/40° de centímetro).
-- `cm`
-  - : Un centímetro (10 milímetros).
-- `in`
-  - : Una pulgada (2.54 centímetros).
-- `pt`
-  - : Un punto (1/72° de pulgada).
-- `pc`
-  - : Una pica (12 puntos).
-- `mozmm` {{non-standard_inline}}
-  - : Una unidad experimental que intenta generar exactamente un milímetro, sin importar el tamaño de resolución de la pantalla. Esto raramente será lo que se desea, pero podría ser útil para dispositivos móviles, en particular.
+inputElem.addEventListener("change", () => {
+  inputDiv.style.width = inputElem.value;
 
-## Unidades CSS y puntos por pulgada (dots-per-inch)
+  const result = document.createElement("div");
+  result.className = "result";
+  result.style.width = inputElem.value;
+  const code = document.createElement("code");
+  code.textContent = `width: ${inputElem.value}`;
+  result.appendChild(code);
+  resultsDiv.appendChild(result);
 
-> [!NOTE]
-> La unidad `in` no representa una pulgada física en pantalla, sino `96px`. Esto significa que sin importar la densidad de píxeles real en pantalla, se asume que serán `96ppp`. En dispositivos con mayor densidad de píxeles, `1in` será menor que una pulgada física. De forma similar, `mm`, `cm`, y `pt` no son longitudes absolutas.
+  inputElem.value = "";
+  inputElem.focus();
+});
+```
 
-Algunos ejemplos específicos:
+#### Resultado
 
-- `1in` siempre son `96px,`
-- `3pt` siempre son `4px`,
-- `25.4mm` siempre son `96px.`
+{{EmbedLiveSample('Comparar distintas unidades de longitud', '100%', 700)}}
 
 ## Especificaciones
 
@@ -103,3 +320,9 @@ Algunos ejemplos específicos:
 ## Compatibilidad con navegadores
 
 {{Compat}}
+
+## Véase también
+
+- [Aprende: valores y unidades](/es/docs/Learn_web_development/Core/Styling_basics/Values_and_units)
+- Módulo [Valores y unidades de CSS](/es/docs/Web/CSS/Guides/Values_and_units)
+- [Modelo de caja](/es/docs/Web/CSS/Guides/Box_model)


### PR DESCRIPTION
### Description

Sincroniza las dos páginas de tablas del módulo `Structuring_content` que seguían muy por detrás de su fuente.

### Motivation

| Página | es antes | en | `l10n.sourceCommit` |
| --- | ---: | ---: | --- |
| `planet_data_table` | 65 | 311 | ausente |
| `table_accessibility` | 461 | 645 | ausente |

**`planet_data_table`** era prácticamente un esqueleto: faltaban el listado de datos en bruto, el CSS del ejemplo, los pasos del desafío y la solución completa. Además referenciaba `assessment-table.png`, una imagen que no existe ni en `files/es` ni en `files/en-us` (se retiró la referencia en #38441).

**`table_accessibility`** estaba desincronizada estructuralmente: el inglés reordenó y renombró las secciones, y adoptó la sintaxis `live-sample` (26 vallas frente a 14, con 3 ejemplos en vivo que el español no tenía).

### Verification

| | es | en |
| --- | ---: | ---: |
| `planet_data_table` encabezados / vallas / bloques / enlaces | 4 / 8 / 4 / 6 | 4 / 8 / 4 / 6 |
| `table_accessibility` encabezados / vallas / bloques / enlaces | 10 / 26 / 13 / 22 | 10 / 26 / 13 / 22 |
| `table_accessibility` diferencias de indentación | 0 | \_ |

`prettier --check` y `markdownlint-cli2` pasan.

### Decisiones de traducción

**Terminología de planetas reutilizada.** `planet_data_table` usa la misma que se fijó al sincronizar `HTML_table_basics` en #38425: `Mercurio`, `La Tierra`, `Los gigantes de gas`, `Los gigantes de hielo`, `Planetas enanos`, y el formato numérico español (coma decimal, punto de millares: `4.222,6`). Las dos páginas muestran la misma tabla, así que tenían que coincidir.

**`id` y `headers` se quedan en inglés.** En `table_accessibility` los valores `clothes`, `trousers`, `belgium`, `antwerp`… son identificadores que deben coincidir entre sí para que la asociación funcione; sólo se traduce el texto visible de las celdas (`Ropa`, `Pantalones`, `Bélgica`, `Amberes`). Traducir los `id` sin traducir los `headers`, o al revés, rompería justamente el mecanismo que el artículo enseña.

**Los identificadores de `live-sample` también se quedan en inglés** (`finished-table-structure`, `planet-data-table`), porque los referencia la macro `embedlivesample`.

### Nota sobre dos anclas

`mdn_review.py` marca dos fragmentos como inexistentes, pero es desfase de despliegue: los encabezados correspondientes ya están en `main` (`## Agrupar columnas con \`<colgroup>\` y \`<col>\`` tras #38425, y `## Aplicando CSS y JavaScript al HTML` tras #38311). Producción todavía no ha reconstruido esas páginas.

Con esto, las cuatro páginas que quedaban señaladas como desactualizadas durante el trabajo de #38407 están al día.