### PR TITLE
chore(es): sync of `Learn_web_development/Extensions/Server-side/Django/Models`

### DIFF
--- a/files/es/learn_web_development/extensions/server-side/django/models/index.md
+++ b/files/es/learn_web_development/extensions/server-side/django/models/index.md
@@ -1,30 +1,28 @@
 ---
 title: "Tutorial Django Parte 3: Uso de modelos"
+short-title: "3: Modelos"
 slug: Learn_web_development/Extensions/Server-side/Django/Models
-original_slug: Learn/Server-side/Django/Models
+l10n:
+  sourceCommit: cb25e0acbd9f0af27c4a99965cb962230d49a35d
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/skeleton_website", "Learn_web_development/Extensions/Server-side/Django/Admin_site", "Learn_web_development/Extensions/Server-side/Django")}}
+{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/skeleton_website", "Learn_web_development/Extensions/Server-side/Django/Admin_site", "Learn_web_development/Extensions/Server-side/Django")}}
 
-Este artículo muestra cómo definir modelos para el sitio web de la [BibliotecaLocal](/es/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website). En él se explica lo que es un modelo, cómo se declara, y cuáles son algunos de los principales tipos de campos de un modelo. También veremos, brevemente, cuáles son algunas de las maneras en que puede accederse a los datos del modelo.
+Este artículo muestra cómo definir modelos para el sitio web de LocalLibrary. En él se explica qué es un modelo, cómo se declara y cuáles son algunos de los principales tipos de campo. También muestra brevemente algunas de las principales formas en que se puede acceder a los datos del modelo.
 
 <table>
   <tbody>
     <tr>
-      <th scope="row">Pre-requisitos:</th>
+      <th scope="row">Prerrequisitos:</th>
       <td>
-        <a
-          href="/es/docs/Learn_web_development/Extensions/Server-side/Django/skeleton_website"
-          >Tutorial Django Parte 2: Creación del esqueleto del sitio web</a
-        >.
+        <a href="/es/docs/Learn_web_development/Extensions/Server-side/Django/skeleton_website">Tutorial de Django parte 2: Crear un sitio web esqueleto</a>.
       </td>
     </tr>
     <tr>
       <th scope="row">Objetivo:</th>
       <td>
         <p>
-          Ser capaz de diseñar y crear tus propios modelos, eligiendo de forma
-          apropiada los campos.
+          Ser capaz de diseñar y crear tus propios modelos, eligiendo los campos de forma adecuada.
         </p>
       </td>
     </tr>
@@ -33,426 +31,468 @@ Este artículo muestra cómo definir modelos para el sitio web de la [Biblioteca
 
 ## Visión general
 
-Las aplicaciones web de Django acceden y administran los datos a través de objetos de Python a los que se hace referencia como modelos. Los modelos definen la _estructura_ de los datos almacenados, incluidos los _tipos_ de campo y los atributos de cada campo, como su tamaño máximo, valores predeterminados, lista de selección de opciones, texto de ayuda para la documentación, texto de etiqueta para formularios, etc. La definición del modelo es independiente de la base de datos subyacente. puede elegir una de entre varias como parte de la configuración de su proyecto. Una vez que haya elegido la base de datos que desea usar, no necesita hablar directamente con ella. Simplemente escriba la estructura de su modelo y algo de código, y Django se encargará de todo el trabajo sucio, al comunicarse con la base de datos por usted.
+Las aplicaciones web de Django acceden y administran los datos a través de objetos de Python a los que se hace referencia como modelos. Los modelos definen la _estructura_ de los datos almacenados, incluidos los _tipos_ de campo y, posiblemente, también su tamaño máximo, valores predeterminados, opciones de lista de selección, texto de ayuda para la documentación, texto de etiqueta para formularios, etc. La definición del modelo es independiente de la base de datos subyacente: puedes elegir una entre varias como parte de la configuración de tu proyecto. Una vez que hayas elegido qué base de datos quieres usar, no necesitas hablar con ella directamente en absoluto: simplemente escribes la estructura de tu modelo y el resto del código, y Django se encarga de todo el trabajo sucio de comunicarse con la base de datos por ti.
 
-Este tutorial muestra cómo definir y acceder a los modelos para el ejemplo del [sitio web LocalLibrary](/es/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website).
+Este tutorial muestra cómo definir y acceder a los modelos para el ejemplo del sitio web [LocalLibrary](/es/docs/Learn_web_development/Extensions/Server-side/Django/Tutorial_local_library_website).
 
 ## Diseñando los modelos de LocalLibrary
 
-Antes de dar el salto y comenzar a codificar los modelos, vale la pena tomarse unos minutos para pensar qué datos necesitamos almacenar y cuáles serán las relaciones entre los diferentes objetos.
+Antes de lanzarte a programar los modelos, vale la pena dedicar unos minutos a pensar qué datos necesitamos almacenar y cuáles son las relaciones entre los diferentes objetos.
 
-Sabemos que tenemos que almacenar información sobre libros (título, resumen, autor, idioma escrito, categoría, ISBN) y que podríamos tener varias copias disponibles (con id único global, estado de disponibilidad, etc.). Es posible que necesitemos almacenar más información sobre el autor que solo su nombre, y puede haber varios autores con el mismo nombre o nombres similares. Queremos poder ordenar la información según el título del libro, el autor, el idioma escrito y la categoría.
+Sabemos que necesitamos almacenar información sobre libros (título, resumen, autor, idioma escrito, categoría, ISBN) y que podríamos tener varias copias disponibles (con un id único a nivel global, estado de disponibilidad, etc.). Es posible que necesitemos almacenar más información sobre el autor que solo su nombre, y puede haber varios autores con nombres iguales o similares. Queremos poder ordenar la información según el título del libro, el autor, el idioma escrito y la categoría.
 
-Al diseñar sus modelos, tiene sentido tener modelos separados para cada "objeto" (grupo de información relacionada). En este caso, los objetos obvios son libros, instancias de libros y autores.
+Al diseñar tus modelos, tiene sentido tener modelos separados para cada "objeto" (un grupo de información relacionada). En este caso, los objetos evidentes son libros, instancias de libro y autores.
 
-También es posible que desee utilizar modelos para representar las opciones de la lista de selección (por ejemplo, como una lista desplegable de opciones), en lugar de codificar las opciones en el sitio web en sí; esto se recomienda cuando no se conocen de antemano todas las opciones posibles o éstas están sujetas a cambios. Los candidatos obvios para las modelos, en este caso, incluyen el género del libro (por ejemplo, ciencia ficción, poesía francesa, etc.) y el idioma (inglés, francés, japonés).
+También puedes querer usar modelos para representar opciones de listas de selección (por ejemplo, como una lista desplegable de opciones), en lugar de codificar las opciones directamente en el sitio web; esto se recomienda cuando no se conocen de antemano todas las opciones posibles o estas pueden cambiar. Los candidatos evidentes para modelos, en este caso, incluyen el género del libro (por ejemplo, ciencia ficción, poesía francesa, etc.) y el idioma (inglés, francés, japonés).
 
-Una vez que hayamos decidido cuáles serán nuestros modelos y sus campos, debemos pensar en la relación que existe entre ellos. Django le permite definir relaciones de uno a uno (`OneToOneField`), de uno a muchos (`ForeignKey`) y de muchos a muchos (`ManyToManyField`).
+Una vez que hemos decidido nuestros modelos y campos, tenemos que pensar en las relaciones. Django te permite definir relaciones de uno a uno (`OneToOneField`), de uno a muchos (`ForeignKey`) y de muchos a muchos (`ManyToManyField`).
 
-Con esto en mente, el diagrama de asociación UML a continuación muestra los modelos que definiremos en este caso (como recuadros). Como se mencionó anteriormente, hemos creado modelos para el libro (los detalles genéricos del libro), instancia del libro (estado de copias físicas específicas del libro disponible en el sistema) y autor. También hemos decidido tener un modelo para el género, para que los valores se puedan crear/seleccionar a través de la interfaz admin. Hemos decidido no tener un modelo para el `BookInstance:status`, en su lugar, hemos especificado directamente, en el código, los valores (`LOAN_STATUS`) porque no esperamos que cambien. Dentro de cada uno de los cuadros, puede ver el nombre del modelo, los nombres y tipos de campo, y también los métodos y sus tipos de devolución.
+Con esto en mente, el siguiente diagrama de asociación UML muestra los modelos que definiremos en este caso (como recuadros).
 
-El diagrama también muestra las relaciones entre los modelos, incluida su _cardinalidad_. La cardinalidad expresa la cantidad de instancias (máximo y mínimo) de cada modelo que pueden estar presentes en la relación. Por ejemplo, la línea de conexión entre los cuadros muestra que _Book_ y _Genre_ están relacionados. Los números cercanos al modelo _Book_ muestran que un libro debe tener uno o más _Genres_ (tantos como desee), mientras que los números al otro lado de la línea al lado de _Genre_ muestran que puede tener cero o más libros asociados.
+![UML del modelo de LocalLibrary con la multiplicidad de Author corregida dentro de la clase Book](local_library_model_uml.svg)
 
-![LocalLibrary Model UML](local_library_model_uml.svg)
+Hemos creado modelos para el libro (los detalles genéricos del libro), la instancia de libro (el estado de las copias físicas específicas del libro disponibles en el sistema) y el autor. También hemos decidido tener un modelo para el género, de manera que los valores se puedan crear/seleccionar a través de la interfaz de administración. Hemos decidido no tener un modelo para `BookInstance:status`; hemos codificado directamente los valores (`LOAN_STATUS`) porque no esperamos que cambien. Dentro de cada uno de los recuadros, puedes ver el nombre del modelo, los nombres y tipos de los campos, y también los métodos y sus tipos de retorno.
+
+El diagrama también muestra las relaciones entre los modelos, incluidas sus _multiplicidades_. Las multiplicidades son los números del diagrama que indican la cantidad (máxima y mínima) de cada modelo que puede estar presente en la relación. Por ejemplo, la línea que conecta los recuadros muestra que Book y Genre están relacionados. Los números cercanos al modelo Genre muestran que un libro debe tener uno o más Genres (tantos como quieras), mientras que los números en el otro extremo de la línea, junto al modelo Book, muestran que un Genre puede tener cero o muchos libros asociados.
 
 > [!NOTE]
-> La siguiente sección proporciona un manual básico que explica cómo se definen y utilizan los modelos. Mientras lo lees, considera cómo construiremos cada uno de los modelos en el diagrama de arriba.
+> La siguiente sección ofrece un manual básico que explica cómo se definen y utilizan los modelos. Mientras la lees, piensa en cómo construiremos cada uno de los modelos del diagrama anterior.
 
-## Cartilla del Modelo
+## Introducción a los modelos
 
-Esta sección provee una vista resumida de cómo se define un modelo y algunos de los campos más importantes y argumentos de campo.
+Esta sección ofrece una breve descripción de cómo se define un modelo y algunos de los campos y argumentos de campo más importantes.
 
-### Definición de modelo
+### Definición del modelo
 
-Los modelos están definidos, normalmente, en el archivo **models.py** de la aplicación. Son implementados como subclases de `django.db.models.Model`, y pueden incluir campos, métodos y metadata. El fragmento de código más abajo muestra un modelo "típico", llamado `MyModelName`:
+Los modelos normalmente se definen en el archivo **models.py** de una aplicación. Se implementan como subclases de `django.db.models.Model` y pueden incluir campos, métodos y metadatos. El siguiente fragmento de código muestra un modelo "típico", llamado `MyModelName`:
 
 ```python
 from django.db import models
+from django.urls import reverse
 
 class MyModelName(models.Model):
-    """
-    Una clase típica definiendo un modelo, derivado desde la clase Model.
-    """
+    """Una clase típica que define un modelo, derivada de la clase Model."""
 
     # Campos
-    my_field_name = models.CharField(max_length=20, help_text="Enter field documentation")
-    ...
+    my_field_name = models.CharField(max_length=20, help_text='Enter field documentation')
+    # …
 
-    # Metadata
+    # Metadatos
     class Meta:
-        ordering = ["-my_field_name"]
+        ordering = ['-my_field_name']
 
     # Métodos
     def get_absolute_url(self):
-         """
-         Devuelve la url para acceder a una instancia particular de MyModelName.
-         """
-         return reverse('model-detail-view', args=[str(self.id)])
+        """Devuelve la URL para acceder a una instancia particular de MyModelName."""
+        return reverse('model-detail-view', args=[str(self.id)])
 
     def __str__(self):
-        """
-        Cadena para representar el objeto MyModelName (en el sitio de Admin, etc.)
-        """
-        return self.field_name
+        """Cadena para representar el objeto MyModelName (en el sitio de Admin, etc.)."""
+        return self.my_field_name
 ```
 
-En las secciones de abajo exploraremos cada una de las características interiores de un modelo en detalle:
+En las siguientes secciones exploraremos en detalle cada una de las características internas de un modelo:
 
 #### Campos
 
-Un modelo puede tener un número arbitrario de campos, de cualquier tipo. Cada uno representa una columna de datos que queremos guardar en nuestras tablas de la base de datos. Cada registro de la base de datos (fila) consistirá en uno de cada posible valor del campo. Echemos un vistazo al ejemplo visto arriba:
+Un modelo puede tener un número arbitrario de campos, de cualquier tipo; cada uno representa una columna de datos que queremos almacenar en una de nuestras tablas de la base de datos. Cada registro de la base de datos (fila) consistirá en uno de cada valor de campo. Veamos el ejemplo de abajo:
 
-```js
-my_field_name = models.CharField(
-  (max_length = 20),
-  (help_text = "Enter field documentation"),
-);
+```python
+my_field_name = models.CharField(max_length=20, help_text='Enter field documentation')
 ```
 
-Nuestro ejemplo de arriba tiene un único campo llamado `my_field_name`, de tipo `models.CharField` — lo que significa que este campo contendrá una cadena de caracteres alfanuméricos. Los tipos de campo son asignados usando clases específicas, que determinan el tipo de registro que se usa para guardar el dato en la base, junto con un criterio de evaluación que se usará cuando se reciban los valores de un formulario HTML (es decir, qué constituye un valor válido). Los tipos de campo pueden también tomar argumentos que especifican además cómo se guarda o cómo se puede usar. En este caso le damos a nuestro campo dos argumentos:
+Nuestro ejemplo de arriba tiene un único campo llamado `my_field_name`, de tipo `models.CharField` — lo que significa que este campo contendrá cadenas de caracteres alfanuméricos. Los tipos de campo se asignan usando clases específicas, que determinan el tipo de registro que se usa para almacenar el dato en la base de datos, junto con los criterios de validación que se usarán cuando se reciban valores de un formulario HTML (es decir, qué constituye un valor válido). Los tipos de campo también pueden tomar argumentos que especifiquen aún más cómo se almacena el campo o cómo se puede usar. En este caso, le damos a nuestro campo dos argumentos:
 
-- `max_length=20` — Establece que la longitud máxima del valor de este campo es 20 caracteres.
-- `help_text="Enter field documentation"` — proporciona una etiqueta de texto para mostrar que ayuda a los usuarios a saber qué valor proporcionar cuando un usuario ha de introducirlo via un formulario HTML.
+- `max_length=20` — Establece que la longitud máxima de un valor de este campo es de 20 caracteres.
+- `help_text='Enter field documentation'` — texto de ayuda que puede mostrarse en un formulario para ayudar a los usuarios a entender cómo se usa el campo.
 
-El nombre del campo se usa para referirnos a él en consultas (_queries_) y plantillas (_templates_). Los campos también tienen una etiqueta, que puede ser especificada como argumento (`verbose_name`) o inferida automáticamente, a partir del nombre de variable que identifica al campo, capitalizando la primera letra y reemplazando los guiones bajos por espacios (por ejemplo `my_field_name` tendría la etiqueta por defecto de _My field name_). El orden en que los campos son declarados afectará su orden por defecto si un modelo es renderizado en un formulario (ej. en el sitio de Administración), aunque este comportamiento se puede anular.
+El nombre del campo se usa para referirse a él en consultas y plantillas.
+Los campos también tienen una etiqueta, que se especifica mediante el argumento `verbose_name` (con un valor predeterminado de `None`).
+Si no se establece `verbose_name`, la etiqueta se crea a partir del nombre del campo reemplazando los guiones bajos por un espacio y poniendo en mayúscula la primera letra (por ejemplo, el campo `my_field_name` tendría una etiqueta predeterminada de _My field name_ cuando se use en formularios).
+
+El orden en que se declaran los campos afectará su orden predeterminado si un modelo se renderiza en un formulario (por ejemplo, en el sitio de administración), aunque esto se puede anular.
 
 ##### Argumentos comunes de los campos
 
-Los siguientes argumentos son comunes a la mayoría de los tipos de campo y pueden usarse al declararlos:
+Los siguientes argumentos comunes se pueden usar al declarar muchos (o la mayoría) de los diferentes tipos de campo:
 
-- [help_text](https://docs.djangoproject.com/en/1.10/ref/models/fields/#help-text): Proporciona una etiqueta de texto para formularios HTML (ej. en el sitio de Administración), tal como se describe arriba.
-- [verbose_name](https://docs.djangoproject.com/en/1.10/ref/models/fields/#verbose-name): Nombre de fácil lectura que se usa en etiquetas para el campo. Si no se especifica, Django inferirá el valor por defecto del verbose name a partir del nombre del campo.
-- [default](https://docs.djangoproject.com/en/1.10/ref/models/fields/#default): Valor por defecto para el campo. Puede ser un valor o un _callable object_ (objeto que puede ser llamado como una función), en cuyo caso el objeto será llamado cada vez que se cree un nuevo registro.
-- [null](https://docs.djangoproject.com/en/1.10/ref/models/fields/#null): Si es `True`, Django guardará valores en blanco o vacíos como `NULL` en la base de datos para campos donde sea apropiado (un `CharField` guardará una cadena vacía en su lugar). Por defecto es `False`.
-- [blank](https://docs.djangoproject.com/en/1.10/ref/models/fields/#blank): Si es `True`, se permite que el campo quede en blanco en tus formularios. El valor por defecto es `False`, lo que significa que la validación de formularios de Django te forzará a introducir un valor. Con frecuencia se usa con `null=True`, porque si vas a permitir valores en blanco, también querrás que la base de datos sea capaz de representarlos de forma apropiada.
-- [choices](https://docs.djangoproject.com/en/1.10/ref/models/fields/#choices): Un grupo de valores de selección para este campo. Si se proporciona, el widget correspondiente por defecto del formulario será una caja de selección con estos valores de selección en vez del campo de texto estándar.
-- [primary_key](https://docs.djangoproject.com/en/1.10/ref/models/fields/#primary-key): Si es `True`, establece el campo actual como clave primaria para el modelo (Una clave primaria es una columna especial de la base de datos, diseñada para identificar de forma única todos los diferentes registros de una tabla). Si no se especifica ningún campo como clave primaria, Django añadirá automáticamente un campo para este propósito.
+- [help_text](https://docs.djangoproject.com/en/5.0/ref/models/fields/#help-text): Proporciona una etiqueta de texto para formularios HTML (por ejemplo, en el sitio de administración), tal como se describió anteriormente.
+- [verbose_name](https://docs.djangoproject.com/en/5.0/ref/models/fields/#verbose-name): Un nombre legible para humanos que se usa en las etiquetas del campo. Si no se especifica, Django inferirá el nombre detallado predeterminado a partir del nombre del campo.
+- [default](https://docs.djangoproject.com/en/5.0/ref/models/fields/#default): El valor predeterminado para el campo. Puede ser un valor o un objeto invocable (_callable_), en cuyo caso el objeto se llamará cada vez que se cree un nuevo registro.
+- [null](https://docs.djangoproject.com/en/5.0/ref/models/fields/#null): Si es `True`, Django almacenará los valores en blanco como `NULL` en la base de datos para los campos donde esto sea apropiado (un `CharField` almacenará, en cambio, una cadena vacía). El valor predeterminado es `False`.
+- [blank](https://docs.djangoproject.com/en/5.0/ref/models/fields/#blank): Si es `True`, se permite que el campo quede en blanco en tus formularios. El valor predeterminado es `False`, lo que significa que la validación de formularios de Django te obligará a introducir un valor. Esto se suele usar junto con `null=True`, porque si vas a permitir valores en blanco, también querrás que la base de datos pueda representarlos de forma adecuada.
+- [choices](https://docs.djangoproject.com/en/5.0/ref/models/fields/#choices): Un grupo de opciones para este campo. Si se proporciona, el widget de formulario correspondiente por defecto será una casilla de selección con estas opciones en lugar del campo de texto estándar.
+- [unique](https://docs.djangoproject.com/en/5.0/ref/models/fields/#unique):
+  Si es `True`, garantiza que el valor del campo sea único en toda la base de datos.
+  Esto se puede usar para evitar la duplicación de campos que no pueden tener los mismos valores.
+  El valor predeterminado es `False`.
+- [primary_key](https://docs.djangoproject.com/en/5.0/ref/models/fields/#primary-key):
+  Si es `True`, establece el campo actual como la clave primaria del modelo (una clave primaria es una columna especial de la base de datos designada para identificar de forma única todos los registros de la tabla).
+  Si no se especifica ningún campo como clave primaria, Django agregará automáticamente un campo para este propósito.
+  El tipo de los campos de clave primaria creados automáticamente se puede especificar para cada aplicación en [`AppConfig.default_auto_field`](https://docs.djangoproject.com/en/5.0/ref/applications/#django.apps.AppConfig.default_auto_field) o de forma global en el ajuste [`DEFAULT_AUTO_FIELD`](https://docs.djangoproject.com/en/5.0/ref/settings/#std:setting-DEFAULT_AUTO_FIELD).
 
-Hay muchas otras opciones — puedes ver la [lista completa de opciones aquí](https://docs.djangoproject.com/en/1.10/ref/models/fields/#field-options).
+  > [!NOTE]
+  > Las aplicaciones creadas con **manage.py** establecen el tipo de la clave primaria como [BigAutoField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#bigautofield).
+  > Puedes ver esto en el archivo **catalog/apps.py** de la biblioteca local:
+  >
+  > ```python
+  > class CatalogConfig(AppConfig):
+  >   default_auto_field = 'django.db.models.BigAutoField'
+  > ```
 
-##### Tipos comunes de campos
+Hay muchas otras opciones: puedes consultar la [lista completa de opciones de campo aquí](https://docs.djangoproject.com/en/5.0/ref/models/fields/#field-options).
 
-La lista siguiente describe algunos de los tipos de campo más comunmente usados.
+##### Tipos comunes de campo
 
-- [CharField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.CharField) se usa para definir cadenas de longitud corta a media. Debes especificar la `max_length` (longitud máxima) de los datos que se guardarán.
-- [TextField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.TextField) se usa para cadenas de longitud grande o arbitraria. Puedes especificar una `max_length` para el campo, pero sólo se usa cuando el campo se muestra en formularios (no se fuerza al nivel de la base de datos).
-- [IntegerField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.IntegerField) es un campo para almacenar valores de números enteros y para validar los valores introducidos como enteros en los formularios.
-- [DateField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#datefield) y [DateTimeField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#datetimefield) se usan para guardar/representar fechas e información fecha/hora (como en los objetos Python `datetime.date` y `datetime.datetime`, respectivamente). Estos campos pueden adicionalmente declarar los parámetros (mutuamente excluyentes) `auto_now=True` (para establecer el campo a la fecha actual cada vez que se guarda el modelo), `auto_now_add` (para establecer sólo la fecha cuando se crea el modelo por primera vez), y `default` (para establecer una fecha por defecto que puede ser sobreescrita por el usuario).
-- [EmailField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#emailfield) se usa para validar direcciones de correo electrónico.
-- [FileField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#filefield) e [ImageField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#imagefield) se usan para subir ficheros e imágenes respectivamente (el `ImageField` añade simplemente una validación adicional de que el fichero subido es una imagen). Éstos tienen parámetros para definir cómo y donde se guardan los ficheros subidos.
-- [AutoField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#autofield) es un tipo especial de `IntegerField` que se incrementa automáticamente. Cuando no especificas una clave primaria para tu modelo, se añade -automáticamente- una de éste tipo.
-- [ForeignKey](https://docs.djangoproject.com/en/1.10/ref/models/fields/#foreignkey) se usa para especificar una relación uno a muchos con otro modelo de la base de datos (ej. un coche tiene un fabricante, pero un fabricante puede hacer muchos coches). El lado "uno" de la relación es el modelo que contiene la clave.
-- [ManyToManyField](https://docs.djangoproject.com/en/1.10/ref/models/fields/#manytomanyfield) se usa para especificar una relación muchos a muchos (ej. un libro puede tener varios géneros, y cada género puede contener varios libros). En nuestra aplicación de la biblioteca usaremos ésta de forma muy similar a `ForeignKeys`, pero pueden usarse de formas más complicadas para describir las relaciones entre grupos. Éstas tienen el parámetro `on_delete` para definir que ocurre cuando un registro asociado se borra (ej. un valor de `models.SET_NULL` establecería simplemente el valor a `NULL`).
+La siguiente lista describe algunos de los tipos de campo más utilizados.
 
-Hay muchos otros tipos de campos, incluyendo campos para diferentes tipos de números (enteros grandes, enteros pequeños, en coma flotante), boleanos, URLs, slugs, identificadores únicos, y otra información relacionada con el tiempo (duración, hora, etc..). Puedes ver la [lista completa aquí](https://docs.djangoproject.com/en/1.10/ref/models/fields/#field-types).
+- [CharField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.CharField) se usa para definir cadenas de longitud fija, de tamaño corto a mediano. Debes especificar el `max_length` de los datos que se van a almacenar.
+- [TextField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.TextField) se usa para cadenas de longitud arbitraria y grande. Puedes especificar un `max_length` para el campo, pero solo se usa cuando el campo se muestra en formularios (no se aplica a nivel de base de datos).
+- [IntegerField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.IntegerField) es un campo para almacenar valores enteros (números completos) y para validar los valores introducidos como enteros en los formularios.
+- [DateField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#datefield) y [DateTimeField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#datetimefield) se usan para almacenar/representar fechas e información de fecha/hora (como objetos `datetime.date` y `datetime.datetime` de Python, respectivamente). Estos campos pueden además declarar los parámetros (mutuamente excluyentes) `auto_now=True` (para establecer el campo con la fecha actual cada vez que se guarda el modelo), `auto_now_add` (para establecer la fecha solo cuando el modelo se crea por primera vez) y `default` (para establecer una fecha predeterminada que el usuario puede sobrescribir).
+- [EmailField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#emailfield) se usa para almacenar y validar direcciones de correo electrónico.
+- [FileField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#filefield) e [ImageField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#imagefield) se usan para subir archivos e imágenes, respectivamente (`ImageField` agrega una validación adicional de que el archivo subido sea una imagen). Estos tienen parámetros para definir cómo y dónde se almacenan los archivos subidos.
+- [AutoField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#autofield) es un tipo especial de `IntegerField` que se incrementa automáticamente. Una clave primaria de este tipo se agrega automáticamente a tu modelo si no especificas explícitamente una.
+- [ForeignKey](https://docs.djangoproject.com/en/5.0/ref/models/fields/#foreignkey) se usa para especificar una relación de uno a muchos con otro modelo de la base de datos (por ejemplo, un coche tiene un solo fabricante, pero un fabricante puede fabricar muchos coches). El lado "uno" de la relación es el modelo que contiene la "clave" (los modelos que contienen una "clave externa" que hace referencia a esa "clave" están en el lado "muchos" de dicha relación).
+- [ManyToManyField](https://docs.djangoproject.com/en/5.0/ref/models/fields/#manytomanyfield) se usa para especificar una relación de muchos a muchos (por ejemplo, un libro puede tener varios géneros, y cada género puede contener varios libros). En nuestra aplicación de biblioteca las usaremos de forma muy similar a `ForeignKeys`, pero se pueden usar de maneras más complicadas para describir las relaciones entre grupos. Estos tienen el parámetro `on_delete` para definir qué ocurre cuando se elimina el registro asociado (por ejemplo, un valor de `models.SET_NULL` establecería el valor en `NULL`).
+
+Hay muchos otros tipos de campo, incluidos campos para diferentes tipos de números (enteros grandes, enteros pequeños, de punto flotante), booleanos, URL, slugs, id únicos y otra información relacionada con el tiempo (duración, hora, etc.). Puedes consultar la [lista completa aquí](https://docs.djangoproject.com/en/5.0/ref/models/fields/#field-types).
 
 #### Metadatos
 
-Puedes declarar metadatos a nivel de modelo para tu Modelo declarando `class Meta`, tal como se muestra.
+Puedes declarar metadatos a nivel de modelo para tu Model declarando `class Meta`, como se muestra.
 
 ```python
 class Meta:
-    ordering = ["-my_field_name"]
-    ...
+    ordering = ['-my_field_name']
 ```
 
-Una de las características más útiles de estos metadatos es controlar el _orden por defecto_ de los registros que se devuelven cuando se consulta el tipo de modelo. Se hace especificando el orden de comprobación en una lista de nombres de campo en el atributo `ordering`, como se muestra arriba. La ordenación dependerá del tipo de campo (los campos de caracteres de ordenan alfabéticamente, mientras que los campos de fechas están clasificados por orden cronológico). Como se muestra arriba, se puede invertir el orden de clasificación añadiendo el símbolo (-) como prefijo del nombre del campo.
+Una de las características más útiles de estos metadatos es controlar el _orden predeterminado_ de los registros que se devuelven al consultar el tipo de modelo. Esto se hace especificando el orden de coincidencia en una lista de nombres de campo en el atributo `ordering`, como se muestra arriba. El orden dependerá del tipo de campo (los campos de caracteres se ordenan alfabéticamente, mientras que los campos de fecha se ordenan cronológicamente). Como se muestra arriba, puedes anteponer el símbolo menos (-) al nombre del campo para invertir el orden de clasificación.
 
-Así como ejemplo, si elegimos clasificar los libros de esta forma por defecto:
+Así, por ejemplo, si eligiéramos ordenar los libros de esta forma por defecto:
 
 ```python
-ordering = ["title", "-pubdate"]
+ordering = ['title', '-publish_date']
 ```
 
-los libros serán clasificados alfabéticamente por título, de la A al a Z, y luego por fecha de publicación dentro de cada título, desde el más reciente al más antiguo.
+los libros se ordenarían alfabéticamente por título, de la A a la Z, y luego por fecha de publicación dentro de cada título, de más reciente a más antiguo.
 
 Otro atributo común es `verbose_name`, un nombre descriptivo para la clase en forma singular y plural:
 
 ```python
-verbose_name = "BetterName"
+verbose_name = 'BetterName'
 ```
 
-Otros atributos útiles te permiten crear y aplicar nuevos "permisos de acceso" para el modelo (los permisos por defecto se aplican automáticamente), te permiten la ordenación basado en otro campo, o declarar que la clase es "abstracta" (una clase base para la que no vas a crear registros, y que en cambio se derivará para crear otros modelos).
+Los metadatos de la clase se pueden usar para crear y aplicar nuevos "permisos de acceso" para el modelo (los permisos predeterminados se aplican automáticamente), permitir la ordenación basada en otro campo, definir [restricciones](https://docs.djangoproject.com/en/5.0/ref/models/constraints/) sobre los posibles valores de los datos que se pueden almacenar, o declarar que la clase es "abstracta" (una clase base para la que no puedes crear registros y que, en cambio, se usará para derivar otros modelos).
 
-Muchas de las otras opciones de metadatos controlan qué base datos debe usarse para el modelo y cómo se guardan los datos (éstas son realmente útiles si necesitas mapear un modelo a una base datos existente).
+Muchas de las otras opciones de metadatos controlan qué base de datos debe usarse para el modelo y cómo se almacenan los datos (estas solo son realmente útiles si necesitas asignar un modelo a una base de datos ya existente).
 
-La lista completa de opciones de metadatos está disponible aquí: [Opciones de metadatos de Modelos](https://docs.djangoproject.com/es/2.0/ref/models/options/) (Django docs).
+La lista completa de opciones de metadatos está disponible aquí: [Opciones de metadatos del modelo](https://docs.djangoproject.com/en/5.0/ref/models/options/) (documentación de Django).
 
-#### Metodos
+#### Métodos
 
-Un modelo puede tener también métodos
+Un modelo también puede tener métodos.
 
-Minimamente, en cada modelo deberías definir el método estándar de las clases de Python `__str__()` para devolver una cadena de texto legible por humanos para cada objeto. Esta cadena se usa para representar registros individuales en el sitio de administración (y en cualquier otro lugar donde necesites referirte a una instancia del modelo). Con frecuencia éste devolverá un título o nombre de campo del modelo.
+**Como mínimo, en cada modelo deberías definir el método estándar de clase de Python `__str__()` para devolver una cadena legible por humanos para cada objeto.** Esta cadena se usa para representar registros individuales en el sitio de administración (y en cualquier otro lugar donde necesites referirte a una instancia del modelo). A menudo, esto devolverá un campo de título o nombre del modelo.
 
 ```python
 def __str__(self):
-    return self.field_name
+    return self.my_field_name
 ```
 
-Otro método común a incluir en los modelos de Django es `get_absolute_url()`, que devuelve un URL para presentar registros individuales del modelo en el sitio web (si defines este método, Django añadirá automáticamente un botón "Ver en el sitio" en la ventana de edición del registro del modelo en el sitio de Administración). Un patrón típico para `get_absolute_url()` se muestra abajo.
+Otro método común para incluir en los modelos de Django es `get_absolute_url()`, que devuelve una URL para mostrar registros individuales del modelo en el sitio web (si defines este método, Django agregará automáticamente un botón "Ver en el sitio" en las pantallas de edición de registros del modelo en el sitio de administración). A continuación se muestra un patrón típico para `get_absolute_url()`.
 
 ```python
 def get_absolute_url(self):
-    """
-     Devuelve la url para acceder a una instancia particular del modelo.
-    """
+    """Devuelve la URL para acceder a una instancia particular del modelo."""
     return reverse('model-detail-view', args=[str(self.id)])
 ```
 
 > [!NOTE]
-> Asumiendo que usarás URLs tipo `/myapplication/mymodelname/2` para presentar registros individuales para tu modelo (donde "2" es el `id` de un registro en particular), necesitarás crear un mapeador URL para pasar la respuesta e id a la "vista detallada del modelo (model detail view)" (que hará el trabajo requerido para presentar el registro). La función `reverse()` de arriba es capaz de "invertir" tu mapeador url (llamado _'model-detail-view'_ en el caso de arriba) para crear una URL del formato correcto.
+> Suponiendo que vas a usar URL como `/my-application/my-model-name/2` para mostrar registros individuales de tu modelo (donde "2" es el `id` de un registro en particular), necesitarás crear un mapeador de URL para pasar la respuesta y el id a una "vista de detalle del modelo" (que hará el trabajo necesario para mostrar el registro). La función `reverse()` de arriba es capaz de "invertir" tu mapeador de URL (en el caso anterior, llamado _'model-detail-view'_) para crear una URL con el formato correcto.
 >
-> Por supuesto para hacer este trabajo ¡tienes aún que escribir el mapeo URL, la vista y la plantilla!
+> ¡Por supuesto, para que esto funcione todavía tienes que escribir el mapeo de URL, la vista y la plantilla!
 
-Puedes también definir todos los métodos que te apetezca y llamarlos desde tu código o plantillas (siempre y cuando no reciban ningún parámetro).
+También puedes definir cualquier otro método que quieras y llamarlo desde tu código o tus plantillas (siempre que no reciban ningún parámetro).
 
-### Gestión de Modelos
+### Gestión de modelos
 
-Una vez que has definido tus clases de modelos puedes usarlas para crear, actualizar o borrar registros, y ejecutar consultas para obtener todos los registros o subconjuntos particulares de registros. Te mostraremos cómo hacer eso en el tutorial cuando definamos nuestras vistas, pero aquí va un breve resumen.
+Una vez que hayas definido tus clases de modelo, puedes usarlas para crear, actualizar o eliminar registros, y para ejecutar consultas que obtengan todos los registros o subconjuntos particulares de registros. Te mostraremos cómo hacerlo en el tutorial cuando definamos nuestras vistas, pero aquí tienes un breve resumen.
 
 #### Creación y modificación de registros
 
-Para crear un registro puedes definir una instancia del modelo y llamar a `save()`.
+Para crear un registro, puedes definir una instancia del modelo y luego llamar a `save()`.
 
 ```python
-# Creación de un nuevo registro usando el constructor del modelo.
-a_record = MyModelName(my_field_name="Instancia #1")
+# Crea un nuevo registro usando el constructor del modelo.
+record = MyModelName(my_field_name="Instancia #1")
 
-# Guardar el objeto en la base de datos.
-a_record.save()
+# Guarda el objeto en la base de datos.
+record.save()
 ```
 
 > [!NOTE]
-> Si no has declarado ningún campo como `primary_key`, al nuevo registro se le proporcionará una automáticamente, con el nombre de campo `id`. Puedes consultar este campo después de guardar el registro anterior y debería tener un valor de 1.
+> Si no has declarado ningún campo como `primary_key`, al nuevo registro se le asignará uno automáticamente, con el nombre de campo `id`. Podrías consultar este campo después de guardar el registro anterior, y tendría un valor de 1.
 
-Puedes acceder a los campos de este nuevo registro usando la sintaxis de puntos y cambiar los valores. Tienes que llamar a `save()` para almacenar los valores modificados en la base de datos.
+Puedes acceder a los campos de este nuevo registro usando la sintaxis de punto, y cambiar los valores. Tienes que llamar a `save()` para almacenar los valores modificados en la base de datos.
 
 ```python
-# Accesso a los valores de los campos del modelo usando atributos Python.
-print(a_record.id) # Debería devolver 1 para el primer registro.
-print(a_record.my_field_name) # Debería imprimir 'Instancia #1'
+# Accede a los valores de los campos del modelo usando atributos de Python.
+print(record.id) # debería devolver 1 para el primer registro.
+print(record.my_field_name) # debería imprimir 'Instancia #1'
 
-# Cambio de un registro modificando los campos llamando a save() a continuación.
-a_record.my_field_name="Nuevo Nombre de Instancia"
-a_record.save()
+# Cambia el registro modificando los campos y luego llamando a save().
+record.my_field_name = "Nuevo nombre de instancia"
+record.save()
 ```
 
 #### Búsqueda de registros
 
-Puedes buscar registros que coincidan con un cierto criterio usando el atributo `objects` del modelo (proporcionado por la clase base).
+Puedes buscar registros que coincidan con ciertos criterios usando el atributo `objects` del modelo (proporcionado por la clase base).
 
 > [!NOTE]
-> Explicar cómo buscar registros usando un modelo y nombres de campo "abstractos" puede resultar un poco confuso. En la exposición de abajo nos referiremos a un modelo `Book` con campos `title` y `genre`, donde genre (género) es también un modelo con un solo campo `name`.
+> Explicar cómo buscar registros usando nombres de modelo y de campo "abstractos" puede resultar un poco confuso. En la explicación siguiente nos referiremos a un modelo `Book` con los campos `title` y `genre`, donde genre es también un modelo con un único campo `name`.
 
-Podemos obtener todos los registros de un modelo como `QuerySet`, usando `objects.all()`. El `QuerySet` es un objeto iterable, significando que contiene un número de objetos por los que podemos iterar/hacer bucle.
+Podemos obtener todos los registros de un modelo como un `QuerySet`, usando `objects.all()`. El `QuerySet` es un objeto iterable, lo que significa que contiene varios objetos por los que podemos iterar/recorrer en un bucle.
 
 ```python
 all_books = Book.objects.all()
 ```
 
-El método de Django `filter()` nos permite filtrar el `QuerySet` devuelto para que coincida un campo de **texto** o **numérico** con un criterio particular. Por ejemplo, para filtrar libros que contengan la palabra "wild" en el título y luego contarlos, podemos hacer lo siguiente:
+El método `filter()` de Django nos permite filtrar el `QuerySet` devuelto para que coincida un campo de **texto** o **numérico** especificado con determinados criterios. Por ejemplo, para filtrar los libros que contengan "wild" en el título y luego contarlos, podríamos hacer lo siguiente:
 
 ```python
 wild_books = Book.objects.filter(title__contains='wild')
-number_wild_books = Book.objects.filter(title__contains='wild').count()
+number_wild_books = wild_books.count()
 ```
 
-Los campos a buscar y el tipo de coincidencia son definidos en el nombre del parámetro de filtro, usando el formato: `field_name__match_type` (ten en cuenta el _doble guión bajo_ entre `title` y `contains` anterior). En el ejemplo anterior estamos filtrando `title` por un valor sensible a mayúsculas y minúsculas. Puedes hacer otros muchos tipos de coincidencias: `icontains` (no sensible a mayúsculas ni minúsculas), `iexact` (coincidencia exacta no sensible a mayúsculas ni minúsculas), `exact` (coincidencia exacta sensible a mayúsculas y minúsculas) e `in`, `gt` (mayor que), `startswith`, etc. Puede ver la [lista completa aquí](https://docs.djangoproject.com/en/1.10/ref/models/querysets/#field-lookups).
+Los campos que se deben coincidir y el tipo de coincidencia se definen en el nombre del parámetro de filtro, usando el formato: `field_name__match_type` (observa el _doble guion bajo_ entre `title` y `contains` arriba). Arriba estamos filtrando `title` con una coincidencia sensible a mayúsculas y minúsculas. Hay muchos otros tipos de coincidencia que puedes hacer: `icontains` (sin distinguir mayúsculas y minúsculas), `iexact` (coincidencia exacta sin distinguir mayúsculas y minúsculas), `exact` (coincidencia exacta sensible a mayúsculas y minúsculas) e `in`, `gt` (mayor que), `startswith`, etc. La [lista completa está aquí](https://docs.djangoproject.com/en/5.0/ref/models/querysets/#field-lookups).
 
-En algunos casos, necesitarás filtrar por un campo que define una relación uno-a-muchos con otro modelo (por ejemplo, una `ForeignKey`). En estos casos puedes "referenciar" a campos dentro del modelo relacionado con un doble guión bajo adicional. Así, por ejemplo, para filtrar los libros de un género específico tienes que referenciar el `name` a través del campo `genre` como se muestra más abajo:
+En algunos casos, necesitarás filtrar por un campo que define una relación de uno a muchos con otro modelo (por ejemplo, una `ForeignKey`). En este caso, puedes "indexar" a campos dentro del modelo relacionado con guiones bajos dobles adicionales.
+Así, por ejemplo, para filtrar libros con un patrón de género específico, tendrás que indexar hasta `name` a través del campo `genre`, como se muestra a continuación:
 
 ```python
-books_containing_genre = Book.objects.filter(genre__name__icontains='fiction')  # Will match on: Fiction, Science fiction, non-fiction etc.
+# Coincidirá con: Fiction, Science fiction, non-fiction etc.
+books_containing_genre = Book.objects.filter(genre__name__icontains='fiction')
 ```
 
 > [!NOTE]
-> Puedes usar guiones bajos (\_\_) para navegar por tantos niveles de relaciones (`ForeignKey`/`ManyToManyField`) como quieras. Por ejemplo, un Book que tuviera diferentes "types", definidos usando una relación adicional "cover", podría tener un nombre de parámetro: `type__cover__name__exact='hard'.`
+> Puedes usar guiones bajos (`__`) para recorrer tantos niveles de relaciones (`ForeignKey`/`ManyToManyField`) como quieras.
+> Por ejemplo, un `Book` que tuviera diferentes tipos, definidos mediante una relación adicional "cover", podría tener un nombre de parámetro: `type__cover__name__exact='hard'`.
 
-Puedes hacer muchas más cosas con las consultas, incluyendo búsquedas hacia atrás de modelos relacionados, filtros encadenados, devolver un conjunto de valores más pequeño, etc. Para más información, puedes consultar [Elaborar consultas](https://docs.djangoproject.com/en/1.10/topics/db/queries/) (Django Docs).
+Hay mucho más que puedes hacer con las consultas, incluidas las búsquedas inversas desde modelos relacionados, el encadenamiento de filtros, la devolución de un conjunto más pequeño de valores, etc. Para más información, consulta [Realizar consultas](https://docs.djangoproject.com/en/5.0/topics/db/queries/) (documentación de Django).
 
-## Definiendo los Modelos de LocalLybrary
+## Definiendo los modelos de LocalLibrary
 
-En esta sección comenzaremos a definir los modelos para nuestra biblioteca. Abre _models.py (en /locallibrary/catalog/)_. El código de más arriba importa el módulo `models` que contiene la clase `models.Model`, que servirá de base para nuestros modelos:
+En esta sección comenzaremos a definir los modelos para la biblioteca. Abre `models.py` (en /django-locallibrary-tutorial/catalog/). El código repetitivo (_boilerplate_) al principio de la página importa el módulo _models_, que contiene la clase base de modelo `models.Model`, de la que heredarán nuestros modelos.
 
 ```python
 from django.db import models
 
-# Create your models here.
+# Crea tus modelos aquí.
 ```
 
 ### Modelo 'Genre'
 
-Copia el código del modelo `Genre` que se muestra abajo y pégalo al final de tu archivo `models.py`. Este modelo nos servirá para almacenar información relativa a la categoría del libro (por ejemplo, si es ficción o no, si es un romancero o es un libro de historia, etc.) Como se dijo más arriba, preferimos modelar el género (Genre) como una entidad, en vez de utilizar un campo de texto o una lista de opciones, porque de esta manera es posible manejar los valores a través de nuestra base de datos, en vez de fijarlo en el código (_hard-coding_)
+Copia el código del modelo `Genre` que se muestra a continuación y pégalo al final de tu archivo `models.py`. Este modelo se usa para almacenar información sobre la categoría del libro, por ejemplo, si es de ficción o no, romance o historia militar, etc.
+Como se mencionó anteriormente, hemos creado el género como un modelo en lugar de como texto libre o una lista de selección, para que los valores posibles se puedan gestionar a través de la base de datos en lugar de codificarlos directamente.
 
 ```python
+from django.urls import reverse # Se usa en get_absolute_url() para obtener la URL del ID especificado
+
+from django.db.models import UniqueConstraint # Restringe los campos a valores únicos
+from django.db.models.functions import Lower # Devuelve el valor del campo en minúsculas
+
 class Genre(models.Model):
-    """
-    Modelo que representa un género literario (p. ej. ciencia ficción, poesía, etc.).
-    """
-    name = models.CharField(max_length=200, help_text="Ingrese el nombre del género (p. ej. Ciencia Ficción, Poesía Francesa etc.)")
+    """Modelo que representa un género literario."""
+    name = models.CharField(
+        max_length=200,
+        unique=True,
+        help_text="Ingresa un género literario (p. ej. Ciencia Ficción, Poesía Francesa, etc.)"
+    )
 
     def __str__(self):
-        """
-        Cadena que representa a la instancia particular del modelo (p. ej. en el sitio de Administración)
-        """
+        """Cadena que representa al objeto Modelo."""
         return self.name
+
+    def get_absolute_url(self):
+        """Devuelve la URL para acceder a una instancia particular de género."""
+        return reverse('genre-detail', args=[str(self.id)])
+
+    class Meta:
+        constraints = [
+            UniqueConstraint(
+                Lower('name'),
+                name='genre_name_case_insensitive_unique',
+                violation_error_message = "El género ya existe (coincidencia sin distinguir mayúsculas y minúsculas)"
+            ),
+        ]
 ```
 
-El modelo tiene un único campo (`name`), de tipo `CharField`, que usaremos para describir el género literario. Este campo tiene un tamaño máximo (`max_length`) de 200 caracteres y, además, posee un `help_text`. Al final de la clase, hemos declarado el método `__str__()`, que simplemente devuelve el nombre de un género definido por un registro en particular. Como no hemos definido un nombre explicativo (`verbose_name`) para nuestro campo, éste se establecerá en `Name` y se mostrará de esa manera en los formularios.
+El modelo tiene un único campo `CharField` (`name`), que se usa para describir el género (está limitado a 200 caracteres y tiene algo de `help_text`).
+Hemos configurado este campo como único (`unique=True`) porque solo debe haber un registro para cada género.
+
+Después del campo, declaramos un método `__str__()`, que devuelve el nombre del género definido por un registro en particular. No se ha definido ningún nombre detallado (_verbose name_), por lo que la etiqueta del campo será `Name` cuando se use en formularios.
+A continuación, declaramos el método `get_absolute_url()`, que devuelve una URL que se puede usar para acceder a un registro de detalle de este modelo (para que esto funcione, tendremos que definir un mapeo de URL que tenga el nombre `genre-detail`, y definir una vista y una plantilla asociadas).
+
+Configurar `unique=True` en el campo anterior evita que se creen géneros con el nombre _exactamente_ igual, pero no variaciones como "fantasy", "Fantasy" o incluso "FaNtAsY".
+La última parte de la definición del modelo usa una opción de [`constraints`](https://docs.djangoproject.com/en/5.0/ref/models/options/#constraints) en los [metadatos](#metadatos) del modelo para especificar que el valor en minúsculas del campo `name` debe ser único en la base de datos, y mostrar la cadena `violation_error_message` si no lo es.
+Aquí no necesitamos hacer nada más, pero puedes definir varias restricciones sobre un campo o varios campos.
+Para más información, consulta la [referencia de Constraints](https://docs.djangoproject.com/en/5.0/ref/models/constraints/), incluyendo [`UniqueConstraint()`](https://docs.djangoproject.com/en/5.0/ref/models/constraints/#uniqueconstraint) (y [`Lower()`](https://docs.djangoproject.com/en/5.0/ref/models/database-functions/#lower)).
 
 ### Modelo 'Book'
 
-Copia el código del modelo `Book` que aparece más abajo y pégalo al final de tu archivo. El modelo Libro representa la información que se tiene sobre un libro, en sentido general, pero no sobre un libro particular que se encuentre disponible en la biblioteca. Este modelo utiliza campos de tipo `CharField` para representar el título (`title)` y el `isbn` del libro (nota que el campo `isbn` especifica su etiqueta como "ISBN" utilizando el primer parámetro posicional, ya que la etiqueta por defecto hubiera sido "Isbn"). Además tenemos un campo para la sinopsis (`summary`), de tipo `TextField`, ya que este texto podría ser bastante largo.
+Copia el modelo `Book` que aparece abajo y vuelve a pegarlo al final de tu archivo. El modelo `Book` representa toda la información sobre un libro disponible en un sentido general, pero no una "instancia" o "copia" física particular disponible para préstamo.
+
+El modelo usa un `CharField` para representar el `title` y el `isbn` del libro.
+En el caso de `isbn`, observa cómo el primer parámetro sin nombre establece explícitamente la etiqueta como "ISBN" (de lo contrario, sería "Isbn" por defecto). También establecemos el parámetro `unique` como `true` para garantizar que todos los libros tengan un ISBN único (el parámetro unique hace que el valor del campo sea único a nivel global en una tabla).
+A diferencia de `isbn` (y del nombre del género), `title` no se establece como único, porque es posible que diferentes libros tengan el mismo nombre.
+El modelo usa `TextField` para `summary`, porque este texto puede necesitar ser bastante largo.
 
 ```python
-from django.urls import reverse #Used to generate URLs by reversing the URL patterns
-
 class Book(models.Model):
-    """
-    Modelo que representa un libro (pero no un Ejemplar específico).
-    """
-
+    """Modelo que representa un libro (pero no una copia específica de un libro)."""
     title = models.CharField(max_length=200)
+    author = models.ForeignKey('Author', on_delete=models.RESTRICT, null=True)
+    # Se usa clave externa porque un libro solo puede tener un autor, pero los autores pueden tener varios libros.
+    # Author como cadena en lugar de objeto porque todavía no se ha declarado en el archivo.
 
-    author = models.ForeignKey('Author', on_delete=models.SET_NULL, null=True)
-    # ForeignKey, ya que un libro tiene un solo autor, pero el mismo autor puede haber escrito muchos libros.
-    # 'Author' es un string, en vez de un objeto, porque la clase Author aún no ha sido declarada.
+    summary = models.TextField(
+        max_length=1000, help_text="Ingresa una breve descripción del libro")
+    isbn = models.CharField('ISBN', max_length=13,
+                            unique=True,
+                            help_text='13 caracteres <a href="https://www.isbn-international.org/content/what-isbn'
+                                      '">número ISBN</a>')
 
-    summary = models.TextField(max_length=1000, help_text="Ingrese una breve descripción del libro")
-
-    isbn = models.CharField('ISBN',max_length=13, help_text='13 Caracteres <a href="https://www.isbn-international.org/content/what-isbn">ISBN number</a>')
-
-    genre = models.ManyToManyField(Genre, help_text="Seleccione un genero para este libro")
-    # ManyToManyField, porque un género puede contener muchos libros y un libro puede cubrir varios géneros.
-    # La clase Genre ya ha sido definida, entonces podemos especificar el objeto arriba.
+    # Se usa ManyToManyField porque un género puede contener muchos libros. Los libros pueden abarcar muchos géneros.
+    # La clase Genre ya se ha definido, así que podemos especificar el objeto arriba.
+    genre = models.ManyToManyField(
+        Genre, help_text="Selecciona un género para este libro")
 
     def __str__(self):
-        """
-        String que representa al objeto Book
-        """
+        """Cadena que representa al objeto Modelo."""
         return self.title
 
-
     def get_absolute_url(self):
-        """
-        Devuelve el URL a una instancia particular de Book
-        """
+        """Devuelve la URL para acceder a un registro de detalle de este libro."""
         return reverse('book-detail', args=[str(self.id)])
 ```
 
-El género es un campo de tipo `ManyToManyField`, de manera tal que un mismo libro podrá abarcar varios géneros y un mismo género podrá abarcar muchos libros. El autor es declarado como `ForeignKey`, de modo que cada libro podrá tener un sólo autor, pero un autor podrá tener muchos libros (en la vida real, un mismo libro puede tener varios autores, pero en nuestra implementación no).
+El género es un `ManyToManyField`, de modo que un libro puede tener varios géneros y un género puede tener muchos libros. El autor se declara como `ForeignKey`, de modo que cada libro solo tendrá un autor, pero un autor puede tener muchos libros (¡en la práctica un libro podría tener varios autores, pero no en esta implementación!)
 
-En la declaración de ambos campos, el modelo relacionado se ingresa como primer parámetro posicional, usando el nombre la clase que lo implementa o, bien, el nombre del modelo como string, si éste no ha sido implementado en el archivo, antes de la declaración del campo. Otros parámetros interesantes que podemos observar, en el campo `author`, son `null=True`, que permite a la base de datos almacenar `null` si el autor no ha sido seleccionado, y `on_delete=models.SET_NULL`, que pondrá en `null` el campo si el registro del autor relacionado es eliminado de la base de datos.
+En ambos tipos de campo, la clase del modelo relacionado se declara como el primer parámetro sin nombre, usando la clase del modelo o una cadena que contiene el nombre del modelo relacionado. ¡Debes usar el nombre del modelo como cadena si la clase asociada aún no se ha definido en este archivo antes de que se haga referencia a ella! Los otros parámetros de interés en el campo `author` son `null=True`, que permite que la base de datos almacene un valor `Null` si no se selecciona ningún autor, y `on_delete=models.RESTRICT`, que evitará que se elimine el autor asociado del libro si algún libro hace referencia a él.
 
-El modelo también define `__str__()`, usando el campo `title` para representar un registro de la clase `Book`. El último método, `get_absoulte_url()` devuelve un URL que puede ser usado para acceder al detalle de un registro particular (para que esto funcione, debemos definir un mapeo de URL que tenga el nombre `book-detail` y una vista y una plantilla asociadas a él)
+> [!WARNING]
+> Por defecto, `on_delete=models.CASCADE`, lo que significa que si se eliminara el autor, ¡este libro también se eliminaría! Aquí usamos `RESTRICT`, pero también podríamos usar `PROTECT` para evitar que se elimine el autor mientras algún libro lo use, o `SET_NULL` para establecer el autor del libro en `Null` si se elimina el registro.
+
+El modelo también define `__str__()`, usando el campo `title` del libro para representar un registro `Book`. El último método, `get_absolute_url()`, devuelve una URL que se puede usar para acceder a un registro de detalle de este modelo (tendremos que definir un mapeo de URL que tenga el nombre `book-detail`, y definir una vista y una plantilla asociadas).
 
 ### Modelo 'BookInstance'
 
-A continuación, copie el model `BookInstance` (mostrado a continuación) debajo de los otros modelos. `BookInstance` representa una copia específica de un libro que alguien pueda pedir prestado, en incluye información sobre si la copia esta disponible o sobre cual es la fecha que se espera sea devuelto, "imprenta" o detalles de versión, y un id único para el libro en la biblioteca.
+A continuación, copia el modelo `BookInstance` (que se muestra abajo) debajo de los otros modelos. `BookInstance` representa una copia específica de un libro que alguien podría pedir prestado, e incluye información sobre si la copia está disponible o en qué fecha se espera que sea devuelta, detalles de "impresión" o versión, y un id único para el libro en la biblioteca.
 
-Algunos de los campos y métodos ahora serán familiares. El modelo usa
+Algunos de los campos y métodos ya te resultarán familiares. El modelo usa:
 
-- `ForeignKey` para identificar el Libro asociado (cada libro puede tener muchas copias, pero una copia solo puede tener un `Book`).
-- `CharField` para representar la imprenta (publicación específica) del libro.
+- `ForeignKey` para identificar el `Book` asociado (cada libro puede tener muchas copias, pero una copia solo puede tener un `Book`). La clave especifica `on_delete=models.RESTRICT` para garantizar que `Book` no se pueda eliminar mientras una `BookInstance` haga referencia a él.
+- `CharField` para representar la impresión (edición específica) del libro.
 
 ```python
-import uuid # Requerida para las instancias de libros únicos
+import uuid # Necesario para las instancias únicas de libro
 
 class BookInstance(models.Model):
-    """
-    Modelo que representa una copia específica de un libro (i.e. que puede ser prestado por la biblioteca).
-    """
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, help_text="ID único para este libro particular en toda la biblioteca")
-    book = models.ForeignKey('Book', on_delete=models.SET_NULL, null=True)
+
+    """Modelo que representa una copia específica de un libro (es decir, que se puede tomar prestada de la biblioteca)."""
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4,
+                          help_text="ID único para este libro en particular en toda la biblioteca")
+    book = models.ForeignKey('Book', on_delete=models.RESTRICT, null=True)
     imprint = models.CharField(max_length=200)
     due_back = models.DateField(null=True, blank=True)
 
     LOAN_STATUS = (
-        ('m', 'Maintenance'),
-        ('o', 'On loan'),
-        ('a', 'Available'),
-        ('r', 'Reserved'),
+        ('m', 'Mantenimiento'),
+        ('o', 'Prestado'),
+        ('a', 'Disponible'),
+        ('r', 'Reservado'),
     )
 
-    status = models.CharField(max_length=1, choices=LOAN_STATUS, blank=True, default='m', help_text='Disponibilidad del libro')
+    status = models.CharField(
+        max_length=1,
+        choices=LOAN_STATUS,
+        blank=True,
+        default='m',
+        help_text='Disponibilidad del libro',
+    )
 
     class Meta:
-        ordering = ["due_back"]
-
+        ordering = ['due_back']
 
     def __str__(self):
-        """
-        String para representar el Objeto del Modelo
-        """
-        return '%s (%s)' % (self.id,self.book.title)
+        """Cadena que representa al objeto Modelo."""
+        return f'{self.id} ({self.book.title})'
 ```
 
-Adicionalmente hemos declarado algunos tipos nuevos de campos:
+Además, declaramos algunos tipos de campo nuevos:
 
-- `UUIDField` es usado para establecer el campo `id` como una `primary_key` para este modelo. Este tipo de campo asigna un único valor global para cada instancia ( uno para cada libro que puedes encontrar en la biblioteca).
-- `DateField` es usado para la fecha `due_back` (en la que se espera que el libro este diponible despues de ser prestado o estar en mantenimiento). Este valor puede ser `blank` o `null` (necesario cuando el libro esta disponible). El patrón metadata (`Class Meta`) usa este campo para ordenar registros cuando se retornan en una consulta.
-- `status` es un `CharField` que define una lista de elección/selección. Como puedes ver, hemos definido una tupla que contiene tuplas de pares clave-valor y los pasamos a los argumentos de choice. El valor en un par clave/valor es un valor desplegable que el usuario puede seleccionar, mientras las claves son valores que en realidad son guardados en la opción seleccionada. Tambien establecemos un valor por defecto de 'm' (maintenance) ya que los libros inicialmente se crearán como no disponibles antes de que esten almacenados en los estantes.
+- `UUIDField` se usa para el campo `id`, para establecerlo como la `primary_key` de este modelo.
+  Este tipo de campo asigna un valor único a nivel global para cada instancia (uno para cada libro que puedas encontrar en la biblioteca).
+- `DateField` se usa para la fecha `due_back` (fecha en la que se espera que el libro vuelva a estar disponible después de haber sido prestado o estar en mantenimiento). Este valor puede ser `blank` o `null` (necesario para cuando el libro está disponible). Los metadatos del modelo (`Class Meta`) usan este campo para ordenar los registros cuando se devuelven en una consulta.
+- `status` es un `CharField` que define una lista de opciones/selección. Como puedes ver, definimos una tupla que contiene tuplas de pares clave-valor y la pasamos al argumento choices. El valor en un par clave/valor es un valor que se muestra y que un usuario puede seleccionar, mientras que las claves son los valores que realmente se guardan si se selecciona la opción. También hemos establecido un valor predeterminado de 'm' (mantenimiento), ya que los libros se crearán inicialmente como no disponibles antes de que se coloquen en los estantes.
 
-El patrón `__str__()` representa el objeto `BookInstance` usando una combinación de su id único y el título del `Book` asociado.
+El método `__str__()` representa el objeto `BookInstance` usando una combinación de su id único y el título del `Book` asociado.
 
 > [!NOTE]
 > Un poco de Python:
 >
-> El valor retornado por `__str__()` es una _cadena formateada_. Dentro de la cadena usamos `%s` para declarar "marcadores de posición". Después de la cadena ponemos `%` y después una tupla que contiene los valores que serán puestos en los marcadores de posición. Si solo tienes un marcador de posición entonces puedes omitir la tupla — e.j. `'Mi valor: %s' % variable.`
->
-> Note que aunque este enfoque es perfectamente válido, sea conciente que ya no es preferido. Desde Python 3 debes usar en su lugar el método **format**, ej. `'{0} ({1})'.format(self.id,self.book.title)`. Puedes leer más sobre esto [aquí](https://www.python.org/dev/peps/pep-3101/). A partir de Python 3.6 también puedes usar la sintaxis de interpolación de cadena, e.j. `f'{self.id} ({self.book.title})'`.
+> - A partir de Python 3.6, puedes usar la sintaxis de interpolación de cadenas (también conocida como f-strings): `f'{self.id} ({self.book.title})'`.
+> - En versiones anteriores de este tutorial usábamos una sintaxis de [cadena formateada](https://peps.python.org/pep-3101/), que también es una forma válida de dar formato a cadenas en Python (por ejemplo, `'{0} ({1})'.format(self.id,self.book.title)`).
 
 ### Modelo 'Author'
 
-Copia el modelo `Author` (mostrado abajo) bajo el código existente en **models.py**.
-
-Todos los campos/métodos ahora deben ser familiares. El modelo define a un autor que tiene un primer nombre, apellido, fecha de nacimiento, y (opcional) fecha de fallecimiento. Especifica que de forma predeterminada el `__str__()` retorna el nombre en el _orden apellido_, _primer nombre_. El método `get_absolute_url()` invierte el mapeo URL `author-detail` para obtener el URL para mostrar un autor individual.
+Copia el modelo `Author` (que se muestra abajo) debajo del código existente en **models.py**.
 
 ```python
 class Author(models.Model):
-    """
-    Modelo que representa un autor
-    """
+    """Modelo que representa un autor."""
     first_name = models.CharField(max_length=100)
     last_name = models.CharField(max_length=100)
     date_of_birth = models.DateField(null=True, blank=True)
-    date_of_death = models.DateField('Died', null=True, blank=True)
+    date_of_death = models.DateField('Fallecimiento', null=True, blank=True)
+
+    class Meta:
+        ordering = ['last_name', 'first_name']
 
     def get_absolute_url(self):
-        """
-        Retorna la url para acceder a una instancia particular de un autor.
-        """
+        """Devuelve la URL para acceder a una instancia particular de un autor."""
         return reverse('author-detail', args=[str(self.id)])
 
-
     def __str__(self):
-        """
-        String para representar el Objeto Modelo
-        """
-        return '%s, %s' % (self.last_name, self.first_name)
+        """Cadena que representa al objeto Modelo."""
+        return f'{self.last_name}, {self.first_name}'
 ```
 
-## Reiniciar las migraciones a la base de datos
+Todos los campos/métodos ya deberían resultarte familiares. El modelo define un autor con nombre, apellido, y fechas de nacimiento y fallecimiento (ambas opcionales). Especifica que, por defecto, `__str__()` devuelve el nombre en el orden _apellido_, _nombre_. El método `get_absolute_url()` invierte el mapeo de URL `author-detail` para obtener la URL que muestra un autor individual.
 
-Todos tus modelos han sido creados. Para añadirlos a tu base de datos, vuelve a ejecutar las migraciones de tu base de datos.
+## Vuelve a ejecutar las migraciones de la base de datos
+
+Ya se han creado todos tus modelos. Ahora vuelve a ejecutar las migraciones de tu base de datos para agregarlos a tu base de datos.
 
 ```bash
 python3 manage.py makemigrations
 python3 manage.py migrate
 ```
 
-## Modelo 'Language' - desafío
+## Modelo 'Language' — desafío
 
-Imagina que un benefactor local dona un número de libros nuevos escritos en otro lenguaje (digamos, Farsi). El desafío es averiguar como estos pueden ser bien representados en tu sitio Web, y luego agregarlos a los modelos.
+Imagina que un benefactor local dona una serie de libros nuevos escritos en otro idioma (digamos, farsi). El desafío es averiguar cómo se representarían mejor estos libros en nuestro sitio web de biblioteca, y luego agregarlos a los modelos.
 
-Algunas cosas a considerar:
+Algunas cosas a tener en cuenta:
 
-- ¿Debe asociarse un "lenguaje" a un `Book`, `BookInstance`, o algún otro objeto?
-- ¿Deberian representarse los diferentes idiomas usando un modelo, un campo de texto libre o una lista de seleccion codificada?
+- ¿Debería asociarse "language" (idioma) a un `Book`, a un `BookInstance`, o a algún otro objeto?
+- ¿Deberían representarse los distintos idiomas mediante un modelo, un campo de texto libre o una lista de selección codificada directamente?
 
-Después que hayas decidido, agrega el campo. Puedes ver que decidimos nostros en Github [aquí](https://github.com/mdn/django-locallibrary-tutorial/blob/master/catalog/models.py).
+Después de decidirte, agrega el campo. Puedes ver qué decidimos [para nuestro proyecto en GitHub](https://github.com/mdn/django-locallibrary-tutorial/blob/main/catalog/models.py).
 
-No olvides que después de un cambio en tu modelo, debes volver a hacer las migraciones para que se apliquen los cambios en tu base de datos.
+No olvides que, después de un cambio en tu modelo, debes volver a ejecutar las migraciones de tu base de datos para agregar los cambios.
 
 ```bash
 python3 manage.py makemigrations
@@ -461,14 +501,14 @@ python3 manage.py migrate
 
 ## Resumen
 
-En este artículo hemos aprendido como son definidos los modelos, y luego usar esta información para diseñar e implementar modelos apropiados para el sitio Web _LocalLibrary_.
+En este artículo hemos aprendido cómo se definen los modelos, y luego hemos usado esta información para diseñar e implementar los modelos adecuados para el sitio web _LocalLibrary_.
 
-En este punto nos desviaremos brevemente de la creación del sitio, y miraremos el _sitio de Administración de_ _Django_. Este sitio nos permitirá añadir algunos datos a la biblioteca, los cuales podemos mostrar usando nuestras (aún por crear) vistas y plantillas.
+En este punto, nos desviaremos brevemente de la creación del sitio y echaremos un vistazo al _sitio de Administración de Django_. Este sitio nos permitirá agregar algunos datos a la biblioteca, que luego podremos mostrar usando nuestras vistas y plantillas (aún por crear).
 
-## Vea también
+## Véase también
 
-- [Escribiendo tu primera aplicación Django, parte 2](https://docs.djangoproject.com/en/1.10/intro/tutorial02/) (Django docs)
-- [Realizando consultas](https://docs.djangoproject.com/en/1.10/topics/db/queries/) (Django Docs)
-- [Referencia del API QuerySet](https://docs.djangoproject.com/en/1.10/ref/models/querysets/) (Django Docs)
+- [Escribiendo tu primera aplicación Django, parte 2](https://docs.djangoproject.com/en/5.0/intro/tutorial02/) (documentación de Django)
+- [Realizar consultas](https://docs.djangoproject.com/en/5.0/topics/db/queries/) (documentación de Django)
+- [Referencia de la API de QuerySet](https://docs.djangoproject.com/en/5.0/ref/models/querysets/) (documentación de Django)
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Django/skeleton_website", "Learn_web_development/Extensions/Server-side/Django/Admin_site", "Learn_web_development/Extensions/Server-side/Django")}}


### PR DESCRIPTION
### Description
Sincroniza la traducción al español de "Tutorial Django Parte 3: Uso de modelos" con la última versión en inglés, que había avanzado significativamente (Django 1.10 a 5.0) sin que la página en español se hubiera actualizado nunca.

### Motivation
La página nunca se había registrado para sincronización (`l10n.sourceCommit` ausente) y llevaba años desactualizada respecto al inglés, según lo detallado en el issue.

### Additional details
- Front-matter reducido a `title`, `short-title`, `slug` y `l10n.sourceCommit` (se quitó `original_slug`).
- Se agregó `l10n.sourceCommit: cb25e0acbd9f0af27c4a99965cb962230d49a35d`.
- Se tradujo/reescribió el artículo completo siguiendo la estructura y el orden de encabezados de la fuente en inglés (nuevos campos `unique`, `UniqueConstraint`/`Lower`, cambios de `SET_NULL` a `RESTRICT`, `BigAutoField`, etc.).
- Se removió la macro `{{LearnSidebar}}` del cuerpo (ya no se usa en el resto de la serie sincronizada; el sidebar no va en el front-matter en español por convención del equipo).
- Enlaces internos actualizados a `/es/` y texto alt de la imagen traducido.
- Validaciones ejecutadas sobre el archivo: Prettier, markdownlint-cli2 y `check-url-locale.js` (todas correctas).

### Related issues and pull requests
Fixes #37267