### PR TITLE
chore(es): sync of `Learn_web_development/Extensions/Server-side/Express_Nodejs/Introduction`

### DIFF
--- a/files/es/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
+++ b/files/es/learn_web_development/extensions/server-side/express_nodejs/introduction/index.md
@@ -1,170 +1,192 @@
 ---
 title: Introducción a Express/Node
 slug: Learn_web_development/Extensions/Server-side/Express_Nodejs/Introduction
-original_slug: Learn/Server-side/Express_Nodejs/Introduction
+l10n:
+  sourceCommit: 2aa175159b0354f7c5ba36574ef99e37e95b19c8
 ---
 
-{{LearnSidebar}}{{NextMenu("Aprendizaje/Lado-Servidor/Express_Nodejs/Ambiente-Desarrollo", "Aprendizaje/Lado-Servidor/Express_Nodejs")}}
+{{NextMenu("Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment", "Learn_web_development/Extensions/Server-side/Express_Nodejs")}}
 
-En este primer articulo de Express resolveremos las preguntas "¿Qué es Node?" y "¿Qué es Express?", y te daremos una visión general de que hace especial al framework web "Express". Delinearemos las características principales, y te mostraremos algunos de los principales bloques de construcción de una aplicación en Express (aunque en este punto no tendrás todavía un entorno de desarrollo en que probarlo).
+En este primer artículo sobre Express respondemos a las preguntas "¿Qué es Node?" y "¿Qué es Express?", y te ofrecemos una visión general de qué hace especial al framework web Express. Describiremos sus características principales y te mostraremos algunos de los principales bloques de construcción de una aplicación Express (aunque en este punto todavía no tendrás un entorno de desarrollo en el que probarlo).
 
 <table>
   <tbody>
     <tr>
-      <th scope="row">Pre-requisitos:</th>
+      <th scope="row">Prerrequisitos:</th>
       <td>
-        <p>
-          Conocimientos básicos de informática. Noción general sobre
-          <a
-            href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps"
-            >programación lado servidor de sitios web</a
-          >, y en particular los mecanismos de las interacciones
-          <a
-            href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Client-Server_overview"
-            >cliente-servidor en sitios web</a
-          >.
-        </p>
+        Comprensión general de la <a href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps">programación de sitios web del lado del servidor</a>, y en particular de los mecanismos de las <a href="/es/docs/Learn_web_development/Extensions/Server-side/First_steps/Client-Server_overview">interacciones cliente-servidor en sitios web</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Objetivo:</th>
       <td>
-        <p>
-          Ganar familiaridad con lo que es Express y cómo encaja con Node, qué
-          funcionalidad proporciona y los pilares de construcción de una
-          aplicación Express.
-        </p>
+        Familiarizarte con qué es Express y cómo encaja con Node, qué funcionalidad ofrece, y los principales bloques de construcción de una aplicación Express.
       </td>
     </tr>
   </tbody>
 </table>
 
-## ¿Qué son Express y Node?
+## Introducción a Node
 
-[Node](https://nodejs.org/) (o más correctamente: _Node.js_) es un entorno que trabaja en tiempo de ejecución, de código abierto, multi-plataforma, que permite a los desarrolladores crear toda clase de herramientas de lado servidor y aplicaciones en [JavaScript](/es/docs/Glossary/JavaScript). La ejecución en tiempo real está pensada para usarse fuera del contexto de un explorador web (es decir, ejecutarse directamente en una computadora o sistema operativo de servidor). Como tal, el entorno omite las APIs de JavaScript específicas del explorador web y añade soporte para APIs de sistema operativo más tradicionales que incluyen HTTP y bibliotecas de sistemas de ficheros.
+[Node](https://nodejs.org/) (o más formalmente, _Node.js_) es un entorno de ejecución de código abierto y multiplataforma que permite a los desarrolladores crear todo tipo de herramientas y aplicaciones del lado del servidor en [JavaScript](/es/docs/Glossary/JavaScript).
+Este entorno de ejecución está pensado para usarse fuera del contexto de un navegador (es decir, ejecutándose directamente en una computadora o en el sistema operativo de un servidor). Como tal, el entorno omite las APIs de JavaScript específicas del navegador y añade soporte para APIs de sistema operativo más tradicionales, incluyendo bibliotecas de HTTP y de sistema de archivos.
 
-Desde una perspectiva de desarrollo de servidor web, Node tiene un gran número de ventajas:
+Desde el punto de vista del desarrollo de servidores web, Node tiene varias ventajas:
 
-- ¡Gran rendimiento! _Node_ ha sido diseñado para optimizar el rendimiento y la escalabilidad en aplicaciones web y es un muy buen complemento para muchos problemas comunes de desarrollo web (ej, aplicaciones web en tiempo real).
-- El código está escrito en "simple JavaScript", lo que significa que se pierde menos tiempo ocupándose de las "conmutaciones de contexto" entre lenguajes cuando estás escribiendo tanto el código del explorador web como del servidor.
-- JavaScript es un lenguaje de programación relativamente nuevo y se beneficia de los avances en diseño de lenguajes cuando se compara con otros lenguajes de servidor web tradicionales (ej, Python, PHP, etc.) Muchos otros lenguajes nuevos y populares se compilan/convierten a JavaScript de manera que puedes también usar CoffeeScript, ClosureScript, Scala, LiveScript, etc.
-- El gestor de paquetes de _Node_ (NPM del inglés: Node Packet Manager) proporciona acceso a cientos o miles de paquetes reutilizables. Tiene además la mejor en su clase resolución de dependencias y puede usarse para automatizar la mayor parte de la cadena de herramientas de compilación.
-- Es portable, con versiones que funcionan en Microsoft Windows, OS X, Linux, Solaris, FreeBSD, OpenBSD, WebOS, y NonStop OS. Además, está bien soportado por muchos de los proveedores de hospedaje web, que proporcionan infraestructura específica y documentación para hospedaje de sitios _Node_.
-- Tiene un ecosistema y comunidad de desarrolladores de terceros muy activa, con cantidad de gente deseosa de ayudar.
+- ¡Gran rendimiento! Node fue diseñado para optimizar el rendimiento y la escalabilidad en aplicaciones web, y es una buena solución para muchos problemas comunes del desarrollo web (por ejemplo, aplicaciones web en tiempo real).
+- El código se escribe en "JavaScript puro y sencillo", lo que significa que se dedica menos tiempo a lidiar con el "cambio de contexto" entre lenguajes cuando escribes tanto código del lado del cliente como del lado del servidor.
+- JavaScript es un lenguaje de programación relativamente nuevo y se beneficia de mejoras en el diseño del lenguaje en comparación con otros lenguajes tradicionales de servidor web (por ejemplo, Python, PHP, etc.). Muchos otros lenguajes nuevos y populares se compilan/convierten a JavaScript, de modo que también puedes usar TypeScript, CoffeeScript, ClojureScript, Scala, LiveScript, etc.
+- El gestor de paquetes de Node (npm) da acceso a cientos de miles de paquetes reutilizables. Además, cuenta con una resolución de dependencias de primer nivel y también se puede usar para automatizar la mayor parte de la cadena de herramientas de compilación.
+- Node.js es portable. Está disponible en Microsoft Windows, macOS, Linux, Solaris, FreeBSD, OpenBSD, WebOS y NonStop OS. Además, cuenta con buen soporte por parte de muchos proveedores de alojamiento web, que a menudo ofrecen infraestructura y documentación específicas para alojar sitios de Node.
+- Tiene un ecosistema y una comunidad de desarrolladores externos muy activos, con mucha gente dispuesta a ayudar.
 
-Puedes crear de forma sencilla un servidor web básico para responder cualquier petición simplemente usando el paquete HTTP de _Node_, como se muestra abajo. Este, creará un servidor y escuchará cualquier clase de peticiones en la URL `http://127.0.0.1:8000/`; cuando se reciba una petición, se responderá enviando en texto la respuesta: "Hola Mundo!".
+Puedes usar Node.js para crear un servidor web sencillo utilizando el paquete HTTP de Node.
 
-```js
-// Se carga el módulo de HTTP
-var http = require("http");
+### Hola, Node.js
 
-// Creación del servidor HTTP, y se define la escucha
-// de peticiones en el puerto 8000
-http
-  .createServer(function (request, response) {
-    // Se define la cabecera HTTP, con el estado HTTP (OK: 200) y el tipo de contenido
-    response.writeHead(200, { "Content-Type": "text/plain" });
+El siguiente ejemplo crea un servidor web que escucha cualquier tipo de solicitud HTTP en la URL `http://127.0.0.1:8000/`; cuando se recibe una solicitud, el script responde con la cadena: "Hello World". Si ya tienes node instalado, puedes seguir estos pasos para probar el ejemplo:
 
-    // Se responde, en el cuerpo de la respuesta con el mensaje "Hello World"
-    response.end("Hola Mundo!\n");
-  })
-  .listen(8000);
+1. Abre una terminal (en Windows, abre el intérprete de línea de comandos)
+2. Crea la carpeta donde quieras guardar el programa, por ejemplo, `test-node`, y entra en ella escribiendo el siguiente comando en tu terminal:
 
-// Se escribe la URL para el acceso al servidor
-console.log("Servidor en la url http://127.0.0.1:8000/");
-```
+   ```bash
+   cd test-node
+   ```
 
-Otras tareas comunes de desarrollo web no están directamente soportadas por el mismo _Node_. Si quieres añadir el manejo específico de diferentes verbos HTTP (ej, `GET`, `POST`, `DELETE`, etc.), gestionar de forma separada las peticiones por medio de diferentes direcciones URL ("rutas"), servir ficheros estáticos o usar plantillas para crear la respuesta de forma dinámica, necesitarás escribir el código por tí mismo, o ¡puedes evitar reinventar la rueda usando un framework web!
+3. Con tu editor de texto favorito, crea un archivo llamado `hello.js` y pega en él el siguiente código:
 
-[Express](https://expressjs.com/) es el framework web más popular de _Node_, y es la librería subyacente para un gran número de otros [frameworks web de Node](https://expressjs.com/en/resources/frameworks.html) populares. Proporciona mecanismos para:
+   ```js
+   // Load HTTP module
+   const http = require("http");
 
-- Escritura de manejadores de peticiones con diferentes verbos HTTP en diferentes caminos URL (rutas).
-- Integración con motores de renderización de "vistas" para generar respuestas mediante la introducción de datos en plantillas.
-- Establecer ajustes de aplicaciones web como qué puerto usar para conectar, y la localización de las plantillas que se utilizan para renderizar la respuesta.
-- Añadir procesamiento de peticiones "middleware" adicional en cualquier punto dentro de la tubería de manejo de la petición.
+   const hostname = "127.0.0.1";
+   const port = 8000;
 
-A pesar de que _Express_ es en sí mismo bastante minimalista, los desarrolladores han creado paquetes de middleware compatibles para abordar casi cualquier problema de desarrollo web. Hay librerías para trabajar con cookies, sesiones, inicios de sesión de usuario, parámetros URL, datos `POST`, cabeceras de seguridad y _muchos_ más. Puedes encontrar una lista de paquetes middleware mantenida por el equipo de Express en [Express Middleware](https://expressjs.com/es/resources/middleware.html) (junto con una lista de algunos de los paquetes más populares de terceros).
+   // Create HTTP server
+   const server = http.createServer((req, res) => {
+     // Set the response HTTP header with HTTP status and Content type
+     res.writeHead(200, { "Content-Type": "text/plain" });
+
+     // Send the response body "Hello World"
+     res.end("Hello World\n");
+   });
+
+   // Prints a log once the server starts listening
+   server.listen(port, hostname, () => {
+     console.log(`Server running at http://${hostname}:${port}/`);
+   });
+   ```
+
+4. Guarda el archivo en la carpeta que creaste antes.
+5. Vuelve a la terminal y escribe el siguiente comando:
+
+   ```bash
+   node hello.js
+   ```
+
+Finalmente, ve a `http://localhost:8000` en tu navegador web; deberías ver el texto "**Hello World**" en la esquina superior izquierda de una página web por lo demás vacía.
 
 > [!NOTE]
-> Esta flexibilidad es una espada de doble filo. Hay paquetes de middleware para abordar casi cualquier problema o requerimiento, pero deducir cuáles son los paquetes adecuados a usar algunas veces puede ser un auténtico reto. Tampoco hay una "forma correcta" de estructurar una aplicación, y muchos ejemplos que puedes encontrar en la Internet no son óptimos, o sólo muestran una pequeña parte de lo que necesitas hacer para desarrollar una aplicación web.
+> Si quieres experimentar con algo de código de Node.js sin necesidad de hacer ninguna instalación local, [Aside: The HTTP module](https://scrimba.com/learn-nodejs-c00ho9qqh6/~07du?via=mdn) de Scrimba <sup>[_socio de aprendizaje de MDN_](/es/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds)</sup> ofrece un recorrido interactivo sobre cómo configurar un servidor básico con el paquete HTTP de Node.
 
-## ¿Dónde comenzó?
+## Frameworks web
 
-_Node_ fué lanzado inicialmente, sólo para Linux, en 2009. El gestor de paquetes NPM fué lanzado en 2010, y el soporte nativo para Windows fue añadido en 2012. La versión actual LTS (Long Term Suppport) es Node v12.18.0 mientras que la última versión es Node 14.4.0. Ésto es sólo una pequeña foto de una historia muy rica; profundiza en [Wikipedia](https://en.wikipedia.org/wiki/Node.js#History) si quieres saber más).
+Node por sí mismo no da soporte directo a otras tareas comunes del desarrollo web. Si quieres añadir un manejo específico para distintos verbos HTTP (por ejemplo, `GET`, `POST`, `DELETE`, etc.), gestionar por separado las solicitudes en distintas rutas de URL ("rutas"), servir archivos estáticos o usar plantillas para crear la respuesta dinámicamente, Node por sí solo no te será de mucha ayuda. Tendrás que escribir el código tú mismo, o puedes evitar reinventar la rueda y usar un framework web.
 
-_Express_ fue lanzado inicialmente en Noviembre de 2010 y está ahora en la versión 4.17.1 de la API. Puedes comprobar en el [changelog](https://expressjs.com/en/changelog/4x.html) la información sobre cambios en la versión actual, y en [GitHub](https://github.com/expressjs/express/blob/master/History.md) notas de lanzamiento históricas más detalladas.
+## Introducción a Express
 
-## ¿Qué popularidad tiene Node/Express?
+[Express](https://expressjs.com/) es el framework web de Node.js más popular, y es la biblioteca subyacente de otros muchos frameworks populares de Node.js. Proporciona mecanismos para:
 
-La popularidad de un framework web es importante porque es un indicador de se continuará manteniendo y qué recursos tienen más probabilidad de estar disponibles en términos de documentación, librerías de extensiones y soporte técnico.
+- Escribir manejadores de solicitudes con distintos verbos HTTP en distintas rutas de URL (rutas).
+- Integrarse con motores de renderización de "vistas" para generar respuestas insertando datos en plantillas.
+- Establecer configuraciones comunes de aplicaciones web, como el puerto que se usará para conectarse, y la ubicación de las plantillas usadas para renderizar la respuesta.
+- Añadir "middleware" adicional de procesamiento de solicitudes en cualquier punto dentro del flujo de manejo de la solicitud.
 
-No existe una medida disponible de inmediato y definitiva de la popularidad de los frameworks de lado servidor (aunque sitios como [Hot Frameworks](http://hotframeworks.com/) intentan asesorar sobre popularidad usando mecanismos como contar para cada plataforma el número de preguntas sobre proyectos en GitHub y StackOverflow). Una pregunta mejor es si Node y Express son lo "suficientemente populares" para evitar los problemas de las plataformas menos populares. ¿Continúan evolucionando? ¿Puedes conseguir la ayuda que necesitas? ¿Hay alguna posibilidad de que consigas un trabajo remunerado si aprendes Express?
+Aunque _Express_ en sí mismo es bastante minimalista, los desarrolladores han creado paquetes de middleware compatibles para abordar casi cualquier problema de desarrollo web. Hay bibliotecas para trabajar con cookies, sesiones, inicios de sesión de usuario, parámetros de URL, datos `POST`, cabeceras de seguridad y _muchas_ más. Puedes encontrar una lista de paquetes de middleware mantenidos por el equipo de Express en [Express Middleware](https://expressjs.com/en/resources/middleware.html) (junto con una lista de algunos paquetes populares de terceros).
 
-De acuerdo con el número de [compañías de perfil alto](https://expressjs.com/en/resources/companies-using-express.html) que usan Express, el número de gente que contribuye al código base, y el número de gente que proporciona soporte tanto libre como pagado, podemos entonces decir que sí, !_Express_ es un framework popular!
+> [!NOTE]
+> Esta flexibilidad es un arma de doble filo. Hay paquetes de middleware para abordar casi cualquier problema o requisito, pero averiguar cuáles son los paquetes adecuados a usar a veces puede ser todo un reto. Tampoco hay una "forma correcta" de estructurar una aplicación, y muchos de los ejemplos que puedes encontrar en Internet no son óptimos, o solo muestran una pequeña parte de lo que necesitas hacer para desarrollar una aplicación web.
+
+## ¿De dónde vienen Node y Express?
+
+Node se lanzó inicialmente, solo para Linux, en 2009. El gestor de paquetes npm se lanzó en 2010, y el soporte nativo para Windows se añadió en 2012. Consulta [Wikipedia](https://en.wikipedia.org/wiki/Node.js#History) si quieres saber más.
+
+Express se lanzó inicialmente en noviembre de 2010 y actualmente está en la versión mayor 5 de la API. Puedes consultar el [changelog](https://expressjs.com/en/changelog/#5.x) para obtener información sobre los cambios en la versión actual, y [GitHub](https://github.com/expressjs/express/blob/master/History.md) para notas de lanzamiento históricas más detalladas.
+
+## ¿Qué tan populares son Node y Express?
+
+La popularidad de un framework web es importante porque es un indicador de si seguirá manteniéndose, y de qué recursos es probable que estén disponibles en cuanto a documentación, bibliotecas adicionales y soporte técnico.
+
+No existe ninguna medida definitiva y de fácil acceso sobre la popularidad de los frameworks del lado del servidor (aunque puedes estimar la popularidad con mecanismos como contar el número de proyectos de GitHub y de preguntas en Stack Overflow para cada plataforma). Una pregunta mejor es si Node y Express son "lo suficientemente populares" como para evitar los problemas de las plataformas poco populares. ¿Siguen evolucionando? ¿Puedes obtener ayuda si la necesitas? ¿Hay oportunidad de conseguir trabajo remunerado si aprendes Express?
+
+A juzgar por el número de empresas de alto perfil que usan Express, el número de personas que contribuyen a la base de código, y el número de personas que ofrecen soporte tanto gratuito como pagado, entonces sí, ¡_Express_ es un framework popular!
 
 ## ¿Es Express dogmático?
 
-Los frameworks web frecuentemente se refieren a sí mismos como "dogmáticos" ("_opinionated_") o "no dogmáticos" ("_unopinionated_").
+Los frameworks web suelen referirse a sí mismos como "dogmáticos" ("_opinionated_") o "no dogmáticos" ("_unopinionated_").
 
-Los frameworks dogmáticos son aquellos que opinan acerca de la "manera correcta" de gestionar cualquier tarea en particular. Ofrecen soporte para el desarrollo rápido en un _dominio en particular_ (resolver problemas de un tipo en particular) porque la manera correcta de hacer cualquier cosa está generalmente bien comprendida y bien documentada. Sin embargo pueden ser menos flexibles para resolver problemas fuera de su dominio principal, y tienden a ofrecer menos opciones para elegir qué componentes y enfoques pueden usarse.
+Los frameworks dogmáticos son aquellos que tienen opiniones sobre la "forma correcta" de gestionar cualquier tarea en particular. Suelen favorecer el desarrollo rápido _en un dominio en particular_ (resolver problemas de un tipo determinado) porque la forma correcta de hacer cualquier cosa suele estar bien comprendida y bien documentada. Sin embargo, pueden ser menos flexibles para resolver problemas fuera de su dominio principal, y tienden a ofrecer menos opciones sobre qué componentes y enfoques se pueden usar.
 
-Los framewoks no dogmáticos, en contraposición, tienen muchas menos restricciones sobre el modo mejor de unir componentes para alcanzar un objetivo, o incluso qué componentes deberían usarse. Hacen más fácil para los desarrolladores usar las herramientas más adecuadas para completar una tarea en particular, si bien al coste de que necesitas encontrar esos componentes por tí mismo.
+Los frameworks no dogmáticos, en cambio, tienen muchas menos restricciones sobre la mejor manera de combinar componentes para lograr un objetivo, o incluso sobre qué componentes deberían usarse. Facilitan que los desarrolladores usen las herramientas más adecuadas para completar una tarea en particular, aunque a costa de tener que encontrar esos componentes por ti mismo.
 
-Express es no dogmático, transigente. Puedes insertar casi cualquier middleware compatible que te guste dentro de la cadena de manejo de la petición, en casi cualquier orden que te apetezca. Puedes estructurar la app en un fichero o múltiples ficheros y usar cualquier estructura de directorios. ¡Algunas veces puedes sentir que tienes demasiadas opciones!
+Express no es dogmático. Puedes insertar casi cualquier middleware compatible que quieras en la cadena de manejo de solicitudes, en casi cualquier orden que quieras. Puedes estructurar la app en un solo archivo o en varios archivos, y usar cualquier estructura de directorios. ¡A veces puede que sientas que tienes demasiadas opciones!
 
-## ¿Cómo es el código para Express?
+## ¿Cómo es el código de Express?
 
-En sitios web o aplicaciones web dinámicas, que accedan a bases de datos, el servidor espera a recibir peticiones HTTP del navegador (o cliente). Cuando se recibe una petición, la aplicación determina cuál es la acción adecuada correspondiente, de acuerdo a la estructura de la URL y a la información (opcional) indicada en la petición con los métodos `POST` o `GET`. Dependiendo de la acción a realizar, puede que se necesite leer o escribir en la base de datos, o realizar otras acciones necesarias para atender la petición correctamente. La aplicación ha de responder al navegador, normalmente, creando una página HTML dinámicamente para él, en la que se muestre la información pedida, usualmente dentro de un elemento especifico para este fin, en una plantilla HTML.
+En un sitio web tradicional basado en datos, una aplicación web espera solicitudes HTTP del navegador web (u otro cliente). Cuando se recibe una solicitud, la aplicación determina qué acción se necesita según el patrón de la URL y, posiblemente, la información asociada contenida en datos `POST` o `GET`. Dependiendo de lo que se requiera, puede entonces leer o escribir información en una base de datos, o realizar otras tareas necesarias para satisfacer la solicitud. La aplicación devolverá entonces una respuesta al navegador web, a menudo creando dinámicamente una página HTML para que el navegador la muestre, insertando los datos obtenidos en marcadores de posición dentro de una plantilla HTML.
 
-_Express_ posee métodos para especificar que función ha de ser llamada dependiendo del verbo HTTP usado en la petición (`GET`, `POST`, `SET`, etc.) y la estructura de la URL ("ruta"). También tiene los métodos para especificar que plantilla ("view") o gestor de visualización utilizar, donde están guardadas las plantillas de HTML que han de usarse y como generar la visualización adecuada para cada caso. El middleware de _Express_, puede usarse también para añadir funcionalidades para la gestión de cookies, sesiones y usuarios, mediante el uso de parámetros, en los métodos `POST`/`GET`. Puede utilizarse además cualquier sistema de trabajo con bases de datos, que sea soportado por _Node_ (_Express_ no especifica ningún método preferido para trabajar con bases de datos).
+Express proporciona métodos para especificar qué función se llama para un verbo HTTP en particular (`GET`, `POST`, `PUT`, etc.) y un patrón de URL ("ruta"), y métodos para especificar qué motor de plantillas ("vista") se usa, dónde se ubican los archivos de plantilla, y qué plantilla usar para renderizar una respuesta. Puedes usar middleware de Express para añadir soporte para cookies, sesiones y usuarios, obtener parámetros `POST`/`GET`, etc. Puedes usar cualquier mecanismo de base de datos compatible con Node (Express no define ningún comportamiento relacionado con bases de datos).
 
-En las siguientes secciones, se explican algunos puntos comunes que se pueden encontrar cuando se trabaja con código de _Node_ y _Express_.
+Las siguientes secciones explican algunas de las cosas comunes que verás al trabajar con código de _Express_ y _Node_.
 
-### Hola Mundo! - en Express
+### Hello World de Express
 
-Primero consideremos el tradicional ejemplo de [Hola Mundo!](https://expressjs.com/en/starter/hello-world.html) (se comentará cada parte a continuación).
+Primero, veamos el ejemplo estándar de [Hello World](https://expressjs.com/en/starter/hello-world.html) de Express (comentaremos cada parte de esto a continuación, y en las siguientes secciones).
 
 > [!NOTE]
-> Si tiene _Node_ y _Express_ instalado (o piensa instalarlos posteriormente) puede guardar este código en un archivo llamado **app.js** y ejecutarlo posteriormente en la linea de comandos invocándolo mediante: `node app.js`.
+> Si ya tienes Node y Express instalados (o si los instalas como se muestra en el [siguiente artículo](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment)), puedes guardar este código en un archivo de texto llamado **app.js** y ejecutarlo en una línea de comandos de bash llamando a:
+>
+> **`node ./app.js`**
 
 ```js
-var express = require("express");
-var app = express();
+const express = require("express");
 
-app.get("/", function (req, res) {
-  res.send("Hola Mundo!");
+const app = express();
+const port = 3000;
+
+app.get("/", (req, res) => {
+  res.send("Hello World!");
 });
 
-app.listen(3000, function () {
-  console.log("Aplicación ejemplo, escuchando el puerto 3000!");
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}!`);
 });
 ```
 
-Las primeras dos líneas incluyen (mediante la orden `require()`) el módulo de Express y crean una [aplicación de Express](https://expressjs.com/en/4x/api.html#app). Este elemento se denomina comúnmente `app`, y posee métodos para el enrutamiento de las peticiones HTTP, configuración del 'middleware', y visualización de las vistas de HTML, uso del motores de 'templates', y gestión de las [configuraciones de las aplicaciones](https://expressjs.com/en/4x/api.html#app.settings.table) que controlan la aplicación (por ejemplo el entorno, las definiciones para enrutado ... etcetera.)
+Las dos primeras líneas hacen `require()` (importan) el módulo express y crean una [aplicación Express](https://expressjs.com/en/5x/api.html#app). Este objeto, que tradicionalmente se llama `app`, tiene métodos para enrutar solicitudes HTTP, configurar middleware, renderizar vistas HTML, registrar un motor de plantillas, y modificar [ajustes de la aplicación](https://expressjs.com/en/5x/api.html#app.settings.table) que controlan cómo se comporta la aplicación (por ejemplo, el modo de entorno, si las definiciones de ruta distinguen mayúsculas de minúsculas, etc.).
 
-Las líneas que siguen en el código (las tres líneas que comienzan con `app.get`) muestran una definición de ruta que se llamará cuando se reciba una petición HTTP `GET` con una dirección (`'/'`) relativa al directorio raíz. La función 'callback' coge una petición y una respuesta como argumentos, y ejecuta un [`send()`](https://expressjs.com/en/4x/api.html#res.send) en la respuesta, para enviar la cadena de caracteres: "Hola Mundo!".
+La parte central del código (las tres líneas que empiezan con `app.get`) muestra una _definición de ruta_. El método `app.get()` especifica una función de retorno de llamada (callback) que se invocará siempre que haya una solicitud HTTP `GET` con una ruta (`'/'`) relativa a la raíz del sitio. La función de retorno de llamada toma un objeto de solicitud y uno de respuesta como argumentos, y llama a [`send()`](https://expressjs.com/en/5x/api.html#res.send) en la respuesta para devolver la cadena "Hello World!"
 
-El bloque final de código, define y crea el servidor, escuchando el puerto 3000 e imprime un comentario en la consola. Cuando se está ejecutando el servidor, es posible ir hasta la dirección `localhost:3000` en un navegador, y ver como el servidor de este ejemplo devuelve el mensaje de respuesta.
+El bloque final inicia el servidor en un puerto especificado ('3000') e imprime un comentario de registro en la consola. Con el servidor en ejecución, podrías ir a `localhost:3000` en tu navegador para ver la respuesta de ejemplo devuelta.
 
-### Importando y creando módulos
+### Importar y crear módulos
 
-Un modulo es una librería o archivo JavaScript que puede ser importado dentro de otro código utilizando la función `require()` de Node. Por sí mismo, _Express_ es un modulo, como lo son el middleware y las librerías de bases de datos que se utilizan en las aplicaciones _Express._
+Un módulo es una biblioteca/archivo de JavaScript que puedes importar en otro código usando la función `require()` de Node. _Express_ en sí mismo es un módulo, al igual que las bibliotecas de middleware y de bases de datos que usamos en nuestras aplicaciones _Express_.
 
-El código mostrado abajo, muestra como puede importarse un modulo con base a su nombre, como ejemplo se utiliza el framework _Express_ . Primero se invoca la función `require()`, indicando como parámetro el nombre del módulo o librería como una cadena (`'express'`), posteriormente se invoca el objeto obtenido para crear una [aplicación Express](https://expressjs.com/en/4x/api.html#app).
-
-Posteriormente, se puede acceder a las propiedades y funciones del objeto Aplicación.
+El código de abajo muestra cómo importamos un módulo por su nombre, usando el framework _Express_ como ejemplo. Primero invocamos la función `require()`, especificando el nombre del módulo como una cadena (`'express'`), y llamando al objeto devuelto para crear una [aplicación Express](https://expressjs.com/en/5x/api.html#app). Después podemos acceder a las propiedades y funciones del objeto de la aplicación.
 
 ```js
-var express = require("express");
-var app = express();
+const express = require("express");
+
+const app = express();
 ```
 
-También podemos crear nuestros propios módulos que puedan posteriormente ser importados de la misma manera.
+También puedes crear tus propios módulos que se puedan importar de la misma manera.
 
 > [!NOTE]
-> Usted puede desear crear sus propios módulos, esto le permitirá organizar su código en partes más administrables; una aplicación que reside en un solo archivo es difícil de entender y manejar.El utilizar módulos independientes también le permite administrar el espacio de nombres, de esta manera unicamente las variables que exporte explícitamente son importadas cuando utilice un módulo.
+> _Querrás_ crear tus propios módulos, porque esto te permite organizar tu código en partes manejables; una aplicación monolítica de un solo archivo es difícil de entender y mantener. Usar módulos también te ayuda a gestionar tu espacio de nombres, porque solo las variables que exportas explícitamente se importan cuando usas un módulo.
 
-Para hacer que los objetos esten disponibles fuera de un modulo, solamente es necesario asignarlos al objeto `exports`. Por ejemplo, el modulo mostrado a continuación **square.js** es un archivo que exporta los métodos `area()` y `perimeter()` :
+Para hacer que los objetos estén disponibles fuera de un módulo, solo necesitas exponerlos como propiedades adicionales del objeto `exports`. Por ejemplo, el módulo **square.js** de abajo es un archivo que exporta los métodos `area()` y `perimeter()`:
 
 ```js
 exports.area = function (width) {
@@ -175,289 +197,312 @@ exports.perimeter = function (width) {
 };
 ```
 
-Nosotros podemos importar este módulo utilizando la función `require()`, y entonces podremos invocar los métodos exportados de la siguiente manera:
+Podemos importar este módulo usando `require()`, y luego llamar al/los método(s) exportado(s) como se muestra:
 
 ```js
-// Utilizamos la función require() El nombre del archivo se ingresa sin la extensión (opcional) .js
-var square = require("./square");
-// invocamos el metodo area()
-console.log("El área de un cuadrado con lado de 4 es " + square.area(4));
+const square = require("./square"); // Here we require() the name of the file without the (optional) .js file extension
+
+console.log(`The area of a square with a width of 4 is ${square.area(4)}`);
 ```
 
 > [!NOTE]
-> Usted también puede especificar una ruta absoluta a la ubicación del módulo (o un nombre como se realizó inicialmente).
+> También puedes especificar una ruta absoluta al módulo (o un nombre, como hicimos inicialmente).
 
-Si usted desea exportar completamente un objeto en una asignación en lugar de construir cada propiedad por separado, debe asignarlo al módulo `module.exports` como se muestra a continuación (también puede hacer esto al inicio de un constructor o de otra función.)
+Si quieres exportar un objeto completo en una sola asignación en lugar de construirlo propiedad por propiedad, asígnalo a `module.exports` como se muestra abajo (también puedes hacer esto para convertir la raíz del objeto exports en un constructor u otra función):
 
 ```js
 module.exports = {
-  area: function (width) {
+  area(width) {
     return width * width;
   },
 
-  perimeter: function (width) {
+  perimeter(width) {
     return 4 * width;
   },
 };
 ```
 
-Para más información acerca de módulos vea [Modulos](https://nodejs.org/api/modules.html#modules_modules) (_Node_ API docs).
+> [!NOTE]
+> Puedes pensar en `exports` como un [atajo](https://nodejs.org/api/modules.html#modules_exports_shortcut) a `module.exports` dentro de un módulo dado. De hecho, `exports` es simplemente una variable que se inicializa con el valor de `module.exports` antes de que se evalúe el módulo. Ese valor es una referencia a un objeto (un objeto vacío en este caso). Esto significa que `exports` contiene una referencia al mismo objeto al que hace referencia `module.exports`. También significa que, al asignar otro valor a `exports`, este deja de estar vinculado a `module.exports`.
 
-### Usando APIs asíncronas
+Para mucha más información sobre módulos, consulta [Modules](https://nodejs.org/api/modules.html#modules_modules) (documentación de la API de Node).
 
-El código JavaScript usa frecuentemente APIs asíncronas antes que sincrónicas para operaciones que tomen algún tiempo en completarse. En una API sincrónica cada operación debe completarse antes de que la siguiente pueda comenzar. Por ejemplo, la siguiente función de registro es síncrona, y escribirá en orden el texto en la consola (Primero, Segundo).
+### Uso de APIs asíncronas
+
+El código JavaScript usa frecuentemente APIs asíncronas en lugar de síncronas para operaciones que pueden tardar algún tiempo en completarse. Una API síncrona es aquella en la que cada operación debe completarse antes de que pueda empezar la siguiente. Por ejemplo, las siguientes funciones de registro son síncronas, y mostrarán el texto en la consola en orden (First, Second).
 
 ```js
-console.log("Primero");
-console.log("Segundo");
+console.log("First");
+console.log("Second");
 ```
 
-En contraste, en una API asincrónica, la API comenzará una operación e inmediatamente retornará (antes de que la operación se complete). Una vez que la operación finalice, la API usará algún mecanismo para realizar operaciones adicionales. Por ejemplo, el código de abajo imprimirá "Segundo, Primero" porque aunque el método `setTimeout()` es llamado primero y retorna inmediatamente, la operación no se completa por varios segundos.
+Por el contrario, una API asíncrona es aquella en la que la API inicia una operación y retorna inmediatamente (antes de que la operación se complete). Una vez que la operación termina, la API usa algún mecanismo para realizar operaciones adicionales. Por ejemplo, el siguiente código imprimirá "Second, First" porque, aunque el método `setTimeout()` se llama primero y retorna de inmediato, la operación no se completa hasta pasados varios segundos.
 
 ```js
-setTimeout(function () {
-  console.log("Primero");
+setTimeout(() => {
+  console.log("First");
 }, 3000);
-console.log("Segundo");
+console.log("Second");
 ```
 
-Usar APIs asíncronas sin bloques es aun mas importante en _Node_ que en el navegador, porque _Node_ es un entorno de ejecución controlado por eventos de un solo hilo. "Un solo hilo" quiere decir que todas las peticiones al servidor son ejecutadas en el mismo hilo ( en vez de dividirse en procesos separados). Este modelo es extremadamente eficiente en términos de velocidad y recursos del servidor, pero eso significa que si alguna de sus funciones llama a métodos sincrónicos que tomen demasiado tiempo en completarse, bloquearan no solo la solicitud actual, sino también cualquier otra petición que este siendo manejada por tu aplicación web.
+Usar APIs asíncronas no bloqueantes es aún más importante en Node que en el navegador, porque las aplicaciones de _Node_ suelen escribirse como un entorno de ejecución de un solo hilo dirigido por eventos. "Un solo hilo" significa que todas las solicitudes al servidor se ejecutan en el mismo hilo (en lugar de generarse en procesos separados). Este modelo es extremadamente eficiente en cuanto a velocidad y recursos del servidor. Sin embargo, sí significa que, si alguna de tus funciones llama a métodos síncronos que tardan mucho en completarse, bloquearán no solo la solicitud actual, sino también cualquier otra solicitud que esté manejando tu aplicación web.
 
-Hay muchas maneras para una API asincrónica de notificar a su aplicación que se ha completado. La manera mas común es registrar una función callback cuando usted invoca a una API asincrónica, la misma será llamada de vuelta cuando la operación se complete. Éste es el enfoque utilizado anteriormente.
-
-> [!NOTE]
-> Usar "callbacks" puede ser un poco enmarañado si usted tiene una secuencia de operaciones asíncronas dependientes que deben ser llevadas a cabo en orden, porque esto resulta en múltiples niveles de "callbacks" anidadas. Este problema es comúnmente conocido como "callback hell" (callback del infierno). Este problema puede ser reducido con buenas practicas de código (vea <http://callbackhell.com/>), usando un modulo como [async](https://www.npmjs.com/package/async), o incluso avanzando a características de ES6 como las [promesas](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+Hay varias maneras en que una API asíncrona puede notificar a tu aplicación que ha terminado. Históricamente, el enfoque utilizado era registrar una función de retorno de llamada (callback) al invocar la API asíncrona, la cual se llama cuando la operación se completa (este es el enfoque usado arriba).
 
 > [!NOTE]
-> Una convención común para _Node_ y _Express_ es usar callbacks de error primero. En esta convención el primer valor en su función callback es un error, mientras que los argumentos subsecuentes contienen datos correctos. Hay una buena explicación de porque este enfoque es útil en este blog: [The Node.js Way - Understanding Error-First Callbacks](http://fredkschott.com/post/2014/03/understanding-error-first-callbacks-in-node-js) (fredkschott.com).
+> Usar callbacks puede resultar bastante "desordenado" si tienes una secuencia de operaciones asíncronas dependientes que deben realizarse en orden, porque esto da lugar a múltiples niveles de callbacks anidados. Este problema se conoce comúnmente como "callback hell" (el infierno de los callbacks).
 
-### Creando manejadores de rutas
+> [!NOTE]
+> Una convención común en Node y Express es usar callbacks con el error primero (_error-first callbacks_). En esta convención, el primer valor en tus _funciones de retorno de llamada_ es un valor de error, mientras que los argumentos siguientes contienen los datos de éxito. Hay una buena explicación de por qué este enfoque es útil en este blog: [The Node.js Way - Understanding Error-First Callbacks](https://fredkschott.com/post/2014/03/understanding-error-first-callbacks-in-node-js/) (fredkschott.com).
 
-En nuestro ejemplo anterior de "Hola Mundo!" en _Express_ (véase mas arriba), definimos una función (callback) manejadora de ruta para peticiones HTTP `GET` a la raíz del sitio (`'/'`).
+El código JavaScript moderno usa más comúnmente [promesas](/es/docs/Web/JavaScript/Reference/Global_Objects/Promise) y [async/await](/es/docs/Web/JavaScript/Reference/Statements/async_function) para gestionar el flujo asíncrono del programa.
+Deberías usar promesas siempre que sea posible. Si trabajas con código que usa callbacks, puedes usar la función [`utils.promisify`](https://nodejs.org/api/util.html#utilpromisifyoriginal) de Node.js para gestionar la conversión de callback a promesa de forma cómoda.
+
+### Creación de manejadores de rutas
+
+En nuestro ejemplo de Express de _Hello World_ (ver arriba), definimos una función manejadora de ruta (callback) para solicitudes HTTP `GET` a la raíz del sitio (`'/'`).
 
 ```js
-app.get("/", function (req, res) {
+app.get("/", (req, res) => {
   res.send("Hello World!");
 });
 ```
 
-La función callback toma una petición y una respuesta como argumentos. En este caso el método simplemente llama a [`send()`](https://expressjs.com/en/4x/api.html#res.send) en la respuesta para retornar la cadena "Hello World!". Hay un [número de otros métodos de respuesta](https://expressjs.com/en/guide/routing.html#response-methods) para finalizar el ciclo de solicitud/respuesta, por ejemplo podrá llamar a [`res.json()`](https://expressjs.com/en/4x/api.html#res.json) para enviar una respuesta JSON o [`res.sendFile()`](https://expressjs.com/en/4x/api.html#res.sendFile) para enviar un archivo.
+La función de retorno de llamada toma un objeto de solicitud y uno de respuesta como argumentos. En este caso, el método llama a [`send()`](https://expressjs.com/en/5x/api.html#res.send) en la respuesta para devolver la cadena "Hello World!" Hay [varios otros métodos de respuesta](https://expressjs.com/en/guide/routing.html#response-methods) para finalizar el ciclo de solicitud/respuesta; por ejemplo, podrías llamar a [`res.json()`](https://expressjs.com/en/5x/api.html#res.json) para enviar una respuesta JSON, o a [`res.sendFile()`](https://expressjs.com/en/5x/api.html#res.sendFile) para enviar un archivo.
 
 > [!NOTE]
-> Usted puede utilizar cualquier nombre que quiera para los argumentos en las funciones callback; cuando la callback es invocada el primer argumento siempre sera la petición y el segundo siempre sera la respuesta. Tiene sentido nombrarlos de manera que pueda identificar el objeto con el que esta trabajando en el cuerpo de la callback.
+> Puedes usar los nombres de argumento que quieras en las funciones de retorno de llamada; cuando se invoca el callback, el primer argumento siempre será la solicitud y el segundo siempre será la respuesta. Tiene sentido nombrarlos de forma que puedas identificar el objeto con el que estás trabajando en el cuerpo del callback.
 
-El objeto que representa una aplicación de _Express_, también posee métodos para definir los manejadores de rutas para el resto de los verbos HTTP: `post()`, `put()`, `delete()`, `options()`, `trace()`, `copy()`, `lock()`, `mkcol()`, `move()`, `purge()`, `propfind()`, `proppatch()`, `unlock()`, `report()`, `mkactivity()`, `checkout()`, `merge()`, `m-search()`, `notify()`, `subscribe()`, `unsubscribe()`, `patch()`, `search()`, y `connect()`.
+El objeto de la _aplicación Express_ también proporciona métodos para definir manejadores de rutas para todos los demás verbos HTTP, que se usan mayormente de la misma manera:
 
-Hay un método general para definir las rutas: `app.all()`, el cual será llamado en respuesta a cualquier método HTTP. Se usa para cargar funciones del middleware en una dirección particular para todos los métodos de peticiones. El siguiente ejemplo (de la documentación de _Express_) muestra el uso de los manejadores a `/secret` sin tener en cuenta el verbo HTTP utilizado (siempre que esté definido por el [módulo http](https://nodejs.org/api/http.html#http_http_methods)).
+`checkout()`, `copy()`, **`delete()`**, **`get()`**, `head()`, `lock()`, `merge()`, `mkactivity()`, `mkcol()`, `move()`, `m-search()`, `notify()`, `options()`, `patch()`, **`post()`**, `purge()`, **`put()`**, `report()`, `search()`, `subscribe()`, `trace()`, `unlock()`, `unsubscribe()`.
+
+Hay un método de enrutamiento especial, `app.all()`, que se llamará en respuesta a cualquier método HTTP. Se usa para cargar funciones de middleware en una ruta en particular para todos los métodos de solicitud. El siguiente ejemplo (de la documentación de Express) muestra un manejador que se ejecutará para solicitudes a `/secret`, sin importar el verbo HTTP utilizado (siempre que sea compatible con el [módulo http](https://nodejs.org/docs/latest/api/http.html#httpmethods)).
 
 ```js
-app.all("/secret", function (req, res, next) {
-  console.log("Accediendo a la seccion secreta ...");
-  next(); // pasa el control al siguiente manejador
+app.all("/secret", (req, res, next) => {
+  console.log("Accessing the secret section…");
+  next(); // pass control to the next handler
 });
 ```
 
-Las rutas le permiten igualar patrones particulares de caracteres en la URL, y extraer algunos valores de ella y pasarlos como parámetros al manejador de rutas (como atributo del objeto petición pasado como parámetro).
+Las rutas te permiten hacer coincidir patrones particulares de caracteres en una URL, y extraer algunos valores de la URL para pasarlos como parámetros al manejador de ruta (como atributos del objeto de solicitud pasado como parámetro).
 
-Usualmente es útil agrupar manejadores de rutas para una parte del sitio juntos y accederlos usando un prefijo de ruta en común. (Ej: un sitio con una Wiki podría tener todas las rutas relacionadas a dicha sección en un archivo y siendo accedidas con el prefijo de ruta /wiki/. En _Express_ esto se logra usando el objeto [`express.Router`](http://expressjs.com/en/guide/routing.html#express-router). Ej: podemos crear nuestra ruta wiki en un módulo llamado wiki.js, y entonces exportar el objeto `Router`, como se muestra debajo:
+A menudo es útil agrupar los manejadores de ruta de una parte concreta de un sitio y acceder a ellos usando un prefijo de ruta común (por ejemplo, un sitio con una wiki podría tener todas las rutas relacionadas con la wiki en un archivo y acceder a ellas con un prefijo de ruta _/wiki/_). En _Express_ esto se logra usando el objeto [`express.Router`](https://expressjs.com/en/guide/routing.html#express-router). Por ejemplo, podemos crear nuestra ruta de wiki en un módulo llamado **wiki.js**, y luego exportar el objeto `Router`, como se muestra abajo:
 
 ```js
-// wiki.js - Modulo de rutas Wiki
+// wiki.js - Wiki route module
 
-var express = require("express");
-var router = express.Router();
+const express = require("express");
+
+const router = express.Router();
 
 // Home page route
-router.get("/", function (req, res) {
-  res.send("Página de inicio Wiki");
+router.get("/", (req, res) => {
+  res.send("Wiki home page");
 });
 
 // About page route
-router.get("/about", function (req, res) {
-  res.send("Acerca de esta wiki");
+router.get("/about", (req, res) => {
+  res.send("About this wiki");
 });
 
 module.exports = router;
 ```
 
 > [!NOTE]
-> Agregar rutas al objeto `Router` es como agregar rutas al objeto `app` (como se vio anteriormente).
+> Añadir rutas al objeto `Router` es igual que añadir rutas al objeto `app` (como se mostró antes).
 
-Para usar el router en nuestro archivo app principal, necesitamos `require()` el módulo de rutas (**wiki.js**), entonces llame `use()` en la aplicación _Express_ para agregar el Router al software intermediario que maneja las rutas. Las dos rutas serán accesibles entonces desde `/wiki/` y `/wiki/about/`.
+Para usar el router en nuestro archivo de app principal, haríamos `require()` del módulo de ruta (**wiki.js**), y luego llamaríamos a `use()` en la _aplicación Express_ para añadir el Router a la ruta de manejo de middleware. Las dos rutas serían entonces accesibles desde `/wiki/` y `/wiki/about/`.
 
 ```js
-var wiki = require("./wiki.js");
-// ...
+const wiki = require("./wiki.js");
+
+// …
 app.use("/wiki", wiki);
 ```
 
-Le mostraremos mucho más sobre como trabajar con rutas, y en particular, acerca de como usar el `Router`, más adelante en la sección [Rutas y controladores .](/es/docs/Learn/Server-side/Express_Nodejs/routes)
+Te mostraremos mucho más sobre cómo trabajar con rutas, y en particular sobre el uso de `Router`, más adelante en la sección enlazada [Rutas y controladores](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/routes).
 
-### Usando middleware
+### Uso de middleware
 
-El "middleware" es ampliamente utilizado en las aplicaciones de _Express:_ desde tareas para servir archivos estáticos, a la gestión de errores o la compresión de las respuestas HTTP. Mientras las funciones de enrutamiento, con el objeto [express.Router](http://expressjs.com/en/guide/routing.html#express-router), se encargan del ciclo petición-respuesta, al gestionar la respuesta adecuada al cliente, las funciones de middleware normalmente realizan alguna operación al gestionar una petición o respuesta y a continuación llaman a la siguiente función en la "pila", que puede ser otra función de middleware u otra función de enrutamiento. El orden en el que las funciones de middleware son llamadas depende del desarrollador de la aplicación.
+El middleware se usa extensamente en las aplicaciones Express, para tareas que van desde servir archivos estáticos hasta el manejo de errores, pasando por la compresión de respuestas HTTP. Mientras que las funciones de ruta terminan el ciclo de solicitud-respuesta HTTP devolviendo alguna respuesta al cliente HTTP, las funciones de middleware _normalmente_ realizan alguna operación en la solicitud o la respuesta y luego llaman a la siguiente función en la "pila", que puede ser más middleware o un manejador de ruta. El orden en que se llama al middleware depende del desarrollador de la aplicación.
 
 > [!NOTE]
-> El middleware puede realizar cualquier operación: hacer cambios a una petición, ejecutar código, realizar cambios a la petición o al objeto pedido, puede también finalizar el ciclo de petición-respuesta. Si no finaliza el ciclo debe llamar a la función `next()` para pasar el control de la ejecución a la siguiente función del middleware ( o a la petición quedaría esperando una respuesta ... ).
+> El middleware puede realizar cualquier operación, ejecutar cualquier código, hacer cambios en el objeto de solicitud y de respuesta, y _también puede terminar el ciclo de solicitud-respuesta_. Si no termina el ciclo, debe llamar a `next()` para pasar el control a la siguiente función de middleware (o la solicitud quedará colgada).
 
-La mayoría de las aplicaciones usan middleware desarrollado por terceras partes, para simplificar funciones habituales en el desarrollo web, como puede ser: gestión de cookies, sesiones, autentificado de usuarios, peticiones `POST` y datos en JSON, registros de eventos, etc. Puede encontrar en el siguiente enlace una [lista de middleware mantenido por el equipo de _Express_](http://expressjs.com/en/resources/middleware.html) (que también incluye otros paquetes populares de terceras partes). Las librerías de _Express_ están disponibles con la aplicación NPM (Node Package Manager).
+La mayoría de las aplicaciones usarán middleware de _terceros_ para simplificar tareas comunes de desarrollo web como trabajar con cookies, sesiones, autenticación de usuarios, acceder a datos `POST` y JSON de la solicitud, registro de eventos, etc. Puedes encontrar una [lista de paquetes de middleware mantenidos por el equipo de Express](https://expressjs.com/en/resources/middleware.html) (que también incluye otros paquetes populares de terceros). Hay otros paquetes de Express disponibles en el gestor de paquetes npm.
 
-Para usar estas colecciones, primero ha de instalar la aplicación usando NPM. Por ejemplo para instalar el registro de peticiones HTTP [morgan](http://expressjs.com/en/resources/middleware/morgan.html), se haría con el comando Bash:
+Para usar middleware de terceros, primero necesitas instalarlo en tu app usando npm.
+Por ejemplo, para instalar el middleware de registro de solicitudes HTTP [morgan](https://expressjs.com/en/resources/middleware/morgan.html), harías esto:
 
 ```bash
 npm install morgan
 ```
 
-Entonces podría llamar a la función `use()` en un objeto de aplicación _Express_ para utilizar este middleware a su aplicación.
+Después podrías llamar a `use()` en el _objeto de aplicación Express_ para añadir el middleware a la pila:
 
 ```js
-var express = require('express');
-var logger = require('morgan');
-var app = express();
-app.use(logger('dev'));
-...
+const express = require("express");
+const logger = require("morgan");
+
+const app = express();
+app.use(logger("dev"));
+// …
 ```
 
 > [!NOTE]
-> Las funciones Middleware y routing son llamadas en el orden que son declaradas. Para algunos middleware el orden es importante (por ejemplo si el middleware de sesion depende del middleware de cookie, entonces el manejador de cookie tiene que ser llamado antes). Casi siempre es el caso que el middleware es llamado antes de configurar las rutas, o tu manejador de rutas no tendra acceso a la funcionalidad agregada por tu middleware.
+> Las funciones de middleware y de enrutamiento se llaman en el orden en que se declaran. Para algunos middleware el orden es importante (por ejemplo, si el middleware de sesión depende del middleware de cookies, entonces el manejador de cookies debe añadirse primero). Casi siempre es el caso de que el middleware se llama antes de establecer las rutas, o tus manejadores de ruta no tendrán acceso a la funcionalidad añadida por tu middleware.
 
-Tu puedes escribir tu propia funcion middleware, y si quieres hacerlo así (solo para crear código de manejo de error). La única diferencia entre una función middleware y un callback manejador de rutas es que las funciones middleware tienen un tercer argumento `next`, cuyas funciones middleware son esperadas para llamarlas si ellas no completan el ciclo request (cuando la función midleware es llamada, esta contiene la próxima función que debe ser llamada).
+Puedes escribir tus propias funciones de middleware, y es probable que tengas que hacerlo (aunque solo sea para crear código de manejo de errores). La **única** diferencia entre una función de middleware y un callback de manejador de ruta es que las funciones de middleware tienen un tercer argumento, `next`, que se espera que las funciones de middleware llamen si no son las que completan el ciclo de solicitud (cuando se llama a la función de middleware, este contiene la función _siguiente_ que debe llamarse).
 
-Puede agregar una función middleware a la cadenan de procesamiento con cualquier `app.use()` o `app.add()`, dependiendo de si quiere aplicar el middleware a todas las respuestas o a respuestas con un verbo particular HTTP (`GET`, `POST`, etc). Usted especifica rutas, lo mismo en ambos casos, aunque la ruta es opcional cuando llama **app.use()**.
+Puedes añadir una función de middleware a la cadena de procesamiento para _todas las respuestas_ con `app.use()`, o para un verbo HTTP específico usando el método asociado: `app.get()`, `app.post()`, etc. Las rutas se especifican de la misma manera en ambos casos, aunque la ruta es opcional al llamar a `app.use()`.
 
-El ejemplo de abajo muestra como puede agregar la función middleware usando ambos métodos, y con/sin una ruta.
+El ejemplo de abajo muestra cómo puedes añadir la función de middleware usando ambos enfoques, y con/sin una ruta.
 
 ```js
-var express = require("express");
-var app = express();
+const express = require("express");
+
+const app = express();
 
 // An example middleware function
-var a_middleware_function = function (req, res, next) {
-  // ... perform some operations
+function middlewareFunction(req, res, next) {
+  // Perform some operations
   next(); // Call next() so Express will call the next middleware function in the chain.
-};
+}
 
 // Function added with use() for all routes and verbs
-app.use(a_middleware_function);
+app.use(middlewareFunction);
 
 // Function added with use() for a specific route
-app.use("/someroute", a_middleware_function);
+app.use("/some-route", middlewareFunction);
 
 // A middleware function added for a specific HTTP verb and route
-app.get("/", a_middleware_function);
+app.get("/", middlewareFunction);
 
 app.listen(3000);
 ```
 
 > [!NOTE]
-> Arriba declaramos la función middleware separadamente y la configuramos como el callback. En nuestra función previous manejadora de ruta declaramos la función callback cuando esta fué usada. En JavaScript, cualquier aproximación es válida.
+> Arriba declaramos la función de middleware por separado y luego la establecemos como el callback. En nuestra función manejadora de ruta anterior, declaramos la función de callback en el momento de usarla. En JavaScript, ambos enfoques son válidos.
 
-La documentación Express tiene mucha mas documentación excelente acerca del uso y escritura de middleware Express.
+La documentación de Express tiene mucha más documentación excelente sobre cómo [usar](https://expressjs.com/en/guide/using-middleware.html) y [escribir](https://expressjs.com/en/guide/writing-middleware.html) middleware de Express.
 
-### Sirviendo archivos estáticos
+### Servir archivos estáticos
 
-Puede utilizar el middleware [express.static](http://expressjs.com/en/4x/api.html#express.static) para servir archivos estáticos, incluyendo sus imagenes, CSS y JavaScript (`static()` es la única función middleware que es actualmente **parte** de _Express_). Por ejemplo, podria utilizar la linea de abajo para servir imágenes, archivos CSS, y archivos JavaScript desde un directorio nombrado '**public'** al mismo nivel desde donde llama a node:
+Puedes usar el middleware [express.static](https://expressjs.com/en/5x/api.html#express.static) para servir archivos estáticos, incluyendo tus imágenes, CSS y JavaScript (`static()` es la única función de middleware que realmente forma **parte** de _Express_). Por ejemplo, usarías la línea de abajo para servir imágenes, archivos CSS y archivos JavaScript desde un directorio llamado '**public**' en el mismo nivel desde donde llamas a node:
 
 ```js
 app.use(express.static("public"));
 ```
 
-Cualesquiere archivos en el directorio público son servidos al agregar su nombre de archivo (_relativo_ a la ubicación del directorio "público" ) de la ubicación URL. Por ejemplo:
+Cualquier archivo en el directorio public se sirve añadiendo su nombre de archivo (_relativo_ al directorio base "public") a la URL base. Así, por ejemplo:
 
-```
+```plain
 http://localhost:3000/images/dog.jpg
 http://localhost:3000/css/style.css
 http://localhost:3000/js/app.js
 http://localhost:3000/about.html
 ```
 
-Puede llamar `static()` multiples ocasiones a servir multiples directorios. Si un archivo no puede ser encontrado por una función middleware entonces este simplemente será pasado en la subsequente middleware (el orden en que el middleware está basado en su orden de declaración).
+Puedes llamar a `static()` varias veces para servir varios directorios. Si una función de middleware no puede encontrar un archivo, este se pasará al siguiente middleware (el orden en que se llama al middleware se basa en el orden en que lo declaraste).
 
 ```js
 app.use(express.static("public"));
 app.use(express.static("media"));
 ```
 
-Tambien puede crear un prefijo virtual para sus URLs estáticas, aun más teniendo los archivos agregados en la ubicación URL. Por ejemplo, aqui especificamos [a mount path](http://expressjs.com/en/4x/api.html#app.use) tal que los archivos son bajados con el prefijo "/media":
+También puedes crear un prefijo virtual para tus URLs estáticas, en lugar de que los archivos se añadan a la URL base. Por ejemplo, aquí [especificamos una ruta de montaje](https://expressjs.com/en/5x/api.html#app.use) para que los archivos se carguen con el prefijo "/media":
 
 ```js
 app.use("/media", express.static("public"));
 ```
 
-Ahora, puede bajar los archivos que estan en el directorio `publico` del path con prefijo `/media`.
+Ahora puedes cargar los archivos que están en el directorio `public` desde el prefijo de ruta `/media`.
 
-```
+```plain
 http://localhost:3000/media/images/dog.jpg
 http://localhost:3000/media/video/cat.mp4
 http://localhost:3000/media/cry.mp3
 ```
 
-Para más información, ver [Sirviendo archivos estáticos en Express](https://expressjs.com/en/starter/static-files.html).
+> [!NOTE]
+> Consulta también [Serving static files in Express](https://expressjs.com/en/starter/static-files.html).
 
-### Manejando errores
+### Manejo de errores
 
-Los errores manejados por una o más funciones especiales middleware que tienen cuatro argumentos, en lugar de las usuales tres: `(err, req, res, next)`. For example:
+Los errores se manejan mediante una o más funciones especiales de middleware que tienen cuatro argumentos, en lugar de los tres habituales: `(err, req, res, next)`. Por ejemplo:
 
 ```js
-app.use(function (err, req, res, next) {
+app.use((err, req, res, next) => {
   console.error(err.stack);
   res.status(500).send("Something broke!");
 });
 ```
 
-Estas pueden devolver cualquier contenido, pero deben ser llamadas despues de todas las otras `app.use()` llamadas de rutas tal que ellas son las últimas middleware en el proceso de manejo de request!
+Estas pueden devolver cualquier contenido requerido, pero deben llamarse después de todas las demás llamadas a `app.use()` y de rutas, para que sean el último middleware en el proceso de manejo de solicitudes.
 
-Express viene con un manejador de error integrado, el que se ocupa de error remanente que pudiera ser encontrado en la app. Esta función middleware manejador de error esta agregada al final del stack de funciones middleware. Si pasa un error a `next()` y no lo maneja en un manejador de error, este sera manejado por el manejador de error integrado; el error sera escrito en el cliente con el rastreo de pila.
-
-> [!NOTE]
-> El rastreo de pila no esta incluido en el ambiente de producción. Para ejecutarlo en modo de producción necesita configurar la variable de ambiente `NODE_ENV` to '`production'`.
+Express viene con un manejador de errores integrado, que se encarga de cualquier error restante que pueda encontrarse en la app. Esta función de middleware de manejo de errores por defecto se añade al final de la pila de funciones de middleware. Si pasas un error a `next()` y no lo manejas en un manejador de errores, será manejado por el manejador de errores integrado; el error se escribirá al cliente junto con el seguimiento de la pila (stack trace).
 
 > [!NOTE]
-> HTTP404 y otros codigos de estatus de "error" no son tratados como errores. Si quiere manejar estos, puede agregar una función middleware para hacerlo. Para mas información vea las [FAQ](http://expressjs.com/en/starter/faq.html#how-do-i-handle-404-responses).
+> El seguimiento de la pila no se incluye en el entorno de producción. Para ejecutarlo en modo de producción, necesitas establecer la variable de entorno `NODE_ENV` en `"production"`.
 
-Para mayor información vea Manejo de error (Docs. Express).
+> [!NOTE]
+> HTTP404 y otros códigos de estado de "error" no se tratan como errores. Si quieres manejarlos, puedes añadir una función de middleware para hacerlo. Para más información, consulta las [preguntas frecuentes](https://expressjs.com/en/starter/faq.html#how-do-i-handle-404-responses).
 
-### Usando Bases de datos
+Para más información, consulta [Error handling](https://expressjs.com/en/guide/error-handling.html) (documentación de Express).
 
-Las apps de _Express_ pueden usar cualquier mecanismo de bases de datos suportadas por _Node_ (_Express_ en sí mismo no define ningúna conducta/requerimiento specifico adicional para administración de bases de datos). Hay muchas opciones, incluyendo PostgreSQL, MySQL, Redis, SQLite, MongoDB, etc.
+### Uso de bases de datos
 
-Con el propósito de usar éste, debe primero instalar el manejador de bases de datos utilizando NPM. Por ejemplo, para instalar el manejador para el popular NoSQL MongoDB querría utilizar el comando:
+Las apps _Express_ pueden usar cualquier mecanismo de base de datos compatible con _Node_ (_Express_ en sí mismo no define ningún comportamiento/requisito adicional específico para la gestión de bases de datos). Hay muchas opciones, incluyendo PostgreSQL, MySQL, Redis, SQLite, MongoDB, etc.
+
+Para usarlas, primero tienes que instalar el driver de base de datos usando npm. Por ejemplo, para instalar el driver del popular MongoDB NoSQL, usarías el comando:
 
 ```bash
 npm install mongodb
 ```
 
-La base de datos por si misma puede ser instalada localmente o en un servidor de la nube. En su codigo Express requiere el manejador, conectarse a la base de datos, y entonces ejecutar operaciones crear, leer, actualizar, y borrar (CLAB). }El ejemplo de abajo (de la documentación Express documentation) muestra como puede encontrar registros en la colección "mamiferos" usando MongoDB.
+La base de datos en sí se puede instalar localmente o en un servidor en la nube. En tu código Express importas el driver, te conectas a la base de datos, y luego realizas operaciones de crear, leer, actualizar y eliminar (CRUD).
+El siguiente ejemplo muestra cómo puedes buscar registros de "mamíferos" usando MongoDB:
 
 ```js
-var MongoClient = require("mongodb").MongoClient;
+const { MongoClient } = require("mongodb");
 
-MongoClient.connect("mongodb://localhost:27017/animals", function (err, db) {
-  if (err) throw err;
+const uri = "mongodb://localhost:27017";
+const client = new MongoClient(uri);
 
-  db.collection("mammals")
-    .find()
-    .toArray(function (err, result) {
-      if (err) throw err;
+async function run() {
+  try {
+    await client.connect();
+    const db = client.db("animals");
+    const mammals = await db.collection("mammals").find().toArray();
+    console.log(mammals);
+  } finally {
+    await client.close();
+  }
+}
 
-      console.log(result);
-    });
-});
+run().catch(console.error);
 ```
 
-Otra aproximación popular es acceder a su base de datos indirectamente, via an Mapeo Objeto Relacional ("MOR"). En esta aproximación usted define sus datos como "objetos" o "modelos" y el MOR mapea estos a través del deliniamiento basico de la base de datos. Esta aproximación tiene el beneficio de que como un desrrollador puede continuar pensando en términos de objetos de JavaScript mas que en semántica de bases de datos, y en esto hay un lugar obvio para ejecutar la validación y chequeo de entrada de datos. Hablaremos más de bases de datos en un artículo posterior.
+Otro enfoque popular es acceder a tu base de datos indirectamente, mediante un mapeador objeto-relacional ("ORM"). En este enfoque defines tus datos como "objetos" o "modelos" y el ORM los mapea al formato subyacente de la base de datos. Este enfoque tiene la ventaja de que, como desarrollador, puedes seguir pensando en términos de objetos JavaScript en lugar de en semántica de base de datos, y de que hay un lugar obvio para realizar la validación y comprobación de los datos entrantes. Hablaremos más sobre bases de datos en un artículo posterior.
 
-Para más información ver [Integracion de Bases de Datos](https://expressjs.com/en/guide/database-integration.html) (docs Express ).
+Para más información, consulta [Database integration](https://expressjs.com/en/guide/database-integration.html) (documentación de Express).
 
-### Renderización de data (vistas)
+### Renderizado de datos (vistas)
 
-El Motor de plantilla (referido como "motor de vistas" por _Express_) le permite definir la estructura de documento de salida en una plantilla, usando marcadores de posición para datos que seran llenados cuando una pagina es generada. Las plantillas son utilizadas generalmete para crear HTML, pero tambien pueden crear otros tipos de documentos. Express tiene soporte para [numerosos motores de plantillas](https://github.com/expressjs/express/wiki#template-engines), y hay una util comparación de los motores más populares aquí: [Comparando Motores de Plantillas de JavaScript: Jade, Mustache, Dust and More](https://strongloop.com/strongblog/compare-javascript-templates-jade-mustache-dust/).
+Los motores de plantillas (también llamados "motores de vistas" en _Express_) te permiten especificar la _estructura_ de un documento de salida en una plantilla, usando marcadores de posición para los datos que se rellenarán cuando se genere una página. Las plantillas se usan a menudo para crear HTML, pero también pueden crear otros tipos de documentos.
 
-En su código de configuración de su aplicación usted configura el motor de plantillas para usar y su localización Express podiría buscar plantillas usando las configuraciones de 'vistas' y 'motores de vistas', mostrado abajo (tendría también que instalar el paquete conteniendo su librería de plantillas!)
+Express tiene soporte para varios motores de plantillas, en particular Pug (antes "Jade"), Mustache y EJS. Cada uno tiene sus propias fortalezas para abordar casos de uso concretos (las comparaciones relativas se pueden encontrar fácilmente mediante una búsqueda en Internet).
+El generador de aplicaciones de Express usa Jade como motor por defecto, pero también admite varios otros.
+
+En el código de configuración de tu aplicación estableces el motor de plantillas a usar y la ubicación donde Express debe buscar las plantillas, usando los ajustes 'views' y 'view engine', como se muestra abajo (¡también tendrás que instalar el paquete que contiene tu biblioteca de plantillas!)
 
 ```js
-var express = require("express");
-var app = express();
+const express = require("express");
+const path = require("path");
+
+const app = express();
 
 // Set directory to contain the templates ('views')
 app.set("views", path.join(__dirname, "views"));
@@ -466,39 +511,41 @@ app.set("views", path.join(__dirname, "views"));
 app.set("view engine", "some_template_engine_name");
 ```
 
-La apariencia de la plantilla dependera de qué motor use. Asumiendo que tiene un archivo de plantillas nombrado "index.\<template_extension>" este contiene placeholders para variables de datos nombradas 'title' y "message", podría llamar [`Response.render()`](http://expressjs.com/en/4x/api.html#res.render) en una función manejadora de rutas para crear y enviar la HTML response:
+El aspecto de la plantilla dependerá de qué motor uses. Suponiendo que tienes un archivo de plantilla llamado "index.\<template_extension>" que contiene marcadores de posición para las variables de datos llamadas 'title' y "message", llamarías a [`Response.render()`](https://expressjs.com/en/5x/api.html#res.render) en una función manejadora de ruta para crear y enviar la respuesta HTML:
 
 ```js
-app.get("/", function (req, res) {
+app.get("/", (req, res) => {
   res.render("index", { title: "About dogs", message: "Dogs rock!" });
 });
 ```
 
-Para más información vea [Usando motores de plantillas con Express](http://expressjs.com/en/guide/using-template-engines.html) (docs Express ).
+Para más información, consulta [Using template engines with Express](https://expressjs.com/en/guide/using-template-engines.html) (documentación de Express).
 
-### Estructura de Archivos
+### Estructura de archivos
 
-Express no hace asunciones en términos de estructura o que componentes usted usa. Rutas, vistas, archivos estáticos, y otras lógicas de aplicación específica puede vivir en cualquier número de archivos con cualquier estructura de directorio. Mientras que esto es perfectamente posible, se puede tener toda la aplicación en un solo archivo, en _Express_, tipicamente esto tiene sentido al desplegar su aplicacion dentro de archivos basados en función (e.g. administracion de cuentas, blogs, tableros de discusion) y dominio de problema arquitectonico (e.g. modelo, vista or controlador si tu pasas a estar usando una [arquitectura MVC](/es/docs/Web/Apps/Fundamentals/Modern_web_app_architecture/MVC_architecture)).
+Express no hace suposiciones en cuanto a la estructura o los componentes que usas. Las rutas, vistas, archivos estáticos y demás lógica específica de la aplicación pueden estar en cualquier número de archivos con cualquier estructura de directorios. Aunque es perfectamente posible tener toda la aplicación _Express_ en un solo archivo, normalmente tiene sentido dividir tu aplicación en archivos según la función (por ejemplo, gestión de cuentas, blogs, foros de discusión) y el dominio del problema arquitectónico (por ejemplo, modelo, vista o controlador, si estás usando una [arquitectura MVC](/es/docs/Glossary/MVC)).
 
-En un tópico posterior usaremos el Generador de Aplicaciones _Express Application Generator_, el que crea un esquelo de una app modular que podemos facilmente extender para crear aplicaciones web.
+En un tema posterior usaremos el _generador de aplicaciones Express_, que crea un esqueleto de app modular que podemos ampliar fácilmente para crear aplicaciones web.
 
 ## Resumen
 
-¡Felicitaciones, ha completado el primer paso en su viaje Express/Node! Ahora debes comprender los principales beneficios de Express y Node, y más o menos cómo se verían las partes principales de una aplicación Express (rutas, middleware, manejo de errores y plantillas). ¡También debe comprender que con Express como un framework unopinionated, la forma en que une estas partes y las bibliotecas que usa dependen en gran medida de usted!
+¡Felicidades, has completado el primer paso de tu recorrido por Express/Node! Ahora deberías entender los principales beneficios de Express y Node, y a grandes rasgos cómo podrían ser las partes principales de una app Express (rutas, middleware, manejo de errores y código de plantillas). También deberías entender que, al ser Express un framework no dogmático, la forma en que combines estas partes y las bibliotecas que uses dependen en gran medida de ti.
 
-Por supuesto, Express es deliberadamente un un framework de aplicaciones web muy ligero, por lo que gran parte de sus beneficios y potencial proviene de bibliotecas y características de terceros. Lo veremos con más detalle en los siguientes artículos. En nuestro próximo artículo, veremos cómo configurar un entorno de desarrollo de Node, para que pueda comenzar a ver código de Express en acción.
+Por supuesto, Express es deliberadamente un framework de aplicaciones web muy ligero, así que gran parte de su beneficio y potencial proviene de bibliotecas y características de terceros. Veremos eso con más detalle en los siguientes artículos. En nuestro próximo artículo vamos a ver cómo configurar un entorno de desarrollo de Node, para que puedas empezar a ver algo de código de Express en acción.
 
-## Ver también
+## Véase también
 
-- [Modules](https://nodejs.org/api/modules.html#modules_modules) (Node API docs)
-- [Express](https://expressjs.com/) (home page)
-- [Basic routing](http://expressjs.com/en/starter/basic-routing.html) (Express docs)
-- [Routing guide](http://expressjs.com/en/guide/routing.html) (Express docs)
-- [Using template engines with Express](http://expressjs.com/en/guide/using-template-engines.html) (Express docs)
-- [Using middleware](https://expressjs.com/en/guide/using-middleware.html) (Express docs)
-- [Writing middleware for use in Express apps](http://expressjs.com/en/guide/writing-middleware.html) (Express docs)
-- [Database integration](https://expressjs.com/en/guide/database-integration.html) (Express docs)
-- [Serving static files in Express](https://expressjs.com/en/starter/static-files.html) (Express docs)
-- [Error handling](http://expressjs.com/en/guide/error-handling.html) (Express docs)
+- [Learn Node.js](https://scrimba.com/learn-nodejs-c00ho9qqh6?via=mdn) de Scrimba <sup>[_socio de aprendizaje de MDN_](/es/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds)</sup> ofrece una introducción divertida e interactiva a Node.js.
+- [Learn Express.js](https://scrimba.com/learn-expressjs-c062las154?via=mdn) de Scrimba <sup>[_socio de aprendizaje de MDN_](/es/docs/MDN/Writing_guidelines/Learning_content#partner_links_and_embeds)</sup> se basa en el enlace anterior, mostrando cómo empezar a usar el framework Express para crear sitios web del lado del servidor.
+- [Modules](https://nodejs.org/api/modules.html#modules_modules) (documentación de la API de Node)
+- [Express](https://expressjs.com/) (página de inicio)
+- [Basic routing](https://expressjs.com/en/starter/basic-routing.html) (documentación de Express)
+- [Routing guide](https://expressjs.com/en/guide/routing.html) (documentación de Express)
+- [Using template engines with Express](https://expressjs.com/en/guide/using-template-engines.html) (documentación de Express)
+- [Using middleware](https://expressjs.com/en/guide/using-middleware.html) (documentación de Express)
+- [Writing middleware for use in Express apps](https://expressjs.com/en/guide/writing-middleware.html) (documentación de Express)
+- [Database integration](https://expressjs.com/en/guide/database-integration.html) (documentación de Express)
+- [Serving static files in Express](https://expressjs.com/en/starter/static-files.html) (documentación de Express)
+- [Error handling](https://expressjs.com/en/guide/error-handling.html) (documentación de Express)
 
 {{NextMenu("Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment", "Learn_web_development/Extensions/Server-side/Express_Nodejs")}}


### PR DESCRIPTION
### Description

Sincroniza la traducción al español de "Introducción a Express/Node" con la versión actual en inglés (commit `2aa17515`), reescribiendo el artículo completo.

### Motivation

La página nunca se había registrado para sincronización (`l10n.sourceCommit` ausente) y llevaba años desactualizada: contenido en Express 4.x/npm antiguo, ejemplos de código con `var` y callbacks en vez de `const`/`async`-`await`, la sección de MongoDB con la API antigua del driver, y 3 encabezados menos que la fuente en inglés (17 vs 20).

### Additional details

- Front-matter reducido a `title`, `slug` y `l10n.sourceCommit` (se quitó `original_slug`).
- Se quitó la macro `{{LearnSidebar}}` del cuerpo, siguiendo el patrón ya usado en otras páginas de Learn ya sincronizadas (la fuente en inglés movió esto a `sidebar: learnsidebar` en el front-matter, clave que no se replica en español).
- Estructura, encabezados y orden de secciones ahora coinciden 1:1 con la fuente en inglés (20 encabezados).
- Bloques de código actualizados para reflejar exactamente los ejemplos actuales en inglés (Express 5, `const`, `async`/`await`, driver moderno de MongoDB); solo se tradujeron comentarios y cadenas de usuario final.
- Enlaces internos actualizados de `/en-US/` a `/es/`.
- Validaciones corridas sobre el archivo: Prettier, markdownlint-cli2 y `check-url-locale.js` (todas sin errores).

### Related issues and pull requests

Fixes #37268