### PR TITLE
chore(fr): translation of `Web/API/Navigation/canGoForward`

### DIFF
--- a/files/fr/web/api/navigation/cangoforward/index.md
+++ b/files/fr/web/api/navigation/cangoforward/index.md
@@ -1,0 +1,52 @@
+---
+title: "Navigation : propriété canGoForward"
+short-title: canGoForward
+slug: Web/API/Navigation/canGoForward
+l10n:
+  sourceCommit: 7e14795a6ef2bf5e760c315ce64800dd1cd98c29
+---
+
+{{APIRef("Navigation API")}}
+
+La propriété en lecture seule **`canGoForward`** de l'interface {{DOMxRef("Navigation")}} retourne `true` s'il est possible de naviguer en avant dans l'historique de navigation (c'est-à-dire que la {{DOMxRef("Navigation.currentEntry", "currentEntry")}} n'est pas la dernière de la liste des entrées de l'historique), et `false` dans le cas contraire.
+
+## Valeur
+
+Une valeur booléenne — `true` s'il est possible de naviguer en avant dans l'historique de navigation, `false` dans le cas contraire.
+
+## Exemples
+
+```js
+async function gestionEnArriere() {
+  if (navigation.canGoBack) {
+    await navigation.back().finished;
+    // Gère tout nettoyage nécessaire après
+    // que la navigation est terminée
+  } else {
+    displayBanner("Vous êtes sur la première page");
+  }
+}
+
+async function gestionEnAvant() {
+  if (navigation.canGoForward) {
+    await navigation.forward().finished;
+    // Gère tout nettoyage nécessaire après
+    // que la navigation est terminée
+  } else {
+    displayBanner("Vous êtes sur la dernière page");
+  }
+}
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- [Routage moderne côté client&nbsp;: l'API Navigation <sup>(angl.)</sup>](https://developer.chrome.com/docs/web-platform/navigation-api/)
+- [Présentation de l'API Navigation <sup>(angl.)</sup>](https://github.com/WICG/navigation-api/blob/main/README.md)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/Navigation/canGoForward`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_