### PR TITLE
fix(es): deja de enlazar a las copias archivadas de Structuring_content

### DIFF
--- a/files/es/learn_web_development/core/accessibility/html/index.md
+++ b/files/es/learn_web_development/core/accessibility/html/index.md
@@ -14,7 +14,7 @@ Se puede hacer accesible una gran cantidad de contenido web solo asegurándose d
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimiento básico de informática, entendimiento básico de HTML (ver
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
         >), y entendimiento de
         <a href="/es/docs/Learn_web_development/Core/Accessibility/What_is_accessibility"

--- a/files/es/learn_web_development/core/css_layout/flexbox/index.md
+++ b/files/es/learn_web_development/core/css_layout/flexbox/index.md
@@ -14,7 +14,7 @@ original_slug: Learn/CSS/CSS_layout/Flexbox
       <th scope="row">Prerrequisitos:</th>
       <td>
         Los conceptos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).

--- a/files/es/learn_web_development/core/css_layout/floats/index.md
+++ b/files/es/learn_web_development/core/css_layout/floats/index.md
@@ -14,7 +14,7 @@ Originalmente pensada para flotar imágenes dentro de bloques de texto, la propi
       <th scope="row">Requisitos previos:</th>
       <td>
         HTML básico (ver
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >), y una idea de Cómo funciona CSS (ver
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción a CSS</a>.)

--- a/files/es/learn_web_development/core/css_layout/grids/index.md
+++ b/files/es/learn_web_development/core/css_layout/grids/index.md
@@ -14,7 +14,7 @@ La compaginación en cuadrícula con CSS es un método de diseño de páginas we
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y una idea de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).

--- a/files/es/learn_web_development/core/css_layout/index.md
+++ b/files/es/learn_web_development/core/css_layout/index.md
@@ -12,7 +12,7 @@ Llegados a este punto, hemos examinado los fundamentos básicos de CSS: cómo da
 
 Antes de comenzar este módulo, ya deberías:
 
-1. Estar familiarizado con HTML, como se expone en el módulo [Introduction to HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content).
+1. Estar familiarizado con HTML, como se expone en el módulo [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content).
 2. Sentirte cómodo con los fundamentos de CSS, que se discuten en [Introduction to CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics).
 3. Entender como diseñar cajas [style boxes](/es/docs/Learn_web_development/Core/Styling_basics).
 

--- a/files/es/learn_web_development/core/css_layout/introduction/index.md
+++ b/files/es/learn_web_development/core/css_layout/introduction/index.md
@@ -14,7 +14,7 @@ Este artículo resumirá algunas de las características de diseño de páginas 
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).

--- a/files/es/learn_web_development/core/css_layout/responsive_design/index.md
+++ b/files/es/learn_web_development/core/css_layout/responsive_design/index.md
@@ -14,7 +14,7 @@ En los primeros días del diseño web, las páginas se diseñaban para llenar un
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos en CSS</a> y

--- a/files/es/learn_web_development/core/css_layout/supporting_older_browsers/index.md
+++ b/files/es/learn_web_development/core/css_layout/supporting_older_browsers/index.md
@@ -16,7 +16,7 @@ En este módulo recomendamos utilizar Flexbox y Grid como las herramientas princ
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conceptos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>).

--- a/files/es/learn_web_development/core/scripting/index.md
+++ b/files/es/learn_web_development/core/scripting/index.md
@@ -16,7 +16,7 @@ Hemos reunido un curso que incluye toda la información esencial que necesitas p
 
 ## Pre-requisitos
 
-Antes de empezar este módulo, deberías ya tener alguna familiaridad con lo básico de [HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content) y [CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics), y también deberías haber trabajado todos lo módulos previos, [JavaScript primeros pasos](/es/docs/conflicting/Learn_web_development/Core/Scripting).
+Antes de empezar este módulo, deberías ya tener alguna familiaridad con lo básico de [HTML](/es/docs/Learn_web_development/Core/Structuring_content) y [CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics), y también deberías haber trabajado todos lo módulos previos, [JavaScript primeros pasos](/es/docs/conflicting/Learn_web_development/Core/Scripting).
 
 > [!NOTE]
 > Si estas trabajando en una computadora/tablet/otro dispositivo donde no tienes la capacidad de crear tus propios archivos, podrías practicar (la mayoría de) los ejemplos de código en un programa en linea tales como [JSBin](https://jsbin.com/) o [Glitch](https://glitch.com/).

--- a/files/es/learn_web_development/core/structuring_content/advanced_text_features/index.md
+++ b/files/es/learn_web_development/core/structuring_content/advanced_text_features/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Advanced_text_features
 original_slug: Learn/HTML/Introduction_to_HTML/Advanced_text_formatting
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Creating_links", "Learn_web_development/Core/Structuring_content/Structuring_documents", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Creating_links", "Learn_web_development/Core/Structuring_content/Structuring_documents", "Learn_web_development/Core/Structuring_content")}}
 
 Hay muchos otros elementos en HTML para dar formato al texto, que no expusimos en el artículo [Fundamentos de texto HTML](/es/docs/Learn_web_development/Core/Structuring_content/Headings_and_paragraphs). Los elementos descritos en este artículo son menos conocidos, pero aún así es muy útil conocerlos (no obstante, no es una lista completa de ninguna manera). Aquí aprenderás cómo marcar citas, listas de descripción, código de computadora y otro texto relacionado, subíndices y superíndices, información de contacto y mucho más.
 
@@ -775,4 +775,4 @@ Has llegado al final de este artículo, pero ¿puedes recordar la información m
 
 Esto marca el final de nuestro estudio de la semántica del texto HTML. Ten en cuenta que lo que has visto durante este curso no es una lista exhaustiva de elementos de texto HTML — quisimos tratar de cubrir los aspectos esenciales y algunos de los más comunes que verás en la naturaleza, o al menos podrían resultarte interesantes. Para encontrar muchos más elementos HTML, puedes echarle un vistazo a nuestra [referencia de elementos HTML](/es/docs/Web/HTML/Reference/Elements) (la [La sección Semántica de texto en línea](/es/docs/Web/HTML/Reference/Elements#inline_text_semantics) sería un gran lugar para comenzar). En el próximo artículo veremos los elementos HTML que usarás para estructurar las diferentes partes de un documento HTML.
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Creating_links", "Learn_web_development/Core/Structuring_content/Structuring_documents", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Creating_links", "Learn_web_development/Core/Structuring_content/Structuring_documents", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/basic_html_syntax/index.md
+++ b/files/es/learn_web_development/core/structuring_content/basic_html_syntax/index.md
@@ -6,7 +6,7 @@ l10n:
   sourceCommit: 194ea6cb5ddaf20e4f551cc93574be50b8b4f339
 ---
 
-{{LearnSidebar}}{{NextMenu("Learn_web_development/Core/Structuring_content/Webpage_metadata", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{LearnSidebar}}{{NextMenu("Learn_web_development/Core/Structuring_content/Webpage_metadata", "Learn_web_development/Core/Structuring_content")}}
 
 En este artículo, cubrimos los conceptos básicos de HTML. Para empezar, este artículo define elementos, atributos y todos los demás términos importantes que puedas haber escuchado. También explica dónde encajan en HTML. Aprenderás cómo se estructuran los elementos HTML, cómo se estructura una página HTML típica y otras características importantes del lenguaje básico. ¡En el camino, también tendrás la oportunidad de jugar con HTML!
 
@@ -767,4 +767,4 @@ En este punto, debes entender cómo se ve HTML y cómo funciona a un nivel bási
 
 - [Aplicar color a elementos HTML usando CSS](/es/docs/Web/CSS/CSS_colors/Applying_color)
 
-{{NextMenu("Learn_web_development/Core/Structuring_content/Webpage_metadata", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{NextMenu("Learn_web_development/Core/Structuring_content/Webpage_metadata", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/creating_links/index.md
+++ b/files/es/learn_web_development/core/structuring_content/creating_links/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Creating_links
 original_slug: Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Headings_and_paragraphs", "Learn_web_development/Core/Structuring_content/Advanced_text_features", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Headings_and_paragraphs", "Learn_web_development/Core/Structuring_content/Advanced_text_features", "Learn_web_development/Core/Structuring_content")}}
 
 Los hipervínculos (o enlaces) son elementos verdaderamente importantes — son los que hacen que la web sea _**web**_. Este artículo expone la sintaxis necesaria para crear un enlace, además contiene un catálogo de buenas prácticas para crearlos.
 
@@ -341,4 +341,4 @@ Has llegado al final de este artículo, pero ¿puedes recordar la información m
 
 Eso es todo en cuanto a enlaces, ¡por ahora! Volveremos a ellos más tarde en este curso cuando comencemos a usar estilos. Lo siguiente en HTML, será aprender la semántica de texto para usar algunas características avanzadas/inusuales que nos serán utilidad — Formato de texto avanzado será la próxima parada.
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Headings_and_paragraphs", "Learn_web_development/Core/Structuring_content/Advanced_text_features", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Headings_and_paragraphs", "Learn_web_development/Core/Structuring_content/Advanced_text_features", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/general_embedding_technologies/index.md
+++ b/files/es/learn_web_development/core/structuring_content/general_embedding_technologies/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/General_embedding_technolog
 original_slug: Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_video_and_audio", "Learn_web_development/Core/Structuring_content/Including_vector_graphics_in_HTML", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_video_and_audio", "Learn_web_development/Core/Structuring_content/Including_vector_graphics_in_HTML", "Learn_web_development/Core/Structuring_content")}}
 
 Ahora ya deberías estar acostumbrado a integrar cosas en tus páginas web, incluyendo imágenes, video y audio. En este punto nos gustaría que des algo así como un paso al costado, prestando atención a elementos que te permiten integrar una amplia variedad de tipos de contenido en tus páginas web: los elementos {{htmlelement("iframe")}}, {{htmlelement("embed")}} y {{htmlelement("object")}}. Los `<iframe>`s son para incrustar otras páginas web, y los otros dos te permiten incrustar PDFs, SVG e incluso Flash — una tecnología que está en su camino de despedida, pero la cual seguirás viendo semi-regularmente.
 
@@ -360,4 +360,4 @@ The topic of embedding other content in web documents can quickly become very co
 
 There are many other technologies that involve embedding external content besides the ones we discussed here. We saw some in earlier articles, such as {{htmlelement("video")}}, {{htmlelement("audio")}}, and {{htmlelement("img")}}, but there are others to discover, such as {{htmlelement("canvas")}} for JavaScript-generated 2D and 3D graphics, and {{htmlelement("svg")}} for embedding vector graphics. We'll look at [SVG](/es/docs/Web/SVG) in the next article of the module.
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_video_and_audio", "Learn_web_development/Core/Structuring_content/Including_vector_graphics_in_HTML", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_video_and_audio", "Learn_web_development/Core/Structuring_content/Including_vector_graphics_in_HTML", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/headings_and_paragraphs/index.md
+++ b/files/es/learn_web_development/core/structuring_content/headings_and_paragraphs/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Headings_and_paragraphs
 original_slug: Learn/HTML/Introduction_to_HTML/HTML_text_fundamentals
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Webpage_metadata", "Learn_web_development/Core/Structuring_content/Creating_links", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Webpage_metadata", "Learn_web_development/Core/Structuring_content/Creating_links", "Learn_web_development/Core/Structuring_content")}}
 
 Una de las principales funciones de HTML es dar al texto estructura y significado (también conocido como {{Glossary("semantics", "semántica")}}), de forma que un navegador pueda mostrarlo correctamente. Este articulo explica la forma en que se puede usar {{Glossary("HTML")}} para estructurar una página de texto añadiendo encabezados y párrafos, enfatizando palabras, creando listas y más.
 
@@ -1024,4 +1024,4 @@ Has llegado al final de este artículo, pero ¿puedes recordar la información m
 
 ¡Eso es todo por ahora! Este artículo debería haberte dado una buena idea de cómo comenzar a marcar texto en HTML y te ha presentado algunos de los elementos más importantes en este ámbito. Hay muchos más elementos semánticos para desarrollar en esta área, y veremos muchos más en nuestro artículo [Formateo de texto avanzado](/es/docs/Learn_web_development/Core/Structuring_content/Advanced_text_features), más adelante en el curso. En el siguiente artículo, veremos en detalle cómo [crear hipervínculos](/es/docs/Learn_web_development/Core/Structuring_content/Creating_links), posiblemente el más importante elemento en la web.
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Webpage_metadata", "Learn_web_development/Core/Structuring_content/Creating_links", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Webpage_metadata", "Learn_web_development/Core/Structuring_content/Creating_links", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/html_images/index.md
+++ b/files/es/learn_web_development/core/structuring_content/html_images/index.md
@@ -6,7 +6,7 @@ original_slug: Learn/HTML/Multimedia_and_embedding/Images_in_HTML
 
 {{LearnSidebar}}
 
-{{NextMenu("Learn_web_development/Core/Structuring_content/HTML_video_and_audio", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{NextMenu("Learn_web_development/Core/Structuring_content/HTML_video_and_audio", "Learn_web_development/Core/Structuring_content")}}
 
 Al principio, la web solo era texto y resultaba más bien aburrido. Afortunadamente, no pasó mucho tiempo antes de que se añadiera la capacidad de insertar imágenes (y otros tipos de contenido más interesantes) en las páginas web. Hay otros tipos de elementos multimedia que tener en cuenta, pero es lógico comenzar con el humilde elemento {{htmlelement("img")}} utilizado para insertar una imagen simple en una página web. En este artículo, veremos en detalle cómo usar este elemento, incluidos sus conceptos básicos y cómo añadir pies de imagen usando {{htmlelement("figure")}} y explicaremos cómo se relaciona con las imágenes de fondo en <a class="glossaryLink" href="/es/docs/Glossary/CSS" title="CSS: CSS (Cascading Style Sheets) is a declarative language that controls how webpages look in the browser.">CSS</a>.
 
@@ -525,4 +525,4 @@ En resumen: si una imagen tiene significado en términos del contenido de tu pá
 
 Esto es todo por ahora. Hemos expuesto en detalle los conceptos relativos a imágenes y subtítulos de imagen. En el próximo artículo, subiremos un nivel para insertar vídeo y audio en páginas web con HTML.
 
-{{NextMenu("Learn_web_development/Core/Structuring_content/HTML_video_and_audio", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{NextMenu("Learn_web_development/Core/Structuring_content/HTML_video_and_audio", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/html_video_and_audio/index.md
+++ b/files/es/learn_web_development/core/structuring_content/html_video_and_audio/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/HTML_video_and_audio
 original_slug: Learn/HTML/Multimedia_and_embedding/Video_and_audio_content
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_images", "Learn_web_development/Core/Structuring_content/General_embedding_technologies", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_images", "Learn_web_development/Core/Structuring_content/General_embedding_technologies", "Learn_web_development/Core/Structuring_content")}}
 
 Ahora que estamos cómodos añadiendo imágenes simples a una página web, el siguiente paso será empezar a agregar reproductores de audio y video a tu documento HTML. En este artículo veremos cómo hacerlo con los elementos {{htmlelement("video")}} y {{htmlelement("audio")}}; luego terminaremos viendo como agregar subtítulos a nuestros videos.
 
@@ -319,4 +319,4 @@ Y con esto terminamos; ¡esperamos que te hayas divertido jugando con vídeo y a
 - [Manipulación de audio y vídeo](/es/docs/Web/Media/Audio_and_video_manipulation): Un montón de detalles sobre la manipulación de audio y vídeo utilizando JavaScript (por ejemplo, la adición de filtros.)
 - Opciones automatizadas para [traducir multimedia](http://www.inwhatlanguage.com/blog/translate-video-audio/).
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_images", "Learn_web_development/Core/Structuring_content/General_embedding_technologies", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/HTML_images", "Learn_web_development/Core/Structuring_content/General_embedding_technologies", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/including_vector_graphics_in_html/index.md
+++ b/files/es/learn_web_development/core/structuring_content/including_vector_graphics_in_html/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Including_vector_graphics_i
 original_slug: Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/General_embedding_technologies", "Web/HTML/Guides/Responsive_images", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/General_embedding_technologies", "Web/HTML/Guides/Responsive_images", "Learn_web_development/Core/Structuring_content")}}
 
 Los gráficos vectoriales son muy útiles en muchas circunstancias — tienen tamaño de archivo pequeños y son altamente escalables, por lo que no se pixelan cuando se amplían a un tamaño más grande. En este artículo le mostraremos cómo incluir uno en su página web.
 
@@ -14,7 +14,7 @@ Los gráficos vectoriales son muy útiles en muchas circunstancias — tienen ta
       <th scope="row">Prerequisitos:</th>
       <td>
         Debe conocer los
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >conceptos básicos de HTML</a
         >
         y cómo
@@ -342,4 +342,4 @@ En el próximo artículo de este módulo, exploraremos las imágenes adaptables 
 - [Beneficios de accesibilidad de SVG](https://www.w3.org/TR/SVG-access/)
 - [Cómo escalar SVGs](https://css-tricks.com/scale-svg/) (¡no es tan simple como los gráficos rasterizados!)
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/General_embedding_technologies", "Web/HTML/Guides/Responsive_images", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/General_embedding_technologies", "Web/HTML/Guides/Responsive_images", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/marking_up_a_letter/index.md
+++ b/files/es/learn_web_development/core/structuring_content/marking_up_a_letter/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Marking_up_a_letter
 original_slug: Learn/HTML/Introduction_to_HTML/Marking_up_a_letter
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Debugging_HTML", "Learn_web_development/Core/Structuring_content/Structuring_a_page_of_content", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Debugging_HTML", "Learn_web_development/Core/Structuring_content/Structuring_a_page_of_content", "Learn_web_development/Core/Structuring_content")}}
 
 Todos aprendemos a escribir una carta más tarde o más temprano; es también práctico practicar con nuestras habilidades para dar forma a los textos. En esta prueba deberás demostrar tus habilidades para dar forma a textos, incluyendo enlaces, además pondremos a prueba tu familiaridad con algunos contenidos de encabezamiento `<head>` en HTML.
 
@@ -93,4 +93,4 @@ La siguiente captura de pantalla muestra un ejemplo de cómo se vería la carta 
 
 Si estás haciendo esta prueba como parte de un curso organizado, deberías entregar tu trabajo al profesor para que lo corrija. Si estás auto-aprendiendo puedes conseguir la guía de corrección fácilmente pidiendola en el [Hilo del area de aprendizaje](https://discourse.mozilla-community.org/t/learning-web-development-marking-guides-and-questions/16294), o en el canal IRC de [#mdn](irc://irc.mozilla.org/mdn) en [Mozilla IRC](https://wiki.mozilla.org/IRC). Intenta hacerlo primero — no ganarás nada haciendo trampas.
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Debugging_HTML", "Learn_web_development/Core/Structuring_content/Structuring_a_page_of_content", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Debugging_HTML", "Learn_web_development/Core/Structuring_content/Structuring_a_page_of_content", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/splash_page/index.md
+++ b/files/es/learn_web_development/core/structuring_content/splash_page/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Splash_page
 original_slug: Learn_web_development/Core/Structuring_content/Mozilla_splash_page
 ---
 
-{{LearnSidebar}}{{PreviousMenu("Web/HTML/Guides/Responsive_images", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{LearnSidebar}}{{PreviousMenu("Web/HTML/Guides/Responsive_images", "Learn_web_development/Core/Structuring_content")}}
 
 En esta evaluación, pondremos a prueba tu conocimiento de algunas de las técnicas mostradas en los artículos de este módulo, ¡para que tú agregues algunas imágenes y videos a una página de bienvenida de Mozzilla!.
 
@@ -14,7 +14,7 @@ En esta evaluación, pondremos a prueba tu conocimiento de algunas de las técni
       <th scope="row">Requisitos previos:</th>
       <td>
         Antes de intentar esta evaluación, ya deberías conocer el módulo de
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Multimedia e inserción</a
         >.
       </td>
@@ -103,4 +103,4 @@ Si quieres evaluar tu trabajo, estás atorado o quieres pedir ayuda:
    - Un enlace al ejemplo que deseas evaluar o en el que necesitas ayuda, en un editor en línea. Ésta es una buena práctica: es muy difícil ayudar a alguien con un problema de codificación si no puede ver su código.
    - Un enlace a la página de evaluación actual, para que podamos encontrar la pregunta con la que desea ayuda.
 
-{{PreviousMenu("Web/HTML/Guides/Responsive_images", "conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b")}}
+{{PreviousMenu("Web/HTML/Guides/Responsive_images", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/structuring_a_page_of_content/index.md
+++ b/files/es/learn_web_development/core/structuring_content/structuring_a_page_of_content/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Structuring_a_page_of_conte
 original_slug: Learn/HTML/Introduction_to_HTML/Structuring_a_page_of_content
 ---
 
-{{LearnSidebar}}{{PreviousMenu("Learn_web_development/Core/Structuring_content/Marking_up_a_letter", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{LearnSidebar}}{{PreviousMenu("Learn_web_development/Core/Structuring_content/Marking_up_a_letter", "Learn_web_development/Core/Structuring_content")}}
 
 La estructuración de una página de contenido lista para su uso mediante CSS es una habilidad muy importante para dominar, por lo que en esta evaluación verá su capacidad para pensar en cómo podría finalizar una página buscando y eligiendo la semántica estructural adecuada para construir un diseño en la parte superior.
 
@@ -90,4 +90,4 @@ La siguiente captura de pantalla muestra un ejemplo de cómo podría verse la le
 
 Si está siguiendo esta evaluación como parte de un curso organizado, debe ser capaz de dar su trabajo a su maestro / mentor para el marcado. Si usted está aprendiendo por si mismo, entonces puede obtener la guía de marcado con bastante facilidad preguntando sobre ello en la lista de correo [dev-mdc](https://lists.mozilla.org/listinfo/dev-mdc), o en el canal IRC [#mdn](irc://irc.mozilla.org/mdn) en [Mozilla IRC](https://wiki.mozilla.org/IRC). Pruebe a hacer el ejercicio primero - ¡No hay nada que ganar por hacer trampa!
 
-{{PreviousMenu("Learn_web_development/Core/Structuring_content/Marking_up_a_letter", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenu("Learn_web_development/Core/Structuring_content/Marking_up_a_letter", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/structuring_content/structuring_documents/index.md
+++ b/files/es/learn_web_development/core/structuring_content/structuring_documents/index.md
@@ -4,7 +4,7 @@ slug: Learn_web_development/Core/Structuring_content/Structuring_documents
 original_slug: Learn/HTML/Introduction_to_HTML/Document_and_website_structure
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Advanced_text_features", "Learn_web_development/Core/Structuring_content/Debugging_HTML", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Advanced_text_features", "Learn_web_development/Core/Structuring_content/Debugging_HTML", "Learn_web_development/Core/Structuring_content")}}
 
 Además de definir partes individuales de tu página (como un párrafo o una imagen), {{Glossary("HTML")}} también dispone de elementos de bloque que se pueden utilizar para estructurar las distintas áreas de tu sito web (tal como el encabezado, el menú de navegación o la parte del contenido principal. En este artículo veras cómo planificar una estructura básica de página web y escribirás el HTML que representa esa estructura.
 
@@ -328,4 +328,4 @@ En este punto, deberías tener una mejor idea sobre cómo estructurar una págin
 
 - [Uso de secciones y esquemas HTML](/es/docs/Web/HTML/Reference/Elements/Heading_Elements): Guía avanzada de elementos semánticos HTML5 y el algoritmo de esquema HTML5.
 
-{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Advanced_text_features", "Learn_web_development/Core/Structuring_content/Debugging_HTML", "conflicting/Learn_web_development/Core/Structuring_content")}}
+{{PreviousMenuNext("Learn_web_development/Core/Structuring_content/Advanced_text_features", "Learn_web_development/Core/Structuring_content/Debugging_HTML", "Learn_web_development/Core/Structuring_content")}}

--- a/files/es/learn_web_development/core/styling_basics/attribute_selectors/index.md
+++ b/files/es/learn_web_development/core/styling_basics/attribute_selectors/index.md
@@ -22,7 +22,7 @@ Como ya explicamos en los artículos de HTML, los elementos pueden tener atribut
           href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
+++ b/files/es/learn_web_development/core/styling_basics/backgrounds_and_borders/index.md
@@ -23,7 +23,7 @@ En este artículo, veremos algunas de las cosas creativas que puedes hacer con l
           href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con el CSS</a>).

--- a/files/es/learn_web_development/core/styling_basics/basic_selectors/index.md
+++ b/files/es/learn_web_development/core/styling_basics/basic_selectors/index.md
@@ -22,7 +22,7 @@ En {{Glossary( "CSS")}} los selectores se utilizan para delimitar los elementos 
           href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y una idea de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/box_model/index.md
+++ b/files/es/learn_web_development/core/styling_basics/box_model/index.md
@@ -22,7 +22,7 @@ Todo en CSS tiene una caja alrededor, y comprender estas cajas es clave para pod
         <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).

--- a/files/es/learn_web_development/core/styling_basics/debugging_css/index.md
+++ b/files/es/learn_web_development/core/styling_basics/debugging_css/index.md
@@ -23,7 +23,7 @@ Al escribir CSS te puedes encontrar que, a veces, alguna parte de tu CSS no hace
           href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/getting_started/index.md
+++ b/files/es/learn_web_development/core/styling_basics/getting_started/index.md
@@ -23,7 +23,7 @@ En este artículo aplicaremos CSS a un documento HTML sencillo para aprender alg
           >trabajo con archivos</a
         >
         y conceptos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/handling_conflicts/index.md
+++ b/files/es/learn_web_development/core/styling_basics/handling_conflicts/index.md
@@ -25,7 +25,7 @@ A medida que avances en este apartado verás que puede resultar menos relevante 
           >trabajar con archivos</a
         >, HTML básico (véase
         <a
-          href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+          href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
         >) y una idea de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).

--- a/files/es/learn_web_development/core/styling_basics/images_media_forms/index.md
+++ b/files/es/learn_web_development/core/styling_basics/images_media_forms/index.md
@@ -23,7 +23,7 @@ En este artículo vamos a ver cómo se tratan ciertos elementos especiales en CS
           href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/index.md
+++ b/files/es/learn_web_development/core/styling_basics/index.md
@@ -17,7 +17,7 @@ Antes de comenzar este módulo deberías poseer:
 1. Un entendimiento básico de la utilización de una computadora y de la
    navegación web a nivel de usuario.
 2. Un entorno básico constituido en base a lo dispuesto en la guía [Instalación de software básico](/es/docs/Learn_web_development/Getting_started/Environment_setup/Installing_software), tanto como conocimiento acerca de la creación y la administración de archivos, como es detallado en [Dealing with files](/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files).
-3. Una familiaridad básica con html, como es establecido en el módulo [Introdución a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content).
+3. Una familiaridad básica con html, como es establecido en el módulo [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content).
 4. Un entendimiento elemental de CSS, como es discutido en el módulo [CSS first steps](/es/docs/conflicting/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]

--- a/files/es/learn_web_development/core/styling_basics/overflow/index.md
+++ b/files/es/learn_web_development/core/styling_basics/overflow/index.md
@@ -22,7 +22,7 @@ En este artículo veremos otro concepto importante en CSS: el **desbordamiento**
         <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, conocimientos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y nociones de CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con el CSS</a>).

--- a/files/es/learn_web_development/core/styling_basics/pseudo_classes_and_elements/index.md
+++ b/files/es/learn_web_development/core/styling_basics/pseudo_classes_and_elements/index.md
@@ -22,7 +22,7 @@ El conjunto de selectores que estudiaremos en este artículo se conocen como **p
           href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con el CSS</a>).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/sizing/index.md
+++ b/files/es/learn_web_development/core/styling_basics/sizing/index.md
@@ -23,7 +23,7 @@ En los diversos artículos vistos hasta ahora, has aprendido varias formas de di
           href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con CSS</a>).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/styling_a_bio_page/index.md
+++ b/files/es/learn_web_development/core/styling_basics/styling_a_bio_page/index.md
@@ -15,7 +15,7 @@ Con las cosas que has aprendido en las últimas lecciones, puedes darle formato 
       <td>
         Antes de intentar esta evaluación, deberías haber trabajado a través del
         módulo de CSS básico, y también comprender HTML básico (estudia la
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
         >).
       </td>

--- a/files/es/learn_web_development/core/styling_basics/values_and_units/index.md
+++ b/files/es/learn_web_development/core/styling_basics/values_and_units/index.md
@@ -22,7 +22,7 @@ Todas las propiedades que se utilizan en CSS tienen un valor o un conjunto de va
         <a href="/es/docs/Learn_web_development/Getting_started/Environment_setup/Dealing_with_files"
           >trabajar con archivos</a
         >, HTML básico (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción a HTML</a
         >) y nociones de cómo funciona el CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Primeros pasos con el CSS</a>).

--- a/files/es/learn_web_development/core/styling_basics/what_is_css/index.md
+++ b/files/es/learn_web_development/core/styling_basics/what_is_css/index.md
@@ -25,7 +25,7 @@ Hemos aprendido los conceptos básicos de CSS, para qué sirve y cómo escribir 
           >trabajar con archivos</a
         >
         y conceptos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">Introducción a HTML</a
         >).
       </td>
     </tr>

--- a/files/es/learn_web_development/core/text_styling/index.md
+++ b/files/es/learn_web_development/core/text_styling/index.md
@@ -10,7 +10,7 @@ Con los conceptos básicos del lenguaje CSS cubiertos, el siguiente tema de CSS 
 
 ## Requisitos previos
 
-Antes de iniciar este módulo, ya debe estár familizarizado con HTML, como se explica en el módulo [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content), y sentirse cómodo con los fundamentos de CSS, como se explica en [Introducción a CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics).
+Antes de iniciar este módulo, ya debe estár familizarizado con HTML, como se explica en el módulo [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content), y sentirse cómodo con los fundamentos de CSS, como se explica en [Introducción a CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics).
 
 > [!NOTE]
 > Si está trabajando en una computadora/tableta/u otro dispositivo donde no tenga la capacidad de crear sus propios archivos, puede probar (la mayoría) de los ejemplos de código en un programa de codificación en línea como [JSBin](https://jsbin.com/), [CodePen](https://codepen.io/) o [Glitch](https://glitch.com/).

--- a/files/es/learn_web_development/core/text_styling/styling_links/index.md
+++ b/files/es/learn_web_development/core/text_styling/styling_links/index.md
@@ -14,7 +14,7 @@ A la hora de dar estilo a los [enlaces](/es/docs/Learn_web_development/Core/Stru
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática, conceptos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >), conocimientos básicos de CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>),

--- a/files/es/learn_web_development/core/text_styling/styling_lists/index.md
+++ b/files/es/learn_web_development/core/text_styling/styling_lists/index.md
@@ -15,7 +15,7 @@ Las [listas](/es/docs/Learn_web_development/Core/Structuring_content/Headings_an
       <td>
         Conocimientos básicos de informática, conocimientos básicos de HTML
         (estudio
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">introducción a HTML</a
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">introducción a HTML</a
         >), nociones de cómo trabaja con CSS (estudio
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">introducción a CSS</a>),
         <a href="/es/docs/Learn_web_development/Core/Text_styling/Fundamentals"

--- a/files/es/learn_web_development/core/text_styling/web_fonts/index.md
+++ b/files/es/learn_web_development/core/text_styling/web_fonts/index.md
@@ -14,7 +14,7 @@ En el primer artículo del módulo, exploramos las características básicas del
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática, conceptos básicos de HTML (véase
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >Introducción al HTML</a
         >) y de CSS (véase
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">Introducción al CSS</a>),

--- a/files/es/learn_web_development/extensions/advanced_javascript_objects/index.md
+++ b/files/es/learn_web_development/extensions/advanced_javascript_objects/index.md
@@ -16,7 +16,7 @@ Hemos puesto un curso que incluye toda la información esencial que necesitas pa
 
 ## Prerrequisitos
 
-Antes de empezar este módulo deberías estar familiarizado con {{Glossary("HTML")}} and {{Glossary("CSS")}}. Te aconsejamos trabajar los módulos [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content) y [Introducción a CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics) antes de empezar con JavaScript.
+Antes de empezar este módulo deberías estar familiarizado con {{Glossary("HTML")}} and {{Glossary("CSS")}}. Te aconsejamos trabajar los módulos [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content) y [Introducción a CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics) antes de empezar con JavaScript.
 
 También deberías conocer lo básico de Javascript antes de entrar en detalle en los objetos de Javascript. Antes de empezar este módulo, revisa [Primeros pasos con JavaScript](/es/docs/conflicting/Learn_web_development/Core/Scripting) y [Elementos básicos de JavaScript](/es/docs/Learn_web_development/Core/Scripting).
 

--- a/files/es/learn_web_development/extensions/forms/basic_native_form_controls/index.md
+++ b/files/es/learn_web_development/extensions/forms/basic_native_form_controls/index.md
@@ -14,7 +14,7 @@ En el [artículo anterior](/es/docs/Learn_web_development/Extensions/Forms/How_t
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática y de
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">lenguaje HTML</a>.
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">lenguaje HTML</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
+++ b/files/es/learn_web_development/extensions/forms/how_to_structure_a_web_form/index.md
@@ -14,7 +14,7 @@ Una vez examinados los conceptos básicos, vamos a ver más en detalle los eleme
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática y de
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">lenguajes HTML</a>.
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">lenguajes HTML</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/extensions/forms/index.md
+++ b/files/es/learn_web_development/extensions/forms/index.md
@@ -12,7 +12,7 @@ Este módulo provee una serie de artículos que te ayudarán a dominar los conoc
 
 ## Prerrequisitos
 
-Antes de comenzar este módulo, deberías al menos completar nuestra [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content). Hasta este punto, deberías ser capaz de comprender fácilmente las [Guías Introductorias](#guías_introductorias), y también ser capaz de usar nuestra guía de [Controles de formulario nativos básicos](/es/docs/Learn_web_development/Extensions/Forms/Basic_native_form_controls).
+Antes de comenzar este módulo, deberías al menos completar nuestra [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content). Hasta este punto, deberías ser capaz de comprender fácilmente las [Guías Introductorias](#guías_introductorias), y también ser capaz de usar nuestra guía de [Controles de formulario nativos básicos](/es/docs/Learn_web_development/Extensions/Forms/Basic_native_form_controls).
 
 Sin embargo para dominar los formularios, se require mas que conocimiento en HTML — también necesitas aprender algunas técnicas específicas para estlizar los controles del formulario, y es necesario un poco de conocimiento de _scripting_ para manejar cosas como, validación y creación de controles personalizados. Por lo tanto, antes de que revises las secciones listadas a continuación, te recomendamos que primero vayas y aprendas un poco acerca de [CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics_b957eec7deaf1ea2b20721d6838ea6e1) y [JavaScript](/es/docs/conflicting/Learn_web_development/Core/Scripting_41cf930b8cfd2b83c76f8086a5e24792).
 

--- a/files/es/learn_web_development/extensions/forms/sending_and_retrieving_form_data/index.md
+++ b/files/es/learn_web_development/extensions/forms/sending_and_retrieving_form_data/index.md
@@ -14,7 +14,7 @@ En este artículo se analiza lo que sucede cuando un usuario envía un formulari
       <th scope="row">Requisitos previos:</th>
       <td>
         Conocimientos básicos de informática, una
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content"
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content"
           >comprensión de HTML</a
         >
         , y conocimientos básicos de

--- a/files/es/learn_web_development/extensions/forms/styling_web_forms/index.md
+++ b/files/es/learn_web_development/extensions/forms/styling_web_forms/index.md
@@ -14,7 +14,7 @@ En los artículos anteriores vimos todo el HTML que necesitas para crear y estru
       <th scope="row">Requisitos previos:</th>
       <td>
         Conocimientos básicos de informática y una comprensión básica de
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">HTML</a> y
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a> y
         <a href="/es/docs/conflicting/Learn_web_development/Core/Styling_basics">CSS</a>.
       </td>
     </tr>

--- a/files/es/learn_web_development/extensions/forms/your_first_form/index.md
+++ b/files/es/learn_web_development/extensions/forms/your_first_form/index.md
@@ -14,7 +14,7 @@ El primer artículo de nuestra serie te proporciona una primera experiencia de c
       <th scope="row">Prerrequisitos:</th>
       <td>
         Conocimientos básicos de informática y de
-        <a href="/es/docs/conflicting/Learn_web_development/Core/Structuring_content">lenguaje HTML</a>.
+        <a href="/es/docs/Learn_web_development/Core/Structuring_content">lenguaje HTML</a>.
       </td>
     </tr>
     <tr>

--- a/files/es/learn_web_development/howto/web_mechanics/what_are_hyperlinks/index.md
+++ b/files/es/learn_web_development/howto/web_mechanics/what_are_hyperlinks/index.md
@@ -90,4 +90,4 @@ Los enlaces influyen en la facilidad con que un motor de búsqueda se vinculará
 Ahora querrás configurar algunas páginas web con enlaces.
 
 - Para obtener más antecedentes teóricos, aprenda sobre [URLs y su estructura](/es/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL), dado que todo enlace apunta a una URL.
-- ¿Quieres algo un poco más práctico? El artículo [Creación de hipervínculos](/es/docs/Learn_web_development/Core/Structuring_content/Creating_links) de nuestro módulo [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content) explica cómo implementar enlaces en detalle.
+- ¿Quieres algo un poco más práctico? El artículo [Creación de hipervínculos](/es/docs/Learn_web_development/Core/Structuring_content/Creating_links) de nuestro módulo [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content) explica cómo implementar enlaces en detalle.

--- a/files/es/learn_web_development/index.md
+++ b/files/es/learn_web_development/index.md
@@ -27,7 +27,7 @@ Si eres un principiante, el desarrollo web puede ser un desafío: iremos de la m
 - Principiante
   - : Si eres un principiante en el desarrollo web, te recomendamos que empieces trabajando con nuestro módulo [Cómo empezar con la web](/es/docs/Learn_web_development/Getting_started/Your_first_website), que proporciona una introducción práctica al desarrollo web.
 - Mas allá de lo básico
-  - : Si ya tienes un poco de conocimiento, el siguiente paso es aprender {{glossary("HTML")}} y {{glossary("CSS")}} en detalle: comience con nuestra [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content) y pase a nuestro módulo [Primeros pasos con CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics).
+  - : Si ya tienes un poco de conocimiento, el siguiente paso es aprender {{glossary("HTML")}} y {{glossary("CSS")}} en detalle: comience con nuestra [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content) y pase a nuestro módulo [Primeros pasos con CSS](/es/docs/conflicting/Learn_web_development/Core/Styling_basics).
 - Pasando al código
   - : Si ya te sientes cómodo con HTML y CSS, o si estás principalmente interesado en la codificación, querrá pasar a {{glossary("JavaScript")}} o al desarrollo del lado del servidor. Comience con nuestros módulos [Primeros pasos de JavaScript](/es/docs/conflicting/Learn_web_development/Core/Scripting) y [Primeros pasos del lado del servidor](/es/docs/Learn_web_development/Extensions/Server-side/First_steps).
 - _Frameworks_ y herramientas

--- a/files/es/mdn/tutorials/index.md
+++ b/files/es/mdn/tutorials/index.md
@@ -19,7 +19,7 @@ Estos recursos son creados por empresas y desarrolladores web con visión de fut
 
 ### Nivel introductorio
 
-- [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content)
+- [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content)
   - : Este módulo prepara el escenario, acostumbrándolo a conceptos y sintaxis importantes, analizando la aplicación de HTML al texto, cómo crear hipervínculos y cómo usar HTML para estructurar una página web.
 - [Referencia de Elementos HTML](/es/docs/Web/HTML/Reference/Elements)
   - : Una referencia completa sobre elementos HTML y cómo los implementan los diferentes navegadores.
@@ -30,7 +30,7 @@ Estos recursos son creados por empresas y desarrolladores web con visión de fut
 
 ### Nivel intermedio
 
-- [Multimedia e inserción](/es/docs/conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b)
+- [Multimedia e inserción](/es/docs/Learn_web_development/Core/Structuring_content)
   - : Este módulo explora cómo usar HTML para incluir multimedia en sus páginas web, incluidas las diferentes formas en que se pueden incluir imágenes y cómo incrustar video, audio e incluso otras páginas web completas.
 - [Tablas HTML](/es/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics)
   - : Representar datos tabulares en una página web de una manera {{glossary("Accessibility", "accesible")}} y comprensible puede ser un desafío. Este módulo cubre el marcado básico de tablas, junto con funciones más complejas, como la implementación de subtítulos y resúmenes.

--- a/files/es/orphaned/learn/front-end_web_developer/index.md
+++ b/files/es/orphaned/learn/front-end_web_developer/index.md
@@ -71,8 +71,8 @@ Las evaluaciones de cada módulo están diseñadas para comprobar tu conocimient
 
 #### Módulos
 
-- [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content) (15 a 20 horas de lectura/ejercicios)
-- [Multimedia e inserción](/es/docs/conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b) (15 a 20 horas de lectura/ejercicios)
+- [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content) (15 a 20 horas de lectura/ejercicios)
+- [Multimedia e inserción](/es/docs/Learn_web_development/Core/Structuring_content) (15 a 20 horas de lectura/ejercicios)
 - [tablas HTML](/es/docs/Learn_web_development/Core/Structuring_content/HTML_table_basics) (5 a 10 horas de lectura/ejercicios)
 
 ### Estilo y diseño con CSS
@@ -81,7 +81,7 @@ Tiempo para completar: 90 a 120 horas
 
 #### Prerrequisitos
 
-Es recomendable que tengas conocimientos básicos de HTML antes de comenzar a aprender CSS. Primero deberías estudiar [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content) por lo menos.
+Es recomendable que tengas conocimientos básicos de HTML antes de comenzar a aprender CSS. Primero deberías estudiar [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content) por lo menos.
 
 #### ¿Cómo sabré que estoy listo para seguir adelante?
 
@@ -104,7 +104,7 @@ Tiempo para completar: 135 a 185 horas
 
 #### Prerrequisitos
 
-Es recomendable que tengas conocimientos básicos de HTML antes de comenzar a aprender JavaScript. Primero deberías estudiar [Introducción a HTML](/es/docs/conflicting/Learn_web_development/Core/Structuring_content) por lo menos.
+Es recomendable que tengas conocimientos básicos de HTML antes de comenzar a aprender JavaScript. Primero deberías estudiar [Introducción a HTML](/es/docs/Learn_web_development/Core/Structuring_content) por lo menos.
 
 #### ¿Cómo sabré que estoy listo para seguir adelante?
 


### PR DESCRIPTION
### Description

Reapunta **69 referencias** repartidas por **51 páginas publicadas** que enlazaban a dos copias archivadas del módulo de HTML, hacia el módulo vivo `Learn_web_development/Core/Structuring_content`.

| Slug archivado | Era el módulo | Referencias |
| --- | --- | ---: |
| `conflicting/Learn_web_development/Core/Structuring_content` | Introducción a HTML | 56 |
| `conflicting/Learn_web_development/Core/Structuring_content_010016f551c464adb3e557818ac7189b` | Multimedia e inserción | 13 |

El inglés fusionó ambos módulos en `Learn_web_development/Core/Structuring_content`, que es el destino único de los 69 enlaces.

Parte de #38407.

### Motivation

Las URLs `conflicting/` devuelven 200, así que ningún control las marcaba como rotas. Quien seguía el enlace llegaba a una página huérfana: sin migas de pan, sin barra lateral de módulo y sin equivalente en el sitio en inglés, por lo que el selector de idioma tampoco llevaba a ninguna parte.

### Las dos formas de referencia

Venían en dos formatos y los dos se corrigen:

- **45 enlaces** markdown/HTML: `/es/docs/conflicting/...` → `/es/docs/Learn_web_development/Core/Structuring_content`
- **24 argumentos de macro** en `{{NextMenu}}`, `{{PreviousMenu}}` y `{{PreviousMenuNext}}`. El tercer argumento es la página índice del módulo, y el inglés usa ahí exactamente el mismo slug:

```
en-US/…/structuring_content/html_images/index.md:9
{{PreviousMenuNext("…/Structuring_a_page_of_content", "…/Test_your_skills/Images", "Learn_web_development/Core/Structuring_content")}}
```

### El destino ya estaba al día

No hacía falta sincronizar nada antes de reapuntar: `files/es/learn_web_development/core/structuring_content/index.md` quedó al día en #38424, con 85 líneas en los dos idiomas y `sourceCommit: 25a3f6c`, que es el último commit de `mdn/content` que toca el índice en inglés.

### De paso

Dos textos de enlace en líneas que ya se tocaban:

- `core/css_layout/index.md`: «Introduction to HTML» estaba sin traducir.
- `core/styling_basics/index.md`: «Introdución a HTML» tenía una errata.

### Verificación

- **0** referencias a los dos slugs archivados fuera de `files/es/conflicting/` y `_wikihistory.json`. Las **10** que quedan están en 9 páginas archivadas que se enlazan entre sí, y desaparecen cuando se borren en #38420.
- Los **69** destinos nuevos son el índice del módulo, sin fragmentos `#` ni subrutas inventadas.
- `prettier -c`, `markdownlint-cli2` y `scripts/check-url-locale.js` pasan sobre los 51 archivos.
- El diff es exactamente **69 líneas quitadas y 69 añadidas**: sólo cambia el destino del enlace, nada de reformateo.

### Lo que no entra aquí

- **No se borran las copias archivadas.** Cuatro redirecciones de `_redirects.txt` apuntan todavía a esos dos slugs, así que el borrado va en #38420 con el CLI de `rari`, no a mano.
- **Sólo el módulo de HTML.** En varias de las líneas tocadas conviven enlaces a `conflicting/…/Styling_basics` y `conflicting/…/Scripting`; se quedan como están y van en sus propios lotes de #38407, para que cada lote se pueda revisar contra un destino ya sincronizado.
- **`Multimedia e inserción` queda como entrada duplicada** en `files/es/mdn/tutorials/index.md` y en `files/es/orphaned/learn/front-end_web_developer/index.md`: al fusionarse los módulos, esa viñeta apunta ahora a la misma página que «Introducción a HTML». El inglés resolvió esto eliminando la viñeta, pero eso es una sincronización de esas dos páginas y no un reapuntado de enlaces, así que va aparte.
