### PR TITLE
chore(es): sync of `Learn_web_development/Extensions/Server-side/Django/Home_page`

### DIFF
--- a/files/es/learn_web_development/extensions/server-side/django/home_page/index.md
+++ b/files/es/learn_web_development/extensions/server-side/django/home_page/index.md
@@ -1,92 +1,98 @@
 ---
 title: "Tutorial de Django Parte 5: Creación de tu página de inicio"
+short-title: "5: Página de inicio"
 slug: Learn_web_development/Extensions/Server-side/Django/Home_page
-original_slug: Learn/Server-side/Django/Home_page
+l10n:
+  sourceCommit: be1922d62a0d31e4e3441db0e943aed8df736481
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Admin_site", "Learn_web_development/Extensions/Server-side/Django/Generic_views", "Learn_web_development/Extensions/Server-side/Django")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Admin_site", "Learn_web_development/Extensions/Server-side/Django/Generic_views", "Learn_web_development/Extensions/Server-side/Django")}}
 
-Estamos listos ahora para añadir el código para mostrar nuestra primera página entera — una página de inicio del sitio web de la [BibliotecaLocal](/es/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) que muestra cuántos registros tenemos de cada tipo de modelo y proporciona una barra lateral con enlaces de navegación a nuestras otras páginas. Por el camino ganaremos experiencia práctica en escritura básica de mapeos de URL y vistas, obtención de resgistros de la base de datos y uso de plantillas.
+Ya estamos listos para añadir el código que muestra nuestra primera página completa — una página de inicio para el sitio web de [LocalLibrary](/es/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website). La página de inicio mostrará el número de registros que tenemos de cada tipo de modelo y proporcionará una barra lateral con enlaces de navegación al resto de nuestras páginas. Por el camino ganaremos experiencia práctica escribiendo mapas de URL y vistas básicas, obteniendo registros de la base de datos y usando plantillas.
 
 <table>
   <tbody>
     <tr>
-      <th scope="row">Pre-requisitos:</th>
+      <th scope="row">Prerrequisitos:</th>
       <td>
         Lee la
-        <a
-          href="https://developer.mozilla.org/es/docs/Learn/Server-side/Django/Introducci%C3%B3n"
+        <a href="/es/docs/Learn_web_development/Extensions/Server-side/Django/Introduction"
           >Introducción a Django</a
-        >. Completa los tópicos previos del tutorial (incluyendo
-        <a
-          href="/es/docs/Learn_web_development/Extensions/Server-side/Django/Admin_site"
-          >Tutorial de Django Parte 4: Sitio de administración de Django</a
+        >. Completa los temas previos del tutorial (incluyendo
+        <a href="/es/docs/Learn_web_development/Extensions/Server-side/Django/Admin_site"
+          >Tutorial Django Parte 4: Sitio de Administración de Django</a
         >).
       </td>
     </tr>
     <tr>
       <th scope="row">Objetivo:</th>
       <td>
-        <p>
-          Entender cómo crear mapas url y vistas simples (sin información
-          codificada en la URL), y cómo obtener información desde los modelos y
-          crear plantillas.
-        </p>
+        Aprender a crear mapas de URL y vistas simples (donde no se codifica ningún dato en la URL), obtener datos de los modelos y crear plantillas.
       </td>
     </tr>
   </tbody>
 </table>
 
-## Visión General
+## Visión general
 
-Ahora que hemos definindo nuestros modelos y hemos creado los primeros registros en la librería para trabajar, es hora de escribir código para presentar información a los usuarios. Lo primero que necesitamos es determinar que información queremos mostrar en nuestras páginas, y definir una URL apropiada hacia estos recursos. Vamos a necesitar crear el mapeador de URLs, las vistas y plantillas para mostrar estas páginas.
+Después de definir nuestros modelos y crear algunos registros iniciales de la librería para trabajar con ellos, es hora de escribir el código que presenta esa información a los usuarios. Lo primero que necesitamos hacer es determinar qué información queremos mostrar en nuestras páginas, y definir las URL que usaremos para devolver esos recursos. Luego crearemos un mapeador de URL, vistas y plantillas para mostrar las páginas.
 
-El siguiente diagrama es un recordatorio del principal flujo de datos y cosas necesarias para ser implementadas cuando se maneja una respuesta/petición en HTTP.
-Los principales elementos que necesitamos crear son:
+El siguiente diagrama describe el flujo de datos principal, y los componentes necesarios al manejar solicitudes y respuestas HTTP. Como ya implementamos el modelo, los principales componentes que crearemos son:
 
-- Mapeadores URL para reenviar las URLs admitidas (y cualquier información codificada en las URLs) a las funciones de vista apropiadas.
-- Funciones de vista para obtener los datos solicitados desde los modelos, crear una página HTML que muestre los datos, y devolverlo al usuario para que lo vea en el navegador.
-- Plantillas usadas por las vistas para renderizar los datos.
+- Mapeadores de URL para reenviar las URL admitidas (y cualquier información codificada en las URL) a las funciones de vista apropiadas.
+- Funciones de vista para obtener los datos solicitados desde los modelos, crear páginas HTML que muestren los datos, y devolver las páginas al usuario para que las vea en el navegador.
+- Plantillas para usar al renderizar los datos en las vistas.
 
-![](basic-django.png)
+![Diagrama del flujo de datos principal: los componentes URL, Modelo, Vista y Plantilla necesarios al manejar solicitudes y respuestas HTTP en una aplicación Django. Una solicitud HTTP llega a un servidor Django y se reenvía al archivo "urls.py" del componente URL. La solicitud se reenvía a la vista apropiada. La vista puede leer y escribir datos desde el archivo "models.py" de los Modelos, que contiene el código relacionado con los modelos. La vista también accede al componente de plantilla HTML. La vista devuelve la respuesta al usuario.](basic-django.png)
 
-Como verás en la siguiente sección, vamos a tener 5 páginas para mostrar, que es mucho que documentar en un artículo. Por lo tanto, en la mayor parte de este artículo nos concentraremos en mostrar como implementar solo la página de inicio (nos moverermos a otras páginas en un artículo subsecuente). Esto debe darte un buen entendimiento de extremo a extremo sobre como los mapeadores URL, vistas y modelos funcionan en la práctica.
+Como verás en la siguiente sección, tenemos 5 páginas para mostrar, lo cual es demasiada información para documentar en un solo artículo. Por lo tanto, este artículo se centrará en cómo implementar la página de inicio, y cubriremos las demás páginas en un artículo posterior. Esto debería darte un buen entendimiento de principio a fin de cómo funcionan en la práctica los mapeadores de URL, las vistas y los modelos.
 
-## Definiendo el recurso URL
+## Definiendo las URL de los recursos
 
-Como esta versión de _LocalLibrary_ es escencialmente solo de lectura para usuarios finales, debemos proveer una página de llegada para el sitio (una página de inicio), y páginas que _desplieguen_ listas y vistas detalladas para libros y autores.
+Como esta versión de [LocalLibrary](/es/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website) es, esencialmente, de solo lectura para los usuarios finales, solo necesitamos proporcionar una página de llegada para el sitio (una página de inicio), y páginas que _muestren_ vistas de lista y de detalle para libros y autores.
 
-Las URL que vamos a necesitar para nuestras páginas son:
+Las URL que necesitaremos para nuestras páginas son:
 
-- `catalog/` — La página home/index.
-- `catalog/books/` — La lista de todos los libros.
-- `catalog/authors/` — La lista de todos los autores.
-- `catalog/book/<id>` — La vista detallada para el libro específico con un campo de clave primaria de `<id>` (el valor por defecto). Así por ejemplo, `/catalog/book/3`, para el tercer libro añadido.
-- `catalog/author/<id>` — La vista detallada para el autor específico con un campo de clave primaria llamada `<id>`. Así por ejemplo, `/catalog/author/11`, para el 11vo autor añadido.
+- `catalog/` — La página de inicio (índice).
+- `catalog/books/` — Una lista de todos los libros.
+- `catalog/authors/` — Una lista de todos los autores.
+- `catalog/book/<id>` — La vista de detalle de un libro en particular, con un campo de clave primaria de `<id>` (el valor predeterminado). Por ejemplo, la URL del tercer libro añadido a la lista será `/catalog/book/3`.
+- `catalog/author/<id>` — La vista de detalle del autor específico con un campo de clave primaria de `<id>`. Por ejemplo, la URL del undécimo autor añadido a la lista será `/catalog/author/11`.
 
-La tres primeras URLs son usadas para listar el índice, los libros y autores. Esto no codifica ninguna información adicional, y mientras los resultados retornados dependerán del contenido en la base de datos, las consultas que se ejecutan para obtener la información siempre serán las mismas.
+Las primeras tres URL devolverán la página índice, la lista de libros y la lista de autores. Estas URL no codifican ninguna información adicional, y las consultas que obtienen datos de la base de datos siempre serán las mismas. Sin embargo, los resultados que devuelven las consultas dependerán del contenido de la base de datos.
 
-En contraste las 2 URLs finales son usadas para mostrar información detallada sobre un libro o autor específico — estas codifican la identidad de los ítemes a mostrar en la URL (mostrado arriba como `<id>`). El mapeador URL puede extraer la información codificada y pasársela a la vista, donde se detarminará que información extraer de la base de datos. Al codificar la información en nuestra URL solo necesitamos un mapeador de URL, una vista, y un plantilla para manejar cada libro (o autor).
-
-> [!NOTE]
-> Django te permite construir tus URLs de cualquier forma que quieras — puedes codificar información en el cuerpo de la URL como se muestra arriba o usando la obtención de parámetros `GET` de la URL(e.j. `/book/?id=6`). Culquier enfoque que uses, las URLs deben mantenerse limpias, lógicas y legibles ([observa el consejo del W3C aquí](https://www.w3.org/Provider/Style/URI)).
->
-> La documentación Django tiende a recomendar la codificación de información en el cuerpo de la URL, una práctica que ellos creen que promueve mejores diseños de URL.
-
-Como discutimos en la introducción, el resto de este articulo describe como construimos la página index.
-
-## Creando la página index
-
-La primera página que crearemos será la página index (`catalog/`). Esto desplegará un pequeño HTML estático, junto con algunos "contadores" calculados de diferentes registros en la base de datos. Para hacer este trabajo tendremos que crear un mapeador URL, una vista y una plantilla.
+En cambio, las dos últimas URL mostrarán información detallada sobre un libro o autor específico. Estas URL codifican la identidad del elemento a mostrar (representado arriba por `<id>`). El mapeador de URL extraerá la información codificada y se la pasará a la vista, y la vista determinará dinámicamente qué información obtener de la base de datos. Al codificar la información en la URL, usaremos un único conjunto de mapeo de URL, vista y plantilla para manejar todos los libros (o autores).
 
 > [!NOTE]
-> Vale la pena prestar un poco de atención extra en esta sección. La mayoría del contenido es común para todas las páginas.
+> Con Django puedes construir tus URL como necesites — puedes codificar información en el cuerpo de la URL como se muestra arriba, o incluir parámetros `GET` en la URL, por ejemplo `/book/?id=6`. Sea cual sea el enfoque que uses, las URL deben mantenerse limpias, lógicas y legibles, como [recomienda el W3C](https://www.w3.org/Provider/Style/URI).
+> La documentación de Django recomienda codificar la información en el cuerpo de la URL para lograr un mejor diseño de URL.
 
-### Mapeador URL
+Como se mencionó en el resumen, el resto de este artículo describe cómo construir la página índice.
 
-Hemos creado un archivo básico **/catalog/urls.py** para nuestra aplicación catálogo cuando creamos el [esqueleto del sitio Web](/es/docs/Learn_web_development/Extensions/Server-side/Django/skeleton_website). Las URLs de la aplicación catálogo fueron incluidas dentro del proyecto con un mapeador a `catalog/`, entonces las URLs que llegan a este mapeador deben empezar con `catalog/` (el mapeador funciona sobre todos los string en la URL después de la barra diagonal).
+## Creando la página índice
 
-Abra **urls.py** y pegue la línea en negrita que aparece a continuación.
+La primera página que crearemos es la página índice (`catalog/`). La página índice incluirá algo de HTML estático, junto con "conteos" generados de diferentes registros en la base de datos. Para que esto funcione crearemos un mapeo de URL, una vista y una plantilla.
+
+> [!NOTE]
+> Vale la pena prestar un poco de atención extra en esta sección. La mayor parte de la información también se aplica a las demás páginas que crearemos.
+
+### Mapeo de URL
+
+Cuando creamos el [sitio web esqueleto](/es/docs/Learn_web_development/Extensions/Server-side/Django/skeleton_website), actualizamos el archivo **locallibrary/urls.py** para asegurarnos de que, siempre que se reciba una URL que empiece con `catalog/`, el módulo _URLConf_ `catalog.urls` procese la subcadena restante.
+
+El siguiente fragmento de código de **locallibrary/urls.py** incluye el módulo `catalog.urls`:
+
+```python
+urlpatterns += [
+    path('catalog/', include('catalog.urls')),
+]
+```
+
+> [!NOTE]
+> Siempre que Django encuentra la función de importación [`django.urls.include()`](https://docs.djangoproject.com/en/5.0/ref/urls/#django.urls.include), divide la cadena de la URL en el carácter final designado y envía la subcadena restante al módulo _URLConf_ incluido para que continúe procesándola.
+
+También creamos un archivo marcador de posición para el módulo _URLConf_, llamado **/catalog/urls.py**.
+Añade las siguientes líneas a ese archivo:
 
 ```python
 urlpatterns = [
@@ -94,35 +100,26 @@ urlpatterns = [
 ]
 ```
 
-Esta función `path()` define una cadena vacía (`''`), y una función vista que será llamada si el patrón es detectado (`views.index` — una función llamada `index()` en **views.py**). Hablaremos un poco más sobre los patrones URL más adelante en este tutorial, pero para este caso todo lo que necesitas saber es que en un patron de `''` coincidirá con una cadena vacía.
+La función `path()` define lo siguiente:
 
-> [!NOTE]
-> Nota que en **/locallibrary/locallibrary/urls.py**
->
-> ```py
-> urlpatterns += [
->   path('catalog/', include('catalog.urls')),
-> ]
-> ```
->
-> Siempre cuando Django se encuentra con `include()` ([`django.conf.urls.include()`](https://docs.djangoproject.com/en/1.11/ref/urls/#django.conf.urls.include)), corta cualquier parte de la URL que coincida hasta este punto y envía el resto de la cadena para incluir la configuración URL para el siguiente procesamiento.
->
-> La URL coincidente es en realidad `catalog/` + \<cadena vacía> ( `/catalog/` es asumida ya que include() fue el método usado). Nuestra primera función vista será llamada si recibimos una consulta HTTP con una URL de `/catalog/`.
+- Un patrón de URL, que es una cadena vacía: `''`. Analizaremos los patrones de URL en detalle cuando trabajemos en las demás vistas.
+- Una función de vista que se llamará si se detecta el patrón de URL: `views.index`, que es la función llamada `index()` en el archivo **views.py**.
 
-La función `path()` también especifica un parámetro `name`, que identifica de manera única _este_ mapeador de URL particular. Puedes usar este nombre para "revertir" el mapeador — para crear dinámicamente una URL que apunta al el recurso que el mapeador esta diseñado para manejar. Por ejemplo, con esto hecho ahora podemos enlazar nuestra página inicio creando el siguiente enlace en nuestra plantilla:
+La función `path()` también especifica un parámetro `name`, que es un identificador único para _este_ mapeo de URL en particular. Puedes usar el nombre para "revertir" el mapeador, es decir, para crear dinámicamente una URL que apunte al recurso que el mapeador está diseñado para manejar.
+Por ejemplo, podemos usar el parámetro name para enlazar a nuestra página de inicio desde cualquier otra página añadiendo el siguiente enlace en una plantilla:
 
 ```django
 <a href="{% url 'index' %}">Home</a>.
 ```
 
 > [!NOTE]
-> Por su puesto podemos codificar a fuerza bruta el link anterior (e.j. `<a href="/catalog/">Home</a>`), pero entonces si cambiamos el patrón para nuestra página de inicio (e.j. a `/catalog/index`) la plantilla no podrá seguir enlazando correctamente. Usar un mapeador de url es mucho más flexible y robusto!
+> Podríamos codificar el enlace de forma fija, como en `<a href="/catalog/">Home</a>`, pero si cambiamos el patrón de nuestra página de inicio, por ejemplo, a `/catalog/index`, las plantillas ya no enlazarían correctamente. Usar un mapeo de URL invertido es más robusto.
 
-### Vista (basada-en-funciones)
+### Vista (basada en funciones)
 
-Una vista es una función que procesa una consulta HTTP, trae datos desde la base de datos cuando los necesita, genera una página HTML renderizando estos datos unando una plantilla HTML, y luego retorna el HTML en una respuesta HTTP para ser mostrada al usuario. La vista del índice sigue este modelo — extrae información sobre cuantos `Book`, `BookInstance`, `BookInstance` disponibles y registros `Author` tenemos en la base de datos, y los pasa a una plantilla para mostrarlos.
+Una vista es una función que procesa una solicitud HTTP, obtiene los datos necesarios de la base de datos, renderiza los datos en una página HTML usando una plantilla HTML, y luego devuelve el HTML generado en una respuesta HTTP para mostrar la página al usuario. La vista índice sigue este modelo — obtiene información sobre el número de registros de `Book`, `BookInstance`, `BookInstance` disponibles y `Author` que tenemos en la base de datos, y pasa esa información a una plantilla para mostrarla.
 
-Abre **catalog/views.py**, y nota que el archivo ya importa el atajo de la función [render()](https://docs.djangoproject.com/en/1.10/topics/http/shortcuts/#django.shortcuts.render) que genera archivos HTML usando una plantilla y datos.
+Abre **catalog/views.py** y observa que el archivo ya importa la función de atajo [render()](https://docs.djangoproject.com/en/5.0/topics/http/shortcuts/#django.shortcuts.render) para generar un archivo HTML usando una plantilla y datos:
 
 ```python
 from django.shortcuts import render
@@ -130,132 +127,155 @@ from django.shortcuts import render
 # Create your views here.
 ```
 
-Copia el siguiente código al final del archivo. La primera linea importa las clases de los modelos que usaremos para acceder a los datos en todas nuestras vistas.
+Pega las siguientes líneas al final del archivo:
 
 ```python
 from .models import Book, Author, BookInstance, Genre
 
 def index(request):
-    """
-    Función vista para la página inicio del sitio.
-    """
-    # Genera contadores de algunos de los objetos principales
-    num_books=Book.objects.all().count()
-    num_instances=BookInstance.objects.all().count()
-    # Libros disponibles (status = 'a')
-    num_instances_available=BookInstance.objects.filter(status__exact='a').count()
-    num_authors=Author.objects.count()  # El 'all()' esta implícito por defecto.
+    """View function for home page of site."""
 
-    # Renderiza la plantilla HTML index.html con los datos en la variable contexto
-    return render(
-        request,
-        'index.html',
-        context={'num_books':num_books,'num_instances':num_instances,'num_instances_available':num_instances_available,'num_authors':num_authors},
-    )
+    # Generate counts of some of the main objects
+    num_books = Book.objects.all().count()
+    num_instances = BookInstance.objects.all().count()
+
+    # Available books (status = 'a')
+    num_instances_available = BookInstance.objects.filter(status__exact='a').count()
+
+    # The 'all()' is implied by default.
+    num_authors = Author.objects.count()
+
+    context = {
+        'num_books': num_books,
+        'num_instances': num_instances,
+        'num_instances_available': num_instances_available,
+        'num_authors': num_authors,
+    }
+
+    # Render the HTML template index.html with the data in the context variable
+    return render(request, 'index.html', context=context)
 ```
 
-La primera parte de la función vista extrae contadores de registros usando el atributo `objects.all()` en las clases del modelo. Tambien obtiene una lista de los objetos `BookInstance` que tienen un valor del campo status de 'a' (Disponible). Puedes encontrar un poco más sobre cómo acceder desde modelos en nuestro tutorial previo ([Django Tutorial Part 3: Usando modelos > Buscando registros](/es/docs/Learn_web_development/Extensions/Server-side/Django/Models#searching_for_records)).
+La primera línea importa las clases de modelo que usaremos para acceder a los datos en todas nuestras vistas.
 
-Al final de la función invocamos a la función `render()` para crear y retornar una página HTML como una respuesta (esta función atajo envuelve una serie, simplicando este caso de uso muy común). Esta recibe como parametros el objeto `request original` (una `ConsultaHttp`), una plantilla HTML con marcadores para los datos, y una variable de `contexto` (un diccionario Python que contiene los datos que serán insertados en esos marcadores).
+La primera parte de la función de vista obtiene el número de registros usando el atributo `objects.all()` en las clases de modelo. También obtiene una lista de objetos `BookInstance` que tienen el valor 'a' (Disponible) en el campo status. Puedes encontrar más información sobre cómo acceder a los datos de los modelos en nuestro tutorial anterior [Tutorial de Django Parte 3: Uso de modelos > Búsqueda de registros](/es/docs/Learn_web_development/Extensions/Server-side/Django/Models#búsqueda_de_registros).
 
-Hablaremos más sobre la plantilla y la variable de contexto en la siguiente sección; vamos a crear nuestra plantilla para así de hecho mostrarle algo al usuario!
+Al final de la función de vista llamamos a la función `render()` para crear una página HTML y devolverla como respuesta. Esta función de atajo envuelve varias otras funciones para simplificar un caso de uso muy común. La función `render()` acepta los siguientes parámetros:
+
+- el objeto `request` original, que es un `HttpRequest`.
+- una plantilla HTML con marcadores de posición para los datos.
+- una variable `context`, que es un diccionario de Python que contiene los datos a insertar en los marcadores de posición.
+
+Hablaremos más sobre las plantillas y la variable `context` en la siguiente sección. ¡Vamos a crear nuestra plantilla para poder mostrarle algo al usuario!
 
 ### Plantilla
 
-Una plantilla es un archivo de texto que determina la estructura o diseño de un archivo (como una página HTML), con marcadores usados para representar el contenido real. Django automaticamente buscará plantillas en un directorio llamado '**templates**' de su aplicación. Así por ejemplo, en la vista índice que acabamos de agregar, la función `render()` esperará poder encontrar el archivo **/locallibrary/catalog/templates/_index.html_**, y entregará un error si el archivo no puede ser encontrado. Puede ver esto si guarda los cambios anteriores y vuelve a su navegador — accediendo a `127.0.0.1:8000` ahora le entregará un mensaje de error bastante intuitivo "TemplateDoesNotExist at /catalog/", más otros detalles.
+Una plantilla es un archivo de texto que define la estructura o el diseño de un archivo (como una página HTML), y usa marcadores de posición para representar el contenido real.
+
+Una aplicación de Django creada con **startapp** (como el esqueleto de este ejemplo) buscará plantillas en un subdirectorio llamado "**templates**" de tus aplicaciones. Por ejemplo, en la vista índice que acabamos de añadir, la función `render()` esperará encontrar el archivo **_index.html_** en **/django-locallibrary-tutorial/catalog/templates/** y generará un error si el archivo no está presente.
+
+Puedes comprobarlo guardando los cambios anteriores y accediendo a `127.0.0.1:8000` en tu navegador: mostrará un mensaje de error bastante intuitivo, "TemplateDoesNotExist at /catalog/", y otros detalles.
 
 > [!NOTE]
-> Django buscará en una serie de lugares por plantillas, basandose en su archivo de configuraciones de proyectos (buscar en su aplicación instalada es una configuración por defecto!). Puede encontrar más sobre como Django encuentra plantillas y qué formatos de plantillas soporta [Templates](https://docs.djangoproject.com/en/1.10/topics/templates/) (Django docs).
+> Según el archivo de configuración de tu proyecto, Django buscará plantillas en varios lugares, buscando en tus aplicaciones instaladas por defecto. Puedes encontrar más información sobre cómo Django encuentra las plantillas y qué formatos de plantilla admite en [la sección Templates de la documentación de Django](https://docs.djangoproject.com/en/5.0/topics/templates/).
 
-#### Plantillas extendidas
+#### Extendiendo plantillas
 
-La plantilla índice va a necesitar marcado HTML estándar para la cabecera y el cuerpo, junto con secciones para navegar (a otras páginas en el sitio que todavía no hemos creado) y para mostrar algún texto introductorio y nuestros datos de libro. La mayoría de este texto (el HTML y la estructura de navegación) será el mismo para cada página en nuestro sitio. En lugar de obligar a los desarrolladores a duplicar este texto en cada página, el lenguaje de plantillas de Django le permite declarar una plantilla base y luego extenderla, reemplazando solo las porciones que son distintos para cada página específica.
+La plantilla índice necesitará el marcado HTML estándar para la cabecera y el cuerpo, junto con secciones de navegación que enlacen a las demás páginas del sitio (que todavía no hemos creado), y secciones que muestren un texto introductorio y los datos de los libros.
 
-Por ejemplo, un plantilla base **base_generic.html** podría verse como el texto de abajo. Como puedes ver, este contiene algo de HTML "común" y secciones para el título, barra lateral, y contendio marcados usando las etiquetas de plantillas llamadas `block` y `endblock` (mostradas en negrita). Los bloques pueden estar vacíos, o tener contenido que será usado "por defecto" para páginas derivadas.
+Gran parte de la estructura HTML y de navegación será la misma en todas las páginas de nuestro sitio. En lugar de duplicar el código repetitivo en cada página, puedes usar el lenguaje de plantillas de Django para declarar una plantilla base, y luego extenderla para reemplazar solo las partes que son distintas en cada página específica.
+
+El siguiente fragmento de código es un ejemplo de plantilla base a partir de un archivo **base_generic.html**.
+Crearemos la plantilla para LocalLibrary en breve.
+El ejemplo de abajo incluye HTML común con secciones para un título, una barra lateral y el contenido principal, marcadas con las etiquetas de plantilla `block` y `endblock`.
+Puedes dejar los bloques vacíos, o incluir contenido predeterminado para usar al renderizar páginas derivadas de la plantilla.
 
 > [!NOTE]
-> Las etiquetas de plantilla son como funciones que puede usar en una plantilla para recorrer listas, realizar operaciones condicionales basadas en el valor de una variable, etc. Además de las etiquetas de plantilla, la sintaxis de plantilla te permite referenciar variables de plantilla (que son pasadas en la plantilla desde la vista) y usar _filtros de plantilla_, que reformatean las variables (por ejemplo, establecer una cadena en minúsculas).
+> Las _etiquetas_ de plantilla son funciones que puedes usar en una plantilla para recorrer listas, realizar operaciones condicionales según el valor de una variable, etc. Además de las etiquetas de plantilla, la sintaxis de plantillas te permite hacer referencia a variables que se pasan a la plantilla desde la vista, y usar _filtros de plantilla_ para dar formato a las variables (por ejemplo, para convertir una cadena a minúsculas).
 
 ```django
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  {% block title %}<title>Local Library</title>{% endblock %}
-</head>
-
-<body>
-  {% block sidebar %}<!-- insert default navigation text for every page -->{% endblock %}
-  {% block content %}<!-- default content text (typically empty) -->{% endblock %}
-</body>
+  <head>
+    {% block title %}
+      <title>Local Library</title>
+    {% endblock %}
+  </head>
+  <body>
+    {% block sidebar %}
+      <!-- insert default navigation text for every page -->
+    {% endblock %}
+    {% block content %}
+      <!-- default content text (typically empty) -->
+    {% endblock %}
+  </body>
 </html>
 ```
 
-Cuando queremos definir una plantilla para una vista en particular, primero especificamos la plantila base (con la etiqueta de plantilla `extends` — vea el código siguiente). Si ahí hay alguna seccón que queremos reemplazar en la plantilla declaramos esto, usando secciones `block`/`endblock` idénticas a las usadas en la plantilla base.
+Al definir una plantilla para una vista en particular, primero especificamos la plantilla base usando la etiqueta de plantilla `extends` — mira el ejemplo de código de abajo. Luego declaramos qué secciones de la plantilla queremos reemplazar (si hay alguna), usando secciones `block`/`endblock` como en la plantilla base.
 
-Por ejemplo, el fragmento de código que sigue muestra como usar la etiqueta de plantilla `extends`, y sobrescribe el bloque `content`. El HTML final producido tendrá todo el HTML y la estructura defininda en la plantilla base (incluyendo el contenido por defecto que ha definido dentro del bloque `title`), pero con tu nuevo bloque `content` insertado en lugar del que venía por defecto.
+Por ejemplo, el siguiente fragmento de código muestra cómo usar la etiqueta de plantilla `extends` y sobrescribir el bloque `content`. El HTML generado incluirá el código y la estructura definidos en la plantilla base, incluyendo el contenido predeterminado que definiste en el bloque `title`, pero con el nuevo bloque `content` en lugar del predeterminado.
 
 ```django
 {% extends "base_generic.html" %}
 
 {% block content %}
-<h1>Local Library Home</h1>
-<p>Welcome to <em>LocalLibrary</em>, a very basic Django website developed as a tutorial example on the Mozilla Developer Network.</p>
+  <h1>Local Library Home</h1>
+  <p>
+    Welcome to LocalLibrary, a website developed by
+    <em>Mozilla Developer Network</em>!
+  </p>
 {% endblock %}
 ```
 
 #### La plantilla base de LocalLibrary
 
-La plantilla base que pensamos usar para el siito web _LocalLibrary_ se muestra abajo. Como puedes ver, contiene algo de HTML y bloques definidos para `title`, `sidebar` y `content`. Tenemos un título por defecto (que podríamos querer cambiar) y una barra lateral por defecto con enlaces a listas de todos los libros y autores (que probablemente no querramos cambiar, pero hemos dejado abierta la posibilidad de hacerlo si es necesario, poniéndolo en un bloque).
+Usaremos el siguiente fragmento de código como plantilla base para el sitio web _LocalLibrary_. Como puedes ver, contiene algo de código HTML y define bloques para `title`, `sidebar` y `content`. Tenemos un título predeterminado y una barra lateral predeterminada con enlaces a listas de todos los libros y autores, ambos encerrados en bloques para poder cambiarlos fácilmente en el futuro.
 
 > [!NOTE]
-> También introducimos dos etiquetas de plantilla adicionales: `url` y `load static`. Se discute sobre ellas en secciones posteriores.
+> También introducimos dos etiquetas de plantilla adicionales: `url` y `load static`. Estas etiquetas se explicarán en las siguientes secciones.
 
-Crea un nuevo archivo — **/locallibrary/catalog/templates/_base_generic.html_** — y pon en él el siguiente contenido:
+Crea un nuevo archivo **base_generic.html** en **/django-locallibrary-tutorial/catalog/templates/** y pega el siguiente código en el archivo:
 
 ```django
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-
-  {% block title %}<title>Local Library</title>{% endblock %}
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-
-  <!-- Add additional CSS in static file -->
-  {% load static %}
-  <link rel="stylesheet" href="{% static 'css/styles.css' %}">
-</head>
-
-<body>
-
-  <div class="container-fluid">
-
-    <div class="row">
-      <div class="col-sm-2">
-      {% block sidebar %}
-      <ul class="sidebar-nav">
-          <li><a href="{% url 'index' %}">Home</a></li>
-          <li><a href="">All books</a></li>
-          <li><a href="">All authors</a></li>
-      </ul>
-     {% endblock %}
-      </div>
-      <div class="col-sm-10 ">
-      {% block content %}{% endblock %}
+  <head>
+    {% block title %}
+      <title>Local Library</title>
+    {% endblock %}
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+      crossorigin="anonymous">
+    <!-- Add additional CSS in static file -->
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
+  </head>
+  <body>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-sm-2">
+          {% block sidebar %}
+            <ul class="sidebar-nav">
+              <li><a href="{% url 'index' %}">Home</a></li>
+              <li><a href="">All books</a></li>
+              <li><a href="">All authors</a></li>
+            </ul>
+          {% endblock %}
+        </div>
+        <div class="col-sm-10 ">{% block content %}{% endblock %}</div>
       </div>
     </div>
-
-  </div>
-</body>
+  </body>
 </html>
 ```
 
-La plantilla usa (e incluye) JavaScript y CSS desde [Bootstrap](http://getbootstrap.com/) para mejorar el diseño y la presentación de la página HTML. Usar Bootstrap u otro framework web del lado del cliente es una manera rápida de crear una página atractiva que puede escalarse bien en diferentes tamaños de navegador, y también nos permite concentrarnos en la presentación de la página sin tener que entrar en ninguno de los detalles — ¡queremos enfocarnos nada más en el código del lado del servidor aquí!
+La plantilla incluye CSS de [Bootstrap](https://getbootstrap.com/) para mejorar el diseño y la presentación de la página HTML. Usar Bootstrap (u otro framework web del lado del cliente) es una forma rápida de crear una página atractiva que se muestre bien en distintos tamaños de pantalla.
 
-La plantilla base también hace referencia a un archivo css local (**styles.css**) que brinda algo más de estilo. Crea **/locallibrary/catalog/static/css/styles.css** y pon en él el siguiente contenido:
+La plantilla base también hace referencia a un archivo CSS local (**styles.css**) que proporciona estilos adicionales. Crea un archivo **styles.css** en **/django-locallibrary-tutorial/catalog/static/css/** y pega el siguiente código en el archivo:
 
 ```css
 .sidebar-nav {
@@ -265,20 +285,21 @@ La plantilla base también hace referencia a un archivo css local (**styles.css*
 }
 ```
 
-#### La plantilla index
+#### La plantilla índice
 
-Crea el archivo HTML **/locallibrary/catalog/templates/_index.html_** y pon en él el contenido que se muestra abajo. Como puedes ver, extendemos nuestra plantilla base en la primera línea, y luego reemplazamos el bloque `content` por defecto con uno nuevo para esta plantilla.
+Crea un nuevo archivo HTML **index.html** en **/django-locallibrary-tutorial/catalog/templates/** y pega el siguiente código en el archivo.
+Este código extiende nuestra plantilla base en la primera línea, y luego reemplaza el bloque `content` predeterminado de la plantilla.
 
 ```django
 {% extends "base_generic.html" %}
 
 {% block content %}
-<h1>Local Library Home</h1>
-
-  <p>Welcome to <em>LocalLibrary</em>, a very basic Django website developed as a tutorial example on the Mozilla Developer Network.</p>
-
-<h2>Dynamic content</h2>
-
+  <h1>Local Library Home</h1>
+  <p>
+    Welcome to LocalLibrary, a website developed by
+    <em>Mozilla Developer Network</em>!
+  </p>
+  <h2>Dynamic content</h2>
   <p>The library has the following record counts:</p>
   <ul>
     <li><strong>Books:</strong> \{{ num_books }}</li>
@@ -286,70 +307,76 @@ Crea el archivo HTML **/locallibrary/catalog/templates/_index.html_** y pon en �
     <li><strong>Copies available:</strong> \{{ num_instances_available }}</li>
     <li><strong>Authors:</strong> \{{ num_authors }}</li>
   </ul>
-
 {% endblock %}
 ```
 
-En la sección _Dynamic content_ hemos declarado marcadores de posición (_variables de plantilla_) para la información que quisimos incluir desde la vista. Las variables se marcan usando la sintaxis de "doble corchete" o "llaves" (ver lo que está en negrita arriba).
+En la sección _Dynamic content_ declaramos marcadores de posición (_variables de plantilla_) para la información de la vista que queremos incluir.
+Las variables se encierran entre llaves dobles.
 
 > [!NOTE]
-> Puedes reconocer fácilmente si estás trabajando con variables de plantilla o con etiquetas de plantilla (funciones) porque las variables tienen llaves dobles (`\{{ num_books }}`) mientras que las etiquetas están encerradas entre llaves simples con signos de porcentaje (`{% extends "base_generic.html" %}`).
+> Puedes reconocer fácilmente las variables de plantilla y las etiquetas de plantilla (funciones) — las variables se encierran entre llaves dobles (`\{{ num_books }}`), y las etiquetas se encierran entre llaves simples con signos de porcentaje (`{% extends "base_generic.html" %}`).
 
-Lo importante de todo esto es que estas variables se nombran con las claves que enviamos dentro del diccionario `context` en la función `render()` de nuestra vista (mira abajo); estas variables serán reemplazadas por sus valores asociados cuando la plantilla sea renderizada.
+Lo importante que hay que notar aquí es que las variables se nombran con las _claves_ que pasamos en el diccionario `context` en la función `render()` de nuestra vista (mira el ejemplo de abajo).
+Las variables se reemplazarán por sus _valores_ asociados cuando se renderice la plantilla.
 
 ```python
-return render(
-    request,
-    'index.html',
-     context={'num_books':num_books,'num_instances':num_instances,'num_instances_available':num_instances_available,'num_authors':num_authors},
-)
+context = {
+    'num_books': num_books,
+    'num_instances': num_instances,
+    'num_instances_available': num_instances_available,
+    'num_authors': num_authors,
+}
+
+return render(request, 'index.html', context=context)
 ```
 
 #### Referenciando archivos estáticos en las plantillas
 
-Es probable que uses recursos estáticos en tu proyecto, incluyendo JavaScript, CSS e imágenes. Debido a que la ubicación de estos archivos podría ser desconocida (o podría cambiar), Django te permite especificar la ubicación de los mismos dentro de tus plantillas de forma relativa al parámetro global `STATIC_URL` (el sitio web esqueleto por defecto establece el valor de `STATIC_URL` a '`/static/`', pero puedes elegir alojar los archivos en una red de distribución de contenidos o en cualquier otro lugar).
+Es probable que tu proyecto use recursos estáticos, incluyendo JavaScript, CSS e imágenes. Como la ubicación de estos archivos podría no conocerse (o podría cambiar), Django te permite especificar la ubicación en tus plantillas de forma relativa al parámetro de configuración global `STATIC_URL`. El sitio web esqueleto predeterminado establece el valor de `STATIC_URL` en `"/static/"`, pero podrías elegir alojar estos archivos en una red de distribución de contenidos o en otro lugar.
 
-Dentro de la plantilla, primero llamas a la etiqueta de plantilla `load` especificando "static" para añadir esta biblioteca de plantilla (como se muestra abajo). Luego de que static se carga, puedes usar la etiqueta de plantilla `static` especificando la URL relativa del archivo de interés.
+Dentro de la plantilla, primero llamas a la etiqueta de plantilla `load` especificando "static" para añadir la biblioteca de plantillas, como se muestra en el ejemplo de código de abajo. Luego puedes usar la etiqueta de plantilla `static` y especificar la URL relativa del archivo que necesitas.
 
 ```django
- <!-- Add additional CSS in static file -->
+<!-- Add additional CSS in static file -->
 {% load static %}
-<link rel="stylesheet" href="{% static 'css/styles.css' %}">
+<link rel="stylesheet" href="{% static 'css/styles.css' %}" />
 ```
 
-Si quisieras podrías añadir una imagen a la página de forma similar. Por ejemplo:
+Puedes añadir una imagen a la página de forma similar, por ejemplo:
 
 ```django
 {% load static %}
-<img src="{% static 'catalog/images/local_library_model_uml.png' %}" alt="My image" style="width:555px;height:540px;"/>
+<img
+  src="{% static 'images/local_library_model_uml.png' %}"
+  alt="UML diagram"
+  style="width:555px;height:540px;" />
 ```
 
 > [!NOTE]
-> Los cambios de arriba especifican dónde se localizan los archivos, pero Django no los sirve por defecto. Si bien habilitamos este servicio para el servidor web de desarrollo en el mapeador URL global (**/locallibrary/locallibrary/urls.py**) cuando [creamos el esqueleto del sitio web](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwiq2o-V3PXbAhVM0FMKHcNzAkcQFggnMAA&url=https%3A%2F%2Fdeveloper.mozilla.org%2Fes%2Fdocs%2FLearn%2FServer-side%2FDjango%2Fskeleton_website&usg=AOvVaw2VIIkwGelK5OnECR-4u4sU), aún necesitarás configurar este servicio para producción. Hablaramos de esto más tarde.
+> Los ejemplos de arriba especifican dónde se ubican los archivos, pero Django no los sirve por defecto. Configuramos el servidor web de desarrollo para servir archivos modificando el mapeador de URL global (**/django-locallibrary-tutorial/locallibrary/urls.py**) cuando [creamos el esqueleto del sitio web](/es/docs/Learn_web_development/Extensions/Server-side/Django/skeleton_website), pero todavía necesitamos habilitar el servicio de archivos en producción. Veremos esto más adelante.
 
-Para mayor información sobre el trabajo con archivos estáticos revisa [Managing static files](https://docs.djangoproject.com/en/1.10/howto/static-files/) (Django docs).
+Para más información sobre cómo trabajar con archivos estáticos consulta [Managing static files](https://docs.djangoproject.com/en/5.0/howto/static-files/) en la documentación de Django.
 
-#### Enlazando con URLs
+#### Enlazando a URL
 
-En la plantilla base de arriba se introdujo la etiqueta de plantilla `url`.
+La plantilla base de arriba introdujo la etiqueta de plantilla `url`.
 
-```python
+```django
 <li><a href="{% url 'index' %}">Home</a></li>
 ```
 
-Esta etiqueta toma el nombre de una función `path()` llamada en tu archivo **urls.py,** y valores para cualquier argumento que la vista asociada recibirá desde tal función, y devuelve una URL que puedes usar para enlazar con el recurso.
+Esta etiqueta toma el nombre de una función `path()` llamada en tu **urls.py**, y los valores de cualquier argumento que la vista asociada reciba desde esa función, y devuelve una URL que puedes usar para enlazar al recurso.
 
-#### Configurando adonde buscar las plantillas
+#### Configurando dónde buscar las plantillas
 
-Para que Django encuentre los archivos de plantillas es necesario editar el archivo settings.py agregando el directorio donde creamos nuestras plantillas en el objeto TEMPLATES, como indica la linea en negrita a continuación:
+El lugar donde Django busca las plantillas se especifica en el objeto `TEMPLATES` del archivo **settings.py**.
+El archivo **settings.py** predeterminado (tal como se creó para este tutorial) se ve algo así:
 
 ```python
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [
-            os.path.join(BASE_DIR, 'templates'),
-        ],
+        'DIRS': [],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -363,35 +390,46 @@ TEMPLATES = [
 ]
 ```
 
-## ¿Cómo se ve?
+El valor `'APP_DIRS': True` es el más importante, ya que le indica a Django que busque plantillas en un subdirectorio de cada aplicación del proyecto, llamado "templates" (esto facilita agrupar las plantillas con su aplicación asociada para reutilizarlas fácilmente).
 
-En este punto deberíamos haber creado todo lo necesario para desplegar la página index. Corre el servidor (`python3 manage.py runserver`) y dirige tu navegador a `http://127.0.0.1:8000/`. Si todo se configuró correctamente, tu sitio debería verse similar a la siguiente captura de pantalla.
-
-![Index page for LocalLibrary website](index_page_ok.png)
+También podemos especificar ubicaciones concretas para que Django busque directorios usando `'DIRS': []` (aunque todavía no lo necesitamos).
 
 > [!NOTE]
-> Aún no podrás usar los enlaces **All books** y **All authors** porque las URLs, vistas y plantillas para dichas páginas no se han definido (al momento solo hemos insertado marcadores de posición para esos enlaces en la plantilla `base_generic.html`).
+> Puedes encontrar más información sobre cómo Django encuentra las plantillas y qué formatos de plantilla admite en [la sección Templates de la documentación de Django](https://docs.djangoproject.com/en/5.0/topics/templates/).
 
-## Rétate a tí mismo
+## ¿Cómo se ve?
 
-Aquí hay un par de tareas para probar tu familiaridad con consultas a modelos, vistas y plantillas.
+En este punto ya hemos creado todos los recursos necesarios para mostrar la página índice. Ejecuta el servidor (`python3 manage.py runserver`) y abre `http://127.0.0.1:8000/` en tu navegador. Si todo está configurado correctamente, tu sitio debería verse como en la siguiente captura de pantalla.
 
-1. Declara un nuevo bloque _title_ en la plantilla _index_ y cambia el título de la página para coincidir con esta página en particular.
-2. Modifica la vista para generar un conteo de géneros y otro de libros que contengan una palabra en particular (no sensible a mayúsculas y minúsculas) y luego añade estos campos a la plantilla.
+![Página índice del sitio web LocalLibrary](index_page_ok.png)
+
+> [!NOTE]
+> Los enlaces **All books** y **All authors** todavía no funcionarán porque las rutas, vistas y plantillas para esas páginas aún no están definidas. Solo insertamos marcadores de posición para esos enlaces en la plantilla `base_generic.html`.
+
+## Ponte a prueba
+
+Aquí tienes un par de tareas para poner a prueba tu familiaridad con las consultas a modelos, las vistas y las plantillas.
+
+1. La [plantilla base](#la_plantilla_base_de_locallibrary) de LocalLibrary incluye un bloque `title`. Sobrescribe este bloque en la [plantilla índice](#la_plantilla_índice) y crea un nuevo título para la página.
+
+   > [!NOTE]
+   > La sección [Extendiendo plantillas](#extendiendo_plantillas) explica cómo crear bloques y extender un bloque en otra plantilla.
+
+2. Modifica la [vista](#vista_basada_en_funciones) para generar conteos de _géneros_ y _libros_ que contengan una palabra en particular (sin distinguir mayúsculas de minúsculas), y pasa los resultados al `context`. Puedes lograr esto de forma similar a como creamos y usamos `num_books` y `num_instances_available`. Luego actualiza la [plantilla índice](#la_plantilla_índice) para incluir estas variables.
 
 ## Resumen
 
-Hemos creado la página de inicio para nuestro sitio — una página HTML que despliega algunos conteos de registros de la base de datos y contiene enlaces a otras de nuestras páginas que aún nos faltan por crear. Sobre la marcha hemos adquirido mucha información fundamental sobre mapeadores URL, vistas, consultas a la base de datos usando nuestros modelos, cómo enviar información a una plantilla desde nuestra vista, y cómo crear y extender plantillas.
+Acabamos de crear la página de inicio de nuestro sitio — una página HTML que muestra varios registros de la base de datos y enlaces a otras páginas todavía por crear. Por el camino aprendimos información fundamental sobre mapeadores de URL, vistas, consultas a la base de datos con modelos, cómo pasar información a una plantilla desde una vista, y cómo crear y extender plantillas.
 
-En nuestro siguiente artículo nos basaremos en nuestro conocimiento para crear las otras cuatro páginas.
+En el siguiente artículo construiremos sobre este conocimiento para crear las cuatro páginas restantes de nuestro sitio web.
 
-## Mira también
+## Véase también
 
-- [Escribiendo tu primera aplicación Django, parte 3: Vistas y Plantillas](https://docs.djangoproject.com/en/1.10/intro/tutorial03/) (Django docs)
-- [Despachador URL](https://docs.djangoproject.com/en/1.10/topics/http/urls/) (Django docs)
-- [Funciones de vista](https://docs.djangoproject.com/en/1.10/topics/http/views/) (DJango docs)
-- [Plantillas](https://docs.djangoproject.com/en/1.10/topics/templates/) (Django docs)
-- [Administrando archivos estáticos](https://docs.djangoproject.com/en/1.10/howto/static-files/) (Django docs)
-- [Funciones atajo de Django](https://docs.djangoproject.com/en/1.10/topics/http/shortcuts/#django.shortcuts.render) (Django docs)
+- [Writing your first Django app, part 3: Views and Templates](https://docs.djangoproject.com/en/5.0/intro/tutorial03/) (documentación de Django)
+- [URL dispatcher](https://docs.djangoproject.com/en/5.0/topics/http/urls/) (documentación de Django)
+- [View functions](https://docs.djangoproject.com/en/5.0/topics/http/views/) (documentación de Django)
+- [Templates](https://docs.djangoproject.com/en/5.0/topics/templates/) (documentación de Django)
+- [Managing static files](https://docs.djangoproject.com/en/5.0/howto/static-files/) (documentación de Django)
+- [Django shortcut functions](https://docs.djangoproject.com/en/5.0/topics/http/shortcuts/#django.shortcuts.render) (documentación de Django)
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/Admin_site", "Learn_web_development/Extensions/Server-side/Django/Generic_views", "Learn_web_development/Extensions/Server-side/Django")}}


### PR DESCRIPTION
### Description

Sincroniza la traducción al español de "Django Tutorial Part 5: Creating our home page" con la última versión en inglés, ya que la página nunca se había registrado para sincronización y llevaba años desactualizada (Bootstrap 3, jQuery, documentación de Django 1.10/1.11, texto y ejemplos de código sin traducir en varios bloques).

### Motivation

Resuelve el issue de sincronización `l10n-es`: el artículo no tenía `l10n.sourceCommit` y difería sustancialmente del inglés actual (estructura, ejemplos de código `django`/`python`, capturas de flujo, notas y enlaces).

### Additional details

- Front-matter reducido a `title`, `short-title`, `slug` y `l10n:sourceCommit` (se quitó `original_slug`).
- `l10n.sourceCommit` actualizado al último commit que tocó el archivo en inglés: `be1922d62a0d31e4e3441db0e943aed8df736481`.
- Se tradujo el archivo completo, incluyendo los bloques `django`/`python`/`css` (comentarios y texto visible), manteniendo intactos los identificadores de código y las macros Kumascript.
- Enlaces internos actualizados de `/en-US/` a `/es/`; el enlace a la sección "Searching for records" del tutorial de modelos se ajustó al ancla real de su encabezado ya traducido (`#búsqueda_de_registros`), ya que esa página aún no está sincronizada pero esa sección sí está traducida.
- No se copiaron imágenes (`basic-django.png`, `index_page_ok.png`) porque ya existen sin cambios en `files/en-us/` y no son específicas del idioma.
- Validaciones corridas sobre el archivo: `prettier --write`, `markdownlint-cli2 --fix` y `check-url-locale.js` (0 errores).

### Related issues and pull requests

Fixes #37263