### PR TITLE
chore(es): sync of `Learn_web_development/Extensions/Server-side/Express_Nodejs/Skeleton_website`

### DIFF
--- a/files/es/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
+++ b/files/es/learn_web_development/extensions/server-side/express_nodejs/skeleton_website/index.md
@@ -1,276 +1,318 @@
 ---
-title: "Express Tutorial Part 2: Creating a skeleton website"
+title: "Tutorial de Express parte 2: Crear un sitio web esqueleto"
+short-title: "2: Sitio web esqueleto"
 slug: Learn_web_development/Extensions/Server-side/Express_Nodejs/skeleton_website
-original_slug: Learn/Server-side/Express_Nodejs/skeleton_website
+l10n:
+  sourceCommit: afcdfa050626bb7eb05ee693df8997020db9ff2e
 ---
 
-{{LearnSidebar}}
+{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website", "Learn_web_development/Extensions/Server-side/Express_Nodejs/mongoose", "Learn_web_development/Extensions/Server-side/Express_Nodejs")}}
 
-{{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website", "Learn_web_development/Extensions/Server-side/Express_Nodejs/mongoose", "Learn_web_development/Extensions/Server-side/Express_Nodejs")}}
-
-Este segundo artículo de nuestro [Tutorial Express](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website) muestra cómo puede crear un "esqueleto" para un proyecto de sitio web que luego puede completar con rutas, plantillas/vistas, y llamadas a base de datos especifícas del sitio.
+Este segundo artículo de nuestro [Tutorial de Express](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website) muestra cómo crear un sitio web "esqueleto" que luego podrás completar con rutas, plantillas/vistas y llamadas a base de datos específicas del sitio.
 
 <table>
   <tbody>
     <tr>
-      <th scope="row">Prerequisitos:</th>
+      <th scope="row">Prerrequisitos:</th>
       <td>
-        <a
-          href="/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment"
-          >Configurar un entorno de desarrollo de Node</a
-        >. Revise el Tutorial Express.
+        <a href="/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment">Configura un entorno de desarrollo de Node</a>.
+          Repasa el Tutorial de Express.
       </td>
     </tr>
     <tr>
       <th scope="row">Objetivo:</th>
       <td>
-        Poder empezar sus nuevos proyectos web usando el
-        <em>Generador de Aplicaciones Express</em>.
+        Poder iniciar tus propios proyectos de sitios web nuevos usando el <em>Generador de aplicaciones de Express</em>.
       </td>
     </tr>
   </tbody>
 </table>
 
-## Visión General
+## Visión general
 
-Este artículo muestra cómo puede crear un sitio web "esqueleto" usando la herramienta [Generador de Aplicaciones Express](https://expressjs.com/en/starter/generator.html), que luego puede completar con rutas, vistas/plantillas, y llamadas a base de datos especifícas del sitio. En este caso usaremos la herramienta para crear el framework para nuestro [website Local Library](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website), al que luego agregaremos todo el código que el sitio necesite. El proceso es extremadamente simple, requiriendo sólo que se invoque el generador en la línea de comandos con un nombre para el nuevo proyecto, opcionalmente especificando también el motor de plantillas y el generador de CSS a utilizar.
+Este artículo muestra cómo crear un sitio web "esqueleto" usando la herramienta [Generador de aplicaciones de Express](https://expressjs.com/en/starter/generator.html), que luego puedes completar con rutas, vistas/plantillas y llamadas a base de datos específicas del sitio. En este caso, usaremos la herramienta para crear el framework de nuestro [sitio web Local Library](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website), al que más adelante le añadiremos todo el código restante que el sitio necesite. El proceso es extremadamente simple: solo requiere que invoques al generador en la línea de comandos con un nombre para el nuevo proyecto, especificando opcionalmente también el motor de plantillas del sitio y el generador de CSS.
 
-Las siguientes secciones muestran como puede llamar al generador de aplicaciones, y proporcionan una pequeña explicación sobre las diferentes opciones para vistas y CSS. También explicaremos como está estructurado el esqueleto del sitio web. Al final, mostraremos como puede ejecutar el sitio web para verificar que funciona.
+Las siguientes secciones te muestran cómo invocar el generador de aplicaciones y ofrecen una breve explicación sobre las distintas opciones de vistas y CSS. También explicaremos cómo está estructurado el sitio web esqueleto. Al final, mostraremos cómo puedes ejecutar el sitio web para comprobar que funciona.
 
 > [!NOTE]
-> El _Generador de Aplicaciones Express_ no es el único generador para aplicaciones Express, y el proyecto generado no es la única forma viable para estructurar sus archivos y directorios. El sitio generado, sin embargo, tiene una estructura modular que es fácil de extender y comprender. Para informacion sobre una _mínima_ aplicación Express, vea el [Ejemplo Hello world](https://expressjs.com/en/starter/hello-world.html) (Express docs).
+>
+> - El _Generador de aplicaciones de Express_ no es el único generador para aplicaciones Express, y el proyecto generado no es la única forma viable de estructurar tus archivos y directorios. Sin embargo, el sitio generado tiene una estructura modular fácil de extender y comprender. Para más información sobre una aplicación Express _mínima_, consulta el [ejemplo Hello world](https://expressjs.com/en/starter/hello-world.html) (documentación de Express).
+> - El _Generador de aplicaciones de Express_ declara la mayoría de las variables usando `var`.
+>   En este tutorial hemos cambiado la mayoría a [`const`](/es/docs/Web/JavaScript/Reference/Statements/const) (y algunas a [`let`](/es/docs/Web/JavaScript/Reference/Statements/let)), porque queremos mostrar las prácticas modernas de JavaScript.
+> - Este tutorial usa la versión de _Express_ y de las demás dependencias definidas en el archivo **package.json** creado por el _Generador de aplicaciones de Express_.
+>   Estas no son (necesariamente) las últimas versiones, y deberías actualizarlas al desplegar una aplicación real en producción.
 
 ## Usando el generador de aplicaciones
 
-Ya debe haber instalado el generador como parte de [Configurar un entorno de desarrollo de Node](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment). Como un rápido recordatorio, la herramienta generador se instala para todos los sitios usando el manejador de paquetes NPM, como se muestra:
+Ya deberías tener instalado el generador como parte de la [configuración de un entorno de desarrollo de Node](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/development_environment). Como recordatorio rápido, el paquete generador se instala a nivel de todo el sistema usando el gestor de paquetes npm, tal y como se muestra:
 
 ```bash
 npm install express-generator -g
 ```
 
-El generador tiene un número de opciones, las cuales puede observar en la línea de comandos usando el comando `--help` (o bien `-h`):
+El generador tiene varias opciones, que puedes ver en la línea de comandos usando el comando `--help` (o `-h`):
 
 ```bash
 > express --help
 
-  Usage: express [options] [dir]
+    Usage: express [options] [dir]
 
   Options:
 
-    -h, --help           output usage information
         --version        output the version number
     -e, --ejs            add ejs engine support
         --pug            add pug engine support
         --hbs            add handlebars engine support
     -H, --hogan          add hogan.js engine support
-    -v, --view <engine>  add view <engine> support (ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
-    -c, --css <engine>   add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain css)
+    -v, --view <engine>  add view <engine> support (dust|ejs|hbs|hjs|jade|pug|twig|vash) (defaults to jade)
+        --no-view        use static html instead of view engine
+    -c, --css <engine>   add stylesheet <engine> support (less|stylus|compass|sass) (defaults to plain CSS)
         --git            add .gitignore
     -f, --force          force on non-empty directory
+    -h, --help           output usage information
 ```
 
-Simplemente puede especificar `express` para crear un proyecto dentro del directorio actual usando el motor de plantillas _Jade_ y CSS plano (si especifica un nombre de directorio entonces el proyecto será creado en un subdirectorio con ese nombre).
+Puedes especificar `express` para crear un proyecto dentro del directorio _actual_ usando el motor de vistas _Jade_ y CSS plano (si especificas un nombre de directorio, el proyecto se creará en una subcarpeta con ese nombre).
 
 ```bash
 express
 ```
 
-También puede seleccionar el motor de plantillas para las vistas usando `--view` y/o un motor generador de CSS usando `--css`.
+También puedes elegir un motor de vistas (plantillas) usando `--view` y/o un motor de generación de CSS usando `--css`.
 
 > [!NOTE]
-> Las otras opciones para elegir motores de plantillas (e.g. `--hogan`, `--ejs`, `--hbs` etc.) están descontinuadas. Use `--view` (o bien `-v`)!
+> Las demás opciones para elegir motores de plantillas (por ejemplo, `--hogan`, `--ejs`, `--hbs`, etc.) están obsoletas. Usa `--view` (o `-v`).
 
-### ¿Cuál motor de vistas debo usar?
+### ¿Qué motor de vistas debería usar?
 
-El _Generador de Aplicaciones Express_ le permite configurar un número de populares motores de plantillas, incluyendo [EJS](https://www.npmjs.com/package/ejs), [Hbs](http://github.com/donpark/hbs), [Pug](https://pugjs.org/api/getting-started.html) (Jade), [Twig](https://www.npmjs.com/package/twig), y [Vash](https://www.npmjs.com/package/vash), aunque si no se especifica una opcion de vista, selecciona Jade por defecto. Express puede soportar un gran número de motores de plantillas [aquí una lista](https://github.com/expressjs/express/wiki#template-engines).
-
-> [!NOTE]
-> Si quiere usar un motor de plantillas que no es soportado por el generador entonces vea el artículo [Usando motores de plantillas con Express](https://expressjs.com/en/guide/using-template-engines.html) (Express docs) y la documentación de su motor de plantillas.
-
-Generalmente hablando debe seleccionar un motor de plantillas que le brinde toda la funcionalidad que necesite y le permita ser productivo rápidamente — o en otras palabras, en la misma forma en que selecciona cualquier otro componente. Alguna de las cosas a considerar cuando se comparan motores de plantillas:
-
-- Tiempo de productividad — Si su equipo ya tiene experiencia con un lenguaje de plantillas entonces es probable que sean más productivos usando ese lenguaje. Si no, debería considerar la curva de aprendizaje relativa del motor de plantillas candidato.
-- Popularidad y actividad — Revise la popularidad del motor y si tiene una comunidad activa. Es importante obtener soporte para el motor cuando tenga problemas durante la vida útil del sitio web.
-- Estilo — Algunos motores de plantillas usan marcas específicas para indicar inserción de contenido dentro del HTML "ordinario", mientras que otros construyen el HTML usando una sintaxis diferente (por ejemplo, usando indentación (sangría) y nombres de bloque).
-- Tiempo Renderizado/desempeño.
-- Características — debe considerar si los motores que elija poseen las siguientes características disponibles:
-  - Herencia del diseño: Le permite definir una plantilla base y luego "heredar" sólo las partes que desea que sean diferentes para una página particular. Típicamente esto es un mejor enfoque que construir plantillas incluyendo un número de componentes requeridos, contruyéndolas desde cero cada vez.
-  - Soporte para incluir: Le permite construir plantillas incluyendo otras plantillas.
-  - Control consiso de la sintanxis de variables y ciclos.
-  - Habilidad para filtrar valores de variables a nivel de las plantillas (e.g. convertir variables en mayúsculas, o darle formato a una fecha).
-  - Habilidad para generar formatos de salida distintos al HTML (e.g. JSON o XML).
-  - Soporte para operaciones asincrónas y de transmisión.
-  - Pueden ser usadas tanto en el cliente como en el servidor. Si un motor de plantillas puede ser usado del lado del cliente esto da la posibilidad de servir datos y tener todo o la mayoría del renderizado del lado del cliente.
+El _Generador de aplicaciones de Express_ te permite configurar varios motores de vistas/plantillas populares, entre ellos [EJS](https://www.npmjs.com/package/ejs), [Hbs](https://github.com/pillarjs/hbs), [Pug](https://pugjs.org/api/getting-started.html) (Jade), [Twig](https://www.npmjs.com/package/twig) y [Vash](https://www.npmjs.com/package/vash), aunque elige Jade por defecto si no especificas una opción de vista. El propio Express también admite de forma nativa un gran número de otros lenguajes de plantillas ([aquí tienes la lista](https://github.com/expressjs/express/wiki#template-engines)).
 
 > [!NOTE]
-> En Internet hay muchos recursos que le ayudarán a comparar diferentes opciones.
+> Si quieres usar un motor de plantillas que no sea compatible con el generador, consulta [Uso de motores de plantillas con Express](https://expressjs.com/en/guide/using-template-engines.html) (documentación de Express) y la documentación de tu motor de vistas de destino.
 
-Para este proyecto usaremos el motor de plantillas [Pug](https://pugjs.org/api/getting-started.html) (este es el recientemente renombrado motor Jade), ya que es de los más populares lenguajes de plantillas Express/JavaScript y es soportado por el generador por defecto.
+En términos generales, deberías elegir un motor de plantillas que ofrezca toda la funcionalidad que necesitas y que te permita ser productivo cuanto antes — o dicho de otro modo, de la misma forma en que eliges cualquier otro componente. Algunas cosas a tener en cuenta al comparar motores de plantillas:
 
-### ¿Cuál motor de hojas de estilo CSS debería usar?
-
-El _Generador de Aplicaciones Express_ le permite crear un proyecto que puede usar los más comunes motores de hojas de estilos CSS: [LESS](https://lesscss.org/), [SASS](https://sass-lang.com/), [Compass](http://compass-style.org/), [Stylus](http://stylus-lang.com/).
+- Tiempo hasta ser productivo: si tu equipo ya tiene experiencia con un lenguaje de plantillas, es probable que sea más productivo usando ese lenguaje. Si no, deberías considerar la curva de aprendizaje relativa de los motores de plantillas candidatos.
+- Popularidad y actividad: revisa la popularidad del motor y si cuenta con una comunidad activa. Es importante poder obtener soporte cuando surjan problemas a lo largo de la vida del sitio web.
+- Estilo: algunos motores de plantillas usan marcado específico para indicar el contenido insertado dentro del HTML "normal", mientras que otros construyen el HTML con una sintaxis distinta (por ejemplo, usando sangría y nombres de bloque).
+- Rendimiento/tiempo de renderizado.
+- Características: deberías considerar si los motores que evalúas ofrecen las siguientes características:
+  - Herencia de diseño: te permite definir una plantilla base y luego "heredar" solo las partes que quieras que sean diferentes para una página en particular. Este enfoque suele ser mejor que construir plantillas incluyendo varios componentes obligatorios o partiendo de cero cada vez.
+  - Soporte de "include": te permite construir plantillas incluyendo otras plantillas.
+  - Sintaxis concisa para el control de variables y bucles.
+  - Capacidad de filtrar valores de variables a nivel de plantilla, como convertir variables a mayúsculas o dar formato a un valor de fecha.
+  - Capacidad de generar formatos de salida distintos a HTML, como JSON o XML.
+  - Soporte para operaciones asíncronas y streaming.
+  - Funciones del lado del cliente: si un motor de plantillas se puede usar en el cliente, esto permite la posibilidad de hacer todo o la mayor parte del renderizado del lado del cliente.
 
 > [!NOTE]
-> CSS tiene algunas limitaciones que dificultan ciertas tareas. Los motores de hojas de estilos CSS le permiten usar una sintaxis más poderosa para definir su CSS, y luego compilar la definición en texto plano para su uso en los navegadores .
+> Hay muchos recursos en internet que te ayudarán a comparar las distintas opciones.
 
-Como los motores de plantillas, debería usar el motor CSS que le permita a su equipo ser más productivo. Para este proyecto usaremos CSS ordinario (opción por defecto) ya que nuestros requerimientos no son lo suficientemente complicados para justificar el uso de un motor CSS.
+Para este proyecto, usaremos el motor de plantillas [Pug](https://pugjs.org/api/getting-started.html) (anteriormente llamado "Jade"), ya que es uno de los lenguajes de plantillas más populares para Express/JavaScript y el generador lo admite de forma nativa.
 
-### ¿Cuál base de datos debería usar?
+### ¿Qué motor de hojas de estilo CSS debería usar?
 
-El código generado no usa o incluye ninguna base de datos. Las aplicaciones _Express_ pueden usar cualquier [mecanismo de bases de datos](https://expressjs.com/en/guide/database-integration.html) soportado por _Node_ (_Express_ por si mismo no define ningún comportamiento o requerimiento para el manejo de bases de datos).
+El _Generador de aplicaciones de Express_ te permite crear un proyecto configurado para usar los motores de hojas de estilo CSS más comunes: [LESS](https://lesscss.org/), [SASS](https://sass-lang.com/) y [Stylus](https://stylus-lang.com/).
 
-Discutiremos la integración con una base de datos en un posterior artículo.
+> [!NOTE]
+> CSS tiene algunas limitaciones que dificultan ciertas tareas. Los motores de hojas de estilo CSS te permiten usar una sintaxis más potente para definir tu CSS, que luego se compila en CSS normal para que lo usen los navegadores.
 
-## Creando el proyecto
+Al igual que con los motores de plantillas, deberías usar el motor de hojas de estilo que permita a tu equipo ser más productivo. Para este proyecto usaremos CSS puro (la opción por defecto), ya que nuestros requisitos de CSS no son lo bastante complejos como para justificar el uso de otra cosa.
 
-Para el ejemplo que vamos a crear la app _Local Library_, crearemos un proyecto llamado _express-locallibrary-tutorial usando la librería de plantillas_ _Pug_ y ningún motor CSS.
+### ¿Qué base de datos debería usar?
 
-Primero navegue a donde quiera crear el proyecto y luego ejecute el _Generador de Aplicaciones Express en la línea de comandos como se muestra_:
+El código generado no usa ni incluye ninguna base de datos. Las aplicaciones _Express_ pueden usar cualquier [mecanismo de base de datos](https://expressjs.com/en/guide/database-integration.html) admitido por _Node_ (_Express_ en sí no define ningún comportamiento ni requisito adicional específico para la gestión de bases de datos).
+
+Hablaremos de cómo integrar una base de datos en un artículo posterior.
+
+## Creación del proyecto
+
+Para la aplicación de ejemplo _Local Library_ que vamos a construir, crearemos un proyecto llamado _express-locallibrary-tutorial_ usando la biblioteca de plantillas _Pug_ y ningún motor de CSS.
+
+Primero, navega hasta donde quieras crear el proyecto y luego ejecuta el _Generador de aplicaciones de Express_ en la línea de comandos como se muestra:
 
 ```bash
 express express-locallibrary-tutorial --view=pug
 ```
 
-El generador creará (y listará) los archivos del proyecto.
+El generador creará (y mostrará) los archivos del proyecto.
 
-```bash
-   create : express-locallibrary-tutorial
-   create : express-locallibrary-tutorial/package.json
-   create : express-locallibrary-tutorial/app.js
-   create : express-locallibrary-tutorial/public/images
-   create : express-locallibrary-tutorial/public
-   create : express-locallibrary-tutorial/public/stylesheets
-   create : express-locallibrary-tutorial/public/stylesheets/style.css
-   create : express-locallibrary-tutorial/public/javascripts
-   create : express-locallibrary-tutorial/routes
-   create : express-locallibrary-tutorial/routes/index.js
-   create : express-locallibrary-tutorial/routes/users.js
-   create : express-locallibrary-tutorial/views
-   create : express-locallibrary-tutorial/views/index.pug
-   create : express-locallibrary-tutorial/views/layout.pug
-   create : express-locallibrary-tutorial/views/error.pug
-   create : express-locallibrary-tutorial/bin
-   create : express-locallibrary-tutorial/bin/www
+```plain
+   create : express-locallibrary-tutorial\
+   create : express-locallibrary-tutorial\public\
+   create : express-locallibrary-tutorial\public\javascripts\
+   create : express-locallibrary-tutorial\public\images\
+   create : express-locallibrary-tutorial\public\stylesheets\
+   create : express-locallibrary-tutorial\public\stylesheets\style.css
+   create : express-locallibrary-tutorial\routes\
+   create : express-locallibrary-tutorial\routes\index.js
+   create : express-locallibrary-tutorial\routes\users.js
+   create : express-locallibrary-tutorial\views\
+   create : express-locallibrary-tutorial\views\error.pug
+   create : express-locallibrary-tutorial\views\index.pug
+   create : express-locallibrary-tutorial\views\layout.pug
+   create : express-locallibrary-tutorial\app.js
+   create : express-locallibrary-tutorial\package.json
+   create : express-locallibrary-tutorial\bin\
+   create : express-locallibrary-tutorial\bin\www
+
+   change directory:
+     > cd express-locallibrary-tutorial
 
    install dependencies:
-     > cd express-locallibrary-tutorial && npm install
+     > npm install
 
-   run the app:
+   run the app (Bash (Linux or macOS))
+     > DEBUG=express-locallibrary-tutorial:* npm start
+
+   run the app (PowerShell (Windows))
+     > $env:DEBUG = "express-locallibrary-tutorial:*"; npm start
+
+   run the app (Command Prompt (Windows)):
      > SET DEBUG=express-locallibrary-tutorial:* & npm start
 ```
 
-Al final de la lista el generador mostrará instrucciones sobre como instalar las dependencias necesarias (mostradas en el archivo **package.json**) y luego como ejecutar la aplicación (las instrucciones anteriores son para windows; en Linux/macOS serán ligeramente diferentes).
+Al final de la salida, el generador ofrece instrucciones sobre cómo instalar las dependencias (tal como se indica en el archivo **package.json**) y cómo ejecutar la aplicación en distintos sistemas operativos.
 
-## Ejecutando el esqueleto del sitio web
+> [!NOTE]
+> Los archivos creados por el generador definen todas las variables como `var`.
+> Abre todos los archivos generados y cambia las declaraciones `var` por `const` antes de continuar (el resto del tutorial asume que ya lo has hecho).
 
-En este punto tenemos un esqueleto completo de nuestro proyecto. El sitio web no hace mucho actualmente, pero es bueno ejecutarlo para ver como funciona.
+## Ejecución del sitio web esqueleto
 
-1. Primero instale las dependencias (el comando `install` recuperará todas las dependencias listadas e el archivo **package.json** del proyecto).
+Llegados a este punto, tenemos un proyecto esqueleto completo. El sitio web todavía no _hace_ gran cosa, pero merece la pena ejecutarlo para comprobar que funciona.
+
+1. Primero, instala las dependencias (el comando `install` obtendrá todos los paquetes de dependencias listados en el archivo **package.json** del proyecto).
 
    ```bash
    cd express-locallibrary-tutorial
    npm install
    ```
 
-2. Luego ejecute la aplicación.
-   - En Windows, use este comando:
+2. Luego ejecuta la aplicación.
+   - En el símbolo del sistema (CMD) de Windows, usa este comando:
 
-     ```bash
+     ```batch
      SET DEBUG=express-locallibrary-tutorial:* & npm start
      ```
 
-   - En macOS o Linux, use este comando:
+   - En Windows PowerShell, usa este comando:
+
+     ```powershell
+     $env:DEBUG = "express-locallibrary-tutorial:*"; npm start
+     ```
+
+     > [!NOTE]
+     > Este tutorial no cubre los comandos de PowerShell (los comandos "Windows" indicados asumen que usas el símbolo del sistema de Windows).
+
+   - En macOS o Linux, usa este comando:
 
      ```bash
      DEBUG=express-locallibrary-tutorial:* npm start
      ```
 
-3. Luego carge en su navegador `http://localhost:3000/` para acceder a la aplicación.
+3. Luego carga `http://localhost:3000/` en tu navegador para acceder a la aplicación.
 
-Debería ver una página parecida a esta:
+Deberías ver una página en el navegador parecida a esta:
 
-![Browser for default Express app generator website](expressgeneratorskeletonwebsite.png)
+![Navegador mostrando el sitio web predeterminado del generador de aplicaciones Express](expressgeneratorskeletonwebsite.png)
 
-Tiene una aplicación Express funcional, ejecutandose en _localhost:3000_.
+¡Felicidades! Ahora tienes una aplicación Express funcionando, a la que puedes acceder a través del puerto 3000.
 
 > [!NOTE]
-> También podría ejecutar la app usando el comando `npm start`. Especificado la variable DEBUG como se muestra habilita el logging/debugging por consola. Por ejemplo, cuando visite la página mostrada arriba verá la información de depuración como esta:
+> También podrías iniciar la aplicación simplemente con el comando `npm start`. Especificar la variable DEBUG como se muestra habilita el registro/depuración por consola. Por ejemplo, al visitar la página anterior verás una salida de depuración como esta:
 >
 > ```bash
-> $ SET DEBUG=express-locallibrary-tutorial:* &#x26; npm start
+> SET DEBUG=express-locallibrary-tutorial:* & npm start
+> ```
 >
-> $ express-locallibrary-tutorial@0.0.0 start D:\express-locallibrary-tutorial
-> $ node ./bin/www
+> ```plain
+> > express-locallibrary-tutorial@0.0.0 start D:\github\mdn\test\exprgen\express-locallibrary-tutorial
+> > node ./bin/www
 >
-> express-locallibrary-tutorial:server Listening on port 3000 +0ms
-> GET / 200 288.474 ms - 170
-> GET /stylesheets/style.css 200 5.799 ms - 111
-> GET /favicon.ico 404 34.134 ms - 1335
+>   express-locallibrary-tutorial:server Listening on port 3000 +0ms
+> GET / 304 490.296 ms - -
+> GET /stylesheets/style.css 200 4.886 ms - 111
 > ```
 
-## Habilite el reinicio del servidor cuando los archivos sean modificados
+## Habilitar el reinicio del servidor al modificar archivos
 
-Cualquier cambio que le haga a su sitio web Express no será visible hasta que reinicie el servidor. Rapidamente, tener que detener y reiniciar el servidor cada vez que hacemos un cambio, se vuelve irritante, así que es beneficioso tomarse un tiempo y automátizar el reinicio del servidor cuando sea necesario.
+Actualmente, cualquier cambio que hagas en tu sitio web Express no se verá reflejado hasta que reinicies el servidor. Detener y reiniciar el servidor cada vez que haces un cambio se vuelve rápidamente irritante, así que merece la pena dedicar tiempo a automatizar el reinicio del servidor cuando sea necesario.
 
-Una de las herramientas más sencillas para este propósito es [nodemon](https://github.com/remy/nodemon). Éste usualmente se instala globalmente (ya que es una "herramienta"), pero aquí lo instalaremos y usaremos localmente como una dependencia de desarrollo, así cualquier desarrollador que esté trabajando con el proyecto lo obtendrá automáticamente cuando instale la aplicación. Use el siguiente comando en el directorio raíz del esqueleto del proyecto:
+Una herramienta útil para este propósito es [nodemon](https://github.com/remy/nodemon). Normalmente se instala de forma global (ya que es una "herramienta"), pero aquí la instalaremos y usaremos localmente como _dependencia de desarrollo_, de modo que cualquier desarrollador que trabaje con el proyecto la obtenga automáticamente al instalar la aplicación. Usa el siguiente comando en el directorio raíz del proyecto esqueleto:
 
 ```bash
 npm install --save-dev nodemon
 ```
 
-Si abre el archivo **package.json** de su proyecto verá una nueva sección con esta dependencia:
+Si aun así prefieres instalar [nodemon](https://github.com/remy/nodemon) de forma global en tu máquina, y no solo en el archivo **package.json** de tu proyecto:
+
+```bash
+npm install -g nodemon
+```
+
+Si abres el archivo **package.json** de tu proyecto, ahora verás una nueva sección con esta dependencia:
 
 ```json
+{
   "devDependencies": {
-    "nodemon": "^1.14.11"
+    "nodemon": "^3.1.10"
   }
+}
 ```
 
-Debido a que la herramienta no fue instalada globalmente no podemos ejecutarla desde la línea de comandos (a menos que la agreguemos a la ruta) pero podemos llamarla desde un script NPM porque NPM sabe todo sobre los paquetes instalados. Busque la sección `scripts` de su package.json. Inicialmente contendrá una línea, la cual comienza con `"start"`. Actualicela colocando una coma al final de la línea, y agregue la línea `"devstart"` mostrada abajo:
+Como la herramienta no está instalada de forma global, no podemos ejecutarla desde la línea de comandos (a menos que la agreguemos al PATH). Sin embargo, podemos invocarla desde un script de npm, porque npm sabe qué paquetes están instalados. Busca la sección `scripts` de tu **package.json**. Al principio contendrá una sola línea, que comienza con `"start"`. Actualízala añadiendo una coma al final de esa línea, e incorpora las líneas `"devstart"` y `"serverstart"`:
 
-```json
-  "scripts": {
-    "start": "node ./bin/www",
-    "devstart": "nodemon ./bin/www"
-  },
-```
+- En Linux y macOS, la sección `scripts` quedará así:
 
-Ahora podemos iniciar el servidor casi exactamente como antes, pero especificando el comando devstart:
-
-- En Windows, use este comando:
-
-  ```bash
-  SET DEBUG=express-locallibrary-tutorial:* & npm run devstart
+  ```json
+  {
+    "scripts": {
+      "start": "node ./bin/www",
+      "devstart": "nodemon ./bin/www",
+      "serverstart": "DEBUG=express-locallibrary-tutorial:* npm run devstart"
+    }
+  }
   ```
 
-- En macOS or Linux, use este comando:
+- En Windows, el valor de `"serverstart"` quedaría así en su lugar (si usas el símbolo del sistema):
 
   ```bash
-  DEBUG=express-locallibrary-tutorial:* npm run devstart
+  "serverstart": "SET DEBUG=express-locallibrary-tutorial:* & npm run devstart"
   ```
+
+Ahora podemos iniciar el servidor casi exactamente igual que antes, pero usando el comando `devstart`.
 
 > [!NOTE]
-> Ahora si modifica cualquier archivo del proyecto el servidor se reiniciará (o lo puede reiniciar `rs` en la consola de comandos en cualquier momento). Aún necesitará recargar el navegador para refrescar la página.
+> Ahora, si editas cualquier archivo del proyecto, el servidor se reiniciará (o puedes reiniciarlo escribiendo `rs` en la línea de comandos en cualquier momento). Aun así, tendrás que recargar el navegador para refrescar la página.
 >
-> Ahora tendremos que llamar "`npm run <nombre del script>`" en vez de `npm start`, porque "start" es actualmente un comando NPM que es mapeado al nombre del script. Podríamos haber reemplazado el comando en el script _start_ pero sólo queremos usar _nodemon_ durante el desarrollo, así que tiene sentido crear un nuevo script para este comando.
+> Ahora tenemos que usar `npm run <nombre-del-script>` en lugar de simplemente `npm start`, porque "start" es en realidad un comando de npm que está asignado a ese script. Podríamos haber reemplazado el comando en el script _start_, pero solo queremos usar _nodemon_ durante el desarrollo, así que tiene sentido crear un nuevo comando de script.
+>
+> El comando `serverstart` añadido a los scripts del **package.json** anterior es un buen ejemplo de esto. Con este enfoque, ya no tienes que escribir un comando largo para iniciar el servidor. Ten en cuenta que el comando concreto añadido al script solo funciona en macOS o Linux.
 
 ## El proyecto generado
 
-Observemos el proyecto que hemos creado.
+Ahora vamos a echar un vistazo al proyecto que acabamos de crear.
+Iremos haciendo algunas pequeñas modificaciones a medida que avancemos.
 
-### Estructura del directorio
+### Estructura de directorios
 
-El proyecto generado, ahora que ha instalado las dependencias, tiene la siguiente estructura de archivos (los archivos son los elementos que **no** están precedidos con "/"). El archivo **package.json** define las dependencias de la aplicación y otra información. También define un script de inicio que es el punto de entrada de la aplicación, el archivo JavaScript **/bin/www**. Éste establece algunos de los manejadores de error de la aplicación y luego carga el archivo **app.js** para que haga el resto del trabajo. Las rutas se almacenan en módulos separados en el directorio **/routes**. las plantillas se almacenan en el directorio /**views**.
+Ahora que has instalado las dependencias, el proyecto generado tiene la siguiente estructura de archivos (los archivos son los elementos **sin** el prefijo "/").
+El archivo **package.json** define las dependencias de la aplicación y otra información.
+También define un script de inicio que invoca al punto de entrada de la aplicación, el archivo JavaScript **/bin/www**.
+Este configura parte del manejo de errores de la aplicación y luego carga **app.js** para hacer el resto del trabajo.
+Las rutas de la aplicación se guardan en módulos independientes dentro del directorio **routes/**.
+Las plantillas se guardan en el directorio /**views**.
 
-```
-/express-locallibrary-tutorial
+```plain
+express-locallibrary-tutorial
     app.js
     /bin
         www
     package.json
+    package-lock.json
     /node_modules
-        [about 4,500 subdirectories and files]
+        [unas 6700 subcarpetas y archivos]
     /public
         /images
         /javascripts
@@ -285,7 +327,7 @@ El proyecto generado, ahora que ha instalado las dependencias, tiene la siguient
         layout.pug
 ```
 
-Las siguientes secciones describen los archivos con más detalle.
+Las siguientes secciones describen los archivos con un poco más de detalle.
 
 ### package.json
 
@@ -297,191 +339,237 @@ El archivo **package.json** define las dependencias de la aplicación y otra inf
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www",
-    "devstart": "nodemon ./bin/www"
+    "start": "node ./bin/www"
   },
   "dependencies": {
-    "body-parser": "~1.18.2",
-    "cookie-parser": "~1.4.3",
+    "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
-    "express": "~4.16.2",
-    "morgan": "~1.9.0",
-    "pug": "~2.0.0-rc.4",
-    "serve-favicon": "~2.4.5"
+    "express": "~4.16.1",
+    "http-errors": "~1.6.3",
+    "morgan": "~1.9.1",
+    "pug": "2.0.0-beta11"
   },
   "devDependencies": {
-    "nodemon": "^1.14.11"
+    "nodemon": "^3.1.10"
   }
 }
 ```
 
-Las dependencias incluyen el paquete _express_ y los paquetes para el motor de plantillas elegido (_pug_). Adicionalmente, tenemos los siguientes paquetes que son útiles en muchas aplicaciones web:
+La sección `scripts` primero define un script "_start_", que es el que invocamos al llamar a `npm start` para iniciar el servidor (este script fue añadido por el _Generador de aplicaciones de Express_). En la definición del script puedes ver que en realidad esto inicia el archivo JavaScript **./bin/www** con _node_.
 
-- [body-parser](https://www.npmjs.com/package/body-parser): Esto analiza la parte del cuerpo de una solicitud HTTP entrante y facilita la extracción de diferentes partes de la información contenida. Por ejemplo, puede usar esto para leer los parámetros POST.
-- [cookie-parser](https://www.npmjs.com/package/cookie-parser): Se utiliza para analizar el encabezado de la cookie y rellenar req.cookies (esencialmente proporciona un método conveniente para acceder a la información de la cookie).
-- [debug](https://www.npmjs.com/package/debug): Una pequeña utilidad de depuración de node modelada a partir de la técnica de depuración del núcleo de node.
-- [morgan](https://www.npmjs.com/package/morgan): Un middleware registrador de solicitudes HTTP para node.
-- [serve-favicon](https://www.npmjs.com/package/serve-favicon): Middleware de node para servir un favicon (este es el icono utilizado para representar el sitio dentro de la pestaña del navegador, marcadores, etc.).
-
-La sección de scripts define un script de "_start_", que es lo que invocamos cuando llamamos a npm start para iniciar el servidor. Desde la definición del script, puede ver que esto realmente inicia el archivo JavaScript **./bin/www** con _node_. También define un script "_devstart_", que invocamos cuando llamamos a npm run devstart en su lugar. Esto inicia el mismo archivo **./bin/www**, pero con _nodemon_ en lugar de node.
+Ya modificamos esta sección en [Habilitar el reinicio del servidor al modificar archivos](#habilitar_el_reinicio_del_servidor_al_modificar_archivos) añadiendo los scripts _devstart_ y _serverstart_.
+Estos se pueden usar para iniciar ese mismo archivo **./bin/www** con _nodemon_ en lugar de _node_ (esta versión de los scripts es para Linux y macOS, como se explicó antes).
 
 ```json
+{
   "scripts": {
     "start": "node ./bin/www",
-    "devstart": "nodemon ./bin/www"
-  },
+    "devstart": "nodemon ./bin/www",
+    "serverstart": "DEBUG=express-locallibrary-tutorial:* npm run devstart"
+  }
+}
 ```
 
-### www file
+Las dependencias incluyen el paquete _express_ y el paquete de nuestro motor de vistas elegido (_pug_).
+Además, contamos con los siguientes paquetes que son útiles en muchas aplicaciones web:
 
-El archivo **/bin/www** es el punto de entrada de la aplicación. Lo primero que hace es require () el punto de entrada de la aplicación "real" (**app.js**, en la raíz del proyecto) que configura y devuelve el objeto de la aplicación express ().
+- [cookie-parser](https://www.npmjs.com/package/cookie-parser): se usa para analizar el encabezado de la cookie y rellenar `req.cookies` (básicamente proporciona un método cómodo para acceder a la información de las cookies).
+- [debug](https://www.npmjs.com/package/debug): una pequeña utilidad de depuración para node, inspirada en la técnica de depuración del núcleo de node.
+- [morgan](https://www.npmjs.com/package/morgan): un middleware de registro de solicitudes HTTP para node.
+- [http-errors](https://www.npmjs.com/package/http-errors): crea errores HTTP donde sea necesario (para el manejo de errores de express).
+
+Las versiones predeterminadas del proyecto generado están un poco desactualizadas.
+Reemplaza la sección `dependencies` de tu archivo `package.json` con el siguiente texto, que especifica las versiones más recientes de estas bibliotecas en el momento de escribir esto:
+
+```json
+{
+  "dependencies": {
+    "cookie-parser": "^1.4.7",
+    "debug": "^4.4.1",
+    "express": "^5.1.0",
+    "http-errors": "~2.0.0",
+    "morgan": "^1.10.0",
+    "pug": "3.0.3"
+  }
+}
+```
+
+Luego, actualiza tus dependencias instaladas usando el comando:
+
+```bash
+npm install
+```
+
+> [!NOTE]
+> Es buena idea actualizar con regularidad a las últimas versiones compatibles de tus bibliotecas de dependencias — esto incluso se puede hacer de forma automática o semiautomática como parte de una configuración de {{Glossary("continuous integration", "integración continua")}}.
+>
+> Por lo general, las actualizaciones de versión menor (minor) y de parche (patch) de una biblioteca se mantienen compatibles.
+> Hemos antepuesto `^` a cada versión anterior para poder actualizar automáticamente a la última versión `minor.patch` ejecutando:
+>
+> ```bash
+> npm update --save
+> ```
+>
+> Las versiones mayores (major) cambian la compatibilidad.
+> Para esas actualizaciones tendremos que actualizar manualmente el `package.json` y el código que usa la biblioteca, y volver a probar el proyecto de forma exhaustiva.
+
+### El archivo www
+
+El archivo **/bin/www** es el punto de entrada de la aplicación. Lo primero que hace es usar `require()` para importar el punto de entrada "real" de la aplicación (**app.js**, en la raíz del proyecto), que configura y devuelve el objeto de la aplicación [`express()`](https://expressjs.com/en/api.html).
+`require()` es la [forma CommonJS](https://nodejs.org/api/modules.html) de importar código JavaScript, JSON y otros archivos al archivo actual.
+Aquí especificamos el módulo **app.js** usando una ruta relativa y omitimos la extensión de archivo opcional (**.js**).
 
 ```js
 #!/usr/bin/env node
 
 /**
- * Module dependencies.
+ * Dependencias del módulo.
  */
 
-var app = require("../app");
+const app = require("../app");
 ```
 
 > [!NOTE]
-> `require()` es una función de node global que se usa para importar módulos en el archivo actual. Aquí especificamos el módulo app.js utilizando una ruta relativa y omitiendo la extensión de archivo opcional (.js).
+> Node.js 14 y versiones posteriores admiten las sentencias `import` de ES6 para importar módulos de JavaScript (ECMAScript).
+> Para usar esta función tienes que añadir `"type": "module"` a tu archivo **package.json** de Express, todos los módulos de tu aplicación deben usar `import` en lugar de `require()`, y en las _importaciones relativas_ debes incluir la extensión del archivo (para más información, consulta la [documentación de Node](https://nodejs.org/api/esm.html#introduction)).
+> Aunque usar `import` tiene ventajas, este tutorial usa `require()` para coincidir con [la documentación de Express](https://expressjs.com/en/starter/hello-world.html).
 
-El resto del código en este archivo configura un servidor HTTP de node con la aplicación configurada en un puerto específico (definido en una variable de entorno o 3000 si la variable no está definida), y comienza a escuchar e informar errores y conexiones del servidor. Por ahora no necesita saber nada más sobre el código (todo en este archivo es "repetitivo"), pero siéntase libre de revisarlo si está interesado.
+El resto del código de este archivo configura un servidor HTTP de node con `app` en un puerto específico (definido en una variable de entorno, o 3000 si la variable no está definida), y comienza a escuchar y a reportar los errores y conexiones del servidor. Por ahora no necesitas saber nada más sobre este código (todo lo que hay en este archivo es código "repetitivo" o _boilerplate_), pero siéntete libre de revisarlo si te interesa.
 
 ### app.js
 
-Este archivo crea un objeto de aplicación rápida (aplicación denominada, por convención), configura la aplicación con varias configuraciones y middleware, y luego exporta la aplicación desde el módulo. El siguiente código muestra solo las partes del archivo que crean y exportan el objeto de la aplicación:
+Este archivo crea un objeto de aplicación `express` (llamado `app`, por convención), configura la aplicación con varias opciones y middleware, y luego exporta la aplicación desde el módulo. El siguiente código muestra solo las partes del archivo que crean y exportan el objeto `app`:
 
 ```js
-var express = require('express');
-var app = express();
-...
+const express = require("express");
+
+const app = express();
+// …
 module.exports = app;
 ```
 
-De vuelta en el archivo de punto de entrada **www** anterior, es este objeto module.exports que se proporciona al llamante cuando se importa este archivo.
+De vuelta en el archivo de punto de entrada **www** visto antes, es este objeto `module.exports` el que se proporciona al llamador cuando se importa este archivo.
 
-Permite trabajar a través del archivo **app.js** en detalle. Primero importamos algunas bibliotecas de node útiles en el archivo usando require (), incluyendo _express_, _serve-favicon_, _morgan_, _cookie-parser_ y _body-parser_ que previamente descargamos para nuestra aplicación usando NPM; y _path_, que es una biblioteca central de nodos para analizar rutas de archivos y directorios.
+Vamos a repasar el archivo **app.js** en detalle. Primero, importamos al archivo algunas bibliotecas de node útiles usando `require()`, entre ellas _http-errors_, _express_, _morgan_ y _cookie-parser_, que descargamos antes para nuestra aplicación usando npm; y _path_, que es una biblioteca central de Node para analizar rutas de archivos y directorios.
 
 ```js
-var express = require("express");
-var path = require("path");
-var favicon = require("serve-favicon");
-var logger = require("morgan");
-var cookieParser = require("cookie-parser");
-var bodyParser = require("body-parser");
+const createError = require("http-errors");
+const express = require("express");
+const path = require("path");
+const cookieParser = require("cookie-parser");
+const logger = require("morgan");
 ```
 
-Luego require () modules de nuestro directorio de rutas. Estos modules/files contienen código para manejar conjuntos particulares de "routes" relacionadas (rutas URL). Cuando extendemos la aplicación esqueleto, por ejemplo, para enumerar todos los libros de la biblioteca, agregaremos un nuevo archivo para tratar las rutas relacionadas con los libros.
+Luego usamos `require()` para importar módulos de nuestro directorio de rutas. Estos módulos/archivos contienen código para gestionar conjuntos particulares de "rutas" (rutas de URL) relacionadas. Cuando extendamos la aplicación esqueleto, por ejemplo para listar todos los libros de la biblioteca, añadiremos un nuevo archivo para gestionar las rutas relacionadas con los libros.
 
 ```js
-var index = require("./routes/index");
-var users = require("./routes/users");
+const indexRouter = require("./routes/index");
+const usersRouter = require("./routes/users");
 ```
 
 > [!NOTE]
-> En este punto, acabamos de importar el módulo; aún no hemos utilizado sus rutas (esto sucede un poco más abajo en el archivo).
+> En este punto, solo hemos _importado_ el módulo; todavía no hemos usado sus rutas (esto sucede un poco más abajo en el archivo).
 
-Next we create the `app` object using our imported _express_ module, and then use it to set up the view (template) engine. There are two parts to setting up the engine. First we set the '`views`' value to specify the folder where the templates will be stored (in this case the sub folder **/views**). Then we set the '`view engine`' value to specify the template library (in this case "pug").
+A continuación, creamos el objeto `app` usando nuestro módulo _express_ importado, y luego lo usamos para configurar el motor de vistas (plantillas). Configurar el motor consta de dos partes. Primero, establecemos el valor `"views"` para especificar la carpeta donde se guardarán las plantillas (en este caso, la subcarpeta **/views**). Luego, establecemos el valor `"view engine"` para especificar la biblioteca de plantillas (en este caso, "pug").
 
 ```js
-var app = express();
+const app = express();
 
-// view engine setup
+// configuración del motor de vistas
 app.set("views", path.join(__dirname, "views"));
 app.set("view engine", "pug");
 ```
 
-The next set of functions call `app.use()` to add the _middleware_ libraries into the request handling chain. In addition to the 3rd party libraries we imported previously, we use the `express.static` middleware to get _Express_ to serve all the static files in the **/public** directory in the project root.
+El siguiente conjunto de funciones llama a `app.use()` para añadir a la cadena de manejo de solicitudes las bibliotecas de _middleware_ que importamos antes.
+Por ejemplo, `express.json()` y `express.urlencoded()` son necesarias para rellenar [`req.body`](https://expressjs.com/en/api.html#req.body) con los campos del formulario.
+Después de estas bibliotecas, también usamos el middleware `express.static`, que hace que _Express_ sirva todos los archivos estáticos del directorio **/public** en la raíz del proyecto.
 
 ```js
-// uncomment after placing your favicon in /public
-//app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger("dev"));
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
+
 app.use(express.static(path.join(__dirname, "public")));
 ```
 
-Now that all the other middleware is set up, we add our (previously imported) route-handling code to the request handling chain. The imported code will define particular routes for the different _parts_ of the site:
+Ahora que ya está configurado el resto del middleware, añadimos a la cadena de manejo de solicitudes nuestro código de manejo de rutas (importado previamente). El código importado definirá rutas particulares para las distintas _partes_ del sitio:
 
 ```js
-app.use("/", index);
-app.use("/users", users);
+app.use("/", indexRouter);
+app.use("/users", usersRouter);
 ```
 
 > [!NOTE]
-> The paths specified above ('/' and '`/users'`) are treated as a prefix to routes defined in the imported files. So for example if the imported **users** module defines a route for `/profile`, you would access that route at `/users/profile`. We'll talk more about routes in a later article.
+> Las rutas especificadas arriba (`"/"` y `"/users"`) se tratan como un prefijo para las rutas definidas en los archivos importados.
+> Así, por ejemplo, si el módulo **users** importado define una ruta para `/profile`, accederías a esa ruta en `/users/profile`. Hablaremos más sobre las rutas en un artículo posterior.
 
-The last middleware in the file adds handler methods for errors and HTTP 404 responses.
+El último middleware del archivo añade métodos de manejo para errores y respuestas HTTP 404.
 
 ```js
-// catch 404 and forward to error handler
-app.use(function (req, res, next) {
-  var err = new Error("Not Found");
-  err.status = 404;
-  next(err);
+// captura el error 404 y lo reenvía al manejador de errores
+app.use((req, res, next) => {
+  next(createError(404));
 });
 
-// error handler
-app.use(function (err, req, res, next) {
-  // set locals, only providing error in development
+// manejador de errores
+app.use((err, req, res, next) => {
+  // establece las variables locales; solo se proporciona el error en desarrollo
   res.locals.message = err.message;
   res.locals.error = req.app.get("env") === "development" ? err : {};
 
-  // render the error page
+  // renderiza la página de error
   res.status(err.status || 500);
   res.render("error");
 });
 ```
 
-The Express application object (app) is now fully configured. The last step is to add it to the module exports (this is what allows it to be imported by **/bin/www**).
+El objeto de la aplicación Express (`app`) ya está completamente configurado. El último paso es añadirlo a las exportaciones del módulo (esto es lo que permite que **/bin/www** pueda importarlo).
 
 ```js
 module.exports = app;
 ```
 
-### Routes
+### Rutas
 
-The route file **/routes/users.js** is shown below (route files share a similar structure, so we don't need to also show **index.js**). First it loads the _express_ module, and uses it to get an `express.Router` object. Then it specifies a route on that object, and lastly exports the router from the module (this is what allows the file to be imported into **app.js**).
+A continuación se muestra el archivo de rutas **/routes/users.js** (los archivos de rutas comparten una estructura similar, así que no hace falta mostrar también **index.js**).
+Primero, carga el módulo _express_ y lo usa para obtener un objeto `express.Router`.
+Luego especifica una ruta en ese objeto y, por último, exporta el enrutador desde el módulo (esto es lo que permite importar el archivo en **app.js**).
 
 ```js
-var express = require("express");
-var router = express.Router();
+const express = require("express");
 
-/* GET users listing. */
-router.get("/", function (req, res, next) {
+const router = express.Router();
+
+/* Lista de usuarios (GET). */
+router.get("/", (req, res, next) => {
   res.send("respond with a resource");
 });
 
 module.exports = router;
 ```
 
-The route defines a callback that will be invoked whenever an HTTP `GET` request with the correct pattern is detected. The matching pattern is the route specified when the module is imported ('`/users`') plus whatever is defined in this file ('`/`'). In other words, this route will be used when an URL of `/users/` is received.
+La ruta define un callback que se invocará cada vez que se detecte una solicitud HTTP `GET` con el patrón correcto. El patrón de coincidencia es la ruta especificada al importar el módulo (`"/users"`) más lo que se defina en este archivo (`"/"`). En otras palabras, esta ruta se usará cuando se reciba una URL `/users/`.
 
 > [!NOTE]
-> Try this out by running the server with node and visiting the URL in your browser: `http://localhost:3000/users/`. You should see a message: 'respond with a resource'.
+> Prueba esto ejecutando el servidor con node y visitando la URL en tu navegador: `http://localhost:3000/users/`. Deberías ver el mensaje: "respond with a resource".
 
-One thing of interest above is that the callback function has the third argument '`next`', and is hence a middleware function rather than a simple route callback. While the code doesn't currently use the `next` argument, it may be useful in the future if you want to add multiple route handlers to the `'/'` route path.
+Algo interesante en el código anterior es que la función callback tiene el tercer argumento `next`, por lo que es una función de middleware en lugar de un simple callback de ruta. Aunque el código actualmente no usa el argumento `next`, puede resultar útil en el futuro si quieres añadir varios manejadores de ruta a la ruta `'/'`.
 
-### Views (templates)
+### Vistas (plantillas)
 
-The views (templates) are stored in the **/views** directory (as specified in **app.js**) and are given the file extension **.pug**. The method [`Response.render()`](http://expressjs.com/en/4x/api.html#res.render) is used to render a specified template along with the values of named variables passed in an object, and then send the result as a response. In the code below from **/routes/index.js** you can see how that route renders a response using the template "index" passing the template variable "title".
+Las vistas (plantillas) se guardan en el directorio **/views** (tal como se especifica en **app.js**) y tienen la extensión de archivo **.pug**. El método [`Response.render()`](https://expressjs.com/en/5x/api.html#res.render) se usa para renderizar una plantilla especificada junto con los valores de las variables con nombre pasadas en un objeto, y luego enviar el resultado como respuesta. En el siguiente código de **/routes/index.js** puedes ver cómo esa ruta renderiza una respuesta usando la plantilla "index" y pasando la variable de plantilla "title".
 
 ```js
 /* GET home page. */
-router.get("/", function (req, res) {
+router.get("/", (req, res, next) => {
   res.render("index", { title: "Express" });
 });
 ```
 
-The corresponding template for the above route is given below (**index.pug**). We'll talk more about the syntax later. All you need to know for now is that the `title` variable (with value `'Express'`) is inserted where specified in the template.
+A continuación se muestra la plantilla correspondiente a la ruta anterior (**index.pug**). Hablaremos más sobre la sintaxis más adelante. Por ahora, todo lo que necesitas saber es que la variable `title` (con el valor `'Express'`) se inserta donde se especifica en la plantilla.
 
-```
+```pug
 extends layout
 
 block content
@@ -489,19 +577,19 @@ block content
   p Welcome to #{title}
 ```
 
-## Challenge yourself
+## Ponte a prueba
 
-Create a new route in **/routes/users.js** that will display the text "_You're so cool"_ at URL `/users/cool/`. Test it by running the server and visiting `http://localhost:3000/users/cool/` in your browser
+Crea una nueva ruta en **/routes/users.js** que muestre el texto "_Eres tan genial_" en la URL `/users/cool/`. Pruébala ejecutando el servidor y visitando `http://localhost:3000/users/cool/` en tu navegador.
 
-## Summary
+## Resumen
 
-You have now created a skeleton website project for the [Local Library](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website) and verified that it runs using _node_. Most important, you also understand how the project is structured, so you have a good idea where we need to make changes to add routes and views for our local library.
+Ya has creado un proyecto de sitio web esqueleto para [Local Library](/es/docs/Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website) y has comprobado que funciona usando _node_. Lo más importante es que también entiendes cómo está estructurado el proyecto, así que tienes una buena idea de dónde tendremos que hacer cambios para añadir rutas y vistas a nuestra biblioteca local.
 
-Next we'll start modifying the skeleton so that works as a library website.
+A continuación, empezaremos a modificar el esqueleto para que funcione como el sitio web de la biblioteca.
 
-## See also
+## Véase también
 
-- [Express application generator](https://expressjs.com/en/starter/generator.html) (Express docs)
-- [Using template engines with Express](https://expressjs.com/en/guide/using-template-engines.html) (Express docs)
+- [Express application generator](https://expressjs.com/en/starter/generator.html) (documentación de Express)
+- [Using template engines with Express](https://expressjs.com/en/guide/using-template-engines.html) (documentación de Express)
 
 {{PreviousMenuNext("Learn_web_development/Extensions/Server-side/Express_Nodejs/Tutorial_local_library_website", "Learn_web_development/Extensions/Server-side/Express_Nodejs/mongoose", "Learn_web_development/Extensions/Server-side/Express_Nodejs")}}


### PR DESCRIPTION
### Description
Sincroniza la traducción al español de "Express Tutorial Part 2: Creating a skeleton website" con la versión en inglés actual (nunca se había registrado `l10n.sourceCommit`).

### Motivation
La página llevaba años desactualizada respecto al inglés (front-matter con `original_slug` en vez de `l10n.sourceCommit`, secciones desactualizadas como la migración a Express 5, `http-errors`, PowerShell, `package-lock.json`, y el aviso de deprecación de `var`/`const`). Se reescribió el artículo completo para reflejar la fuente en inglés.

### Additional details
- Front-matter dejado solo con `title`, `short-title`, `slug` y `l10n.sourceCommit` (se quitó `original_slug`).
- `l10n.sourceCommit` apunta a `afcdfa050626bb7eb05ee693df8997020db9ff2e`, el último commit que tocó el archivo en inglés.
- Enlaces internos actualizados a `/es/docs/...`.
- Macros Kumascript (`{{LearnSidebar}}`, `{{PreviousMenuNext(...)}}`, `{{Glossary(...)}}`) verificadas y equivalentes a las de la fuente en inglés.
- Se validó con Prettier, markdownlint-cli2 y `check-url-locale.js` sobre el archivo modificado.

### Related issues and pull requests
Fixes #37269