### PR TITLE
chore(fr): translation of `Web/API/Navigation/navigateerror_event`

### DIFF
--- a/files/fr/web/api/navigation/navigateerror_event/index.md
+++ b/files/fr/web/api/navigation/navigateerror_event/index.md
@@ -1,0 +1,61 @@
+---
+title: "Navigation : évènement navigateerror"
+short-title: navigateerror
+slug: Web/API/Navigation/navigateerror_event
+l10n:
+  sourceCommit: e7ffb2866dc8b67280801535c7f58bf073a5aaf9
+---
+
+{{APIRef("Navigation API")}}
+
+L'évènement **`navigateerror`** de l'interface {{DOMxRef("Navigation")}} est déclenché lorsqu'une navigation échoue.
+
+Par exemple, si le réseau est indisponible, toute méthode {{DOMxRef("Window/fetch", "fetch()")}} invoquée pour gérer une navigation échoue, et l'erreur est transmise à `navigateerror`.
+
+## Syntaxe
+
+Utilisez le nom de l'évènement dans des méthodes comme {{DOMxRef("EventTarget.addEventListener", "addEventListener()")}}, ou définissez une propriété de gestionnaire d'évènement.
+
+```js-nolint
+addEventListener("navigateerror", (event) => { })
+
+onnavigateerror = (event) => { }
+```
+
+## Type d'évènement
+
+Un objet {{DOMxRef("ErrorEvent")}}. Hérite de {{DOMxRef("Event")}}.
+
+{{InheritanceDiagram("ErrorEvent")}}
+
+## Exemples
+
+Vous pouvez gérer une navigation réussie en masquant un indicateur de progression précédemment affiché, comme ceci&nbsp;:
+
+```js
+navigation.addEventListener("navigatesuccess", (event) => {
+  loadingIndicator.hidden = true;
+});
+```
+
+Ou vous pouvez afficher un message d'erreur en cas d'échec&nbsp;:
+
+```js
+navigation.addEventListener("navigateerror", (event) => {
+  loadingIndicator.hidden = true; // masque également l'indicateur
+  showMessage(`Failed to load page: ${event.message}`);
+});
+```
+
+## Spécifications
+
+{{Specifications}}
+
+## Compatibilité des navigateurs
+
+{{Compat}}
+
+## Voir aussi
+
+- [Routage moderne côté client&nbsp;: l'API Navigation <sup>(angl.)</sup>](https://developer.chrome.com/docs/web-platform/navigation-api/)
+- [Présentation de l'API Navigation <sup>(angl.)</sup>](https://github.com/WICG/navigation-api/blob/main/README.md)


### PR DESCRIPTION
### Description

Create translation of pages without french version: `Web/API/Navigation/navigateerror_event`

### Motivation

Create access to the french community of translated content.

### Additional details

_none_

### Related issues and pull requests

_none_