### PR TITLE
chore(es): sync of `Learn_web_development/Core/Scripting/Arrays`

### DIFF
--- a/files/es/learn_web_development/core/scripting/arrays/index.md
+++ b/files/es/learn_web_development/core/scripting/arrays/index.md
@@ -1,677 +1,507 @@
 ---
 title: Arreglos
 slug: Learn_web_development/Core/Scripting/Arrays
-original_slug: Learn/JavaScript/First_steps/Arrays
+l10n:
+  sourceCommit: 0abb70602b0b3b11a2909c417a03e10eabd607a8
 ---
 
-{{LearnSidebar}}{{PreviousMenuNext("Learn_web_development/Core/Scripting/Useful_string_methods", "Learn_web_development/Core/Scripting/Silly_story_generator", "conflicting/Learn_web_development/Core/Scripting")}}
+{{PreviousMenuNext("Learn_web_development/Core/Scripting/Test_your_skills/Strings", "Learn_web_development/Core/Scripting/Test_your_skills/Arrays", "Learn_web_development/Core/Scripting")}}
 
-## Arreglos
+En esta lección veremos los arreglos — una forma ordenada de almacenar una lista de elementos de datos bajo un único nombre de variable. Aquí vemos por qué esto es útil, para luego explorar cómo crear un [arreglo](/es/docs/Web/JavaScript/Reference/Global_Objects/Array), recuperar, agregar y eliminar elementos almacenados en él, y mucho más.
 
-En este último artículo de este módulo, veremos las matrices — una manera ordenada de almacenar una lista de elementos de datos bajo un solo nombre de variable. Aquí vemos por qué esto es útil, luego exploramos cómo crear un arreglo, recuperar, agregar y eliminar elementos almacenados en un arreglo, y más.
-
-| Prerrequisitos: | Conocimientos básicos de informática, una comprensión básica de HTML y CSS, una idea de lo que es JavaScript. |
-| --------------- | ------------------------------------------------------------------------------------------------------------- |
-| Objectivo:      | Para entender qué son las matrices y cómo manipularlas en JavaScript.                                         |
+<table>
+  <tbody>
+    <tr>
+      <th scope="row">Prerrequisitos:</th>
+      <td>Comprender <a href="/es/docs/Learn_web_development/Core/Structuring_content">HTML</a> y los <a href="/es/docs/Learn_web_development/Core/Styling_basics">fundamentos de CSS</a>. Familiaridad con tipos de datos básicos como números y cadenas, como se vio en lecciones anteriores.</td>
+    </tr>
+    <tr>
+      <th scope="row">Resultados de aprendizaje:</th>
+      <td>
+        <ul>
+          <li>Qué es un arreglo — una estructura que contiene una lista de variables.</li>
+          <li>La sintaxis de los arreglos — <code>[a, b, c]</code> y la sintaxis de acceso, <code>miArreglo[x]</code>.</li>
+          <li>Modificar valores de un arreglo con <code>miArreglo[x] = y</code>.</li>
+          <li>Manipulación de arreglos usando propiedades y métodos comunes como <code>length</code>, <code>push()</code>, <code>pop()</code>, <code>join()</code> y <code>split()</code>.</li>
+          <li>Métodos de arreglos más avanzados como <code>forEach()</code>, <code>map()</code> y <code>filter()</code>.</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## ¿Qué es un arreglo?
 
-Las matrices se describen como "objetos tipo lista"; básicamente son objetos individuales que contienen múltiples valores almacenados en una lista. Los objetos de arreglos pueden almacenarse en variables y tratarse de la misma manera que cualquier otro tipo de valor, la diferencia es que podemos acceder individualmente a cada valor dentro de la lista y hacer cosas útiles y eficientes con la lista, como recorrerlo con un bucle y hacer una misma cosa a cada valor. Tal vez tenemos una serie de productos y sus precios almacenados en un arreglo, y queremos recorrerlos e imprimirlos en una factura, sumando todos los precios e imprimiendo el total en la parte inferior.
+Los arreglos se describen generalmente como "objetos tipo lista"; básicamente son objetos individuales que contienen múltiples valores almacenados en una lista. Los objetos de tipo arreglo pueden almacenarse en variables y tratarse de la misma manera que cualquier otro tipo de valor, con la diferencia de que podemos acceder a cada valor dentro de la lista de forma individual, y hacer cosas realmente útiles y eficientes con la lista, como recorrerla y hacer lo mismo con cada valor. Tal vez tengamos una serie de productos y sus precios almacenados en un arreglo, y queramos recorrerlos todos e imprimirlos en una factura, mientras sumamos todos los precios e imprimimos el total al final.
 
-Si no tuvieramos matrices, tendríamos que almacenar cada elemento en una variable separada, luego llamar al código que hace la impresión y agregarlo por separado para cada artículo. Esto sería mucho más largo de escribir, menos eficiente y más propenso a errores. si tuviéramos 10 elementos para agregar a la factura, ya sería suficientemente malo, pero ¿ qué pasa con 100 o 1000 artículos? Volveremos a este ejemplo más adelante en el artículo.
+Si no tuviéramos arreglos, tendríamos que almacenar cada elemento en una variable separada, y luego llamar al código que hace la impresión y la suma por separado para cada elemento. Esto sería mucho más largo de escribir, menos eficiente y más propenso a errores. Si tuviéramos 10 elementos para agregar a la factura ya sería bastante molesto, pero ¿qué pasa con 100 elementos, o 1000? Volveremos a este ejemplo más adelante en el artículo.
 
-Como en artículos anteriores, aprendamos sobre los aspectos básicos reales de las matrices ingresando algunos ejemplos en una consola de JavaScript. A continuación proporcionamos uno (o utilice la [consola de desarrollador de navegador](/es/docs/Learn_web_development/Howto/Tools_and_setup/What_are_browser_developer_tools), si lo prefieres).
+Como en artículos anteriores, aprendamos los aspectos básicos reales de los arreglos ingresando algunos ejemplos en la [consola de desarrollador del navegador](/es/docs/Learn_web_development/Howto/Tools_and_setup/What_are_browser_developer_tools).
 
-```html hidden
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Consola JavaScript</title>
-    <style>
-      * {
-        box-sizing: border-box;
-      }
+> [!NOTE]
+> El scrim de Scrimba [Aside: Intro to arrays](https://scrimba.com/the-frontend-developer-career-path-c0j/~06e?via=mdn) <sup>[_socio de aprendizaje de MDN_](/es/docs/MDN/Writing_guidelines/Learning_content#enlaces_externos_o_embebidos)</sup> ofrece una útil introducción interactiva a los arreglos, con recorridos de ejemplos y un desafío para poner a prueba tus conocimientos.
 
-      html {
-        background-color: #0c323d;
-        color: #809089;
-        font-family: monospace;
-      }
+## Creando arreglos
 
-      body {
-        max-width: 700px;
-      }
+Los arreglos se componen de corchetes y elementos separados por comas.
 
-      p {
-        margin: 0;
-        width: 1%;
-        padding: 0 1%;
-        font-size: 16px;
-        line-height: 1.5;
-        float: left;
-      }
+1. Supongamos que queremos almacenar una lista de compras en un arreglo. Pega el siguiente código en la consola:
 
-      .input p {
-        margin-right: 1%;
-      }
+   ```js
+   const shopping = ["bread", "milk", "cheese", "hummus", "noodles"];
+   console.log(shopping);
+   ```
 
-      .output p {
-        width: 100%;
-      }
+2. En el ejemplo anterior, cada elemento es una cadena, pero en un arreglo podemos almacenar distintos tipos de datos — cadenas, números, objetos, e incluso otros arreglos. También podemos mezclar tipos de datos dentro de un mismo arreglo — no tenemos que limitarnos a almacenar solo números en un arreglo, y en otro solo cadenas. Por ejemplo:
 
-      .input input {
-        width: 96%;
-        float: left;
-        border: none;
-        font-size: 16px;
-        line-height: 1.5;
-        font-family: monospace;
-        padding: 0;
-        background: #0c323d;
-        color: #809089;
-      }
+   ```js
+   const sequence = [1, 1, 2, 3, 5, 8, 13];
+   const random = ["tree", 795, [0, 1, 2]];
+   ```
 
-      div {
-        clear: both;
-      }
-    </style>
-  </head>
-  <body></body>
+3. Antes de continuar, crea algunos arreglos de ejemplo.
 
-  <script>
-    var geval = eval;
-    function createInput() {
-      var inputDiv = document.createElement("div");
-      var inputPara = document.createElement("p");
-      var inputForm = document.createElement("input");
+## Encontrando la longitud de un arreglo
 
-      inputDiv.setAttribute("class", "input");
-      inputPara.textContent = ">";
-      inputDiv.appendChild(inputPara);
-      inputDiv.appendChild(inputForm);
-      document.body.appendChild(inputDiv);
+Puedes averiguar la longitud de un arreglo (cuántos elementos contiene) exactamente de la misma manera en que se averigua la longitud (en caracteres) de una cadena — utilizando la propiedad {{jsxref("Array.prototype.length","length")}}. Prueba lo siguiente:
 
-      if (document.querySelectorAll("div").length > 1) {
-        inputForm.focus();
-      }
-
-      inputForm.addEventListener("change", executeCode);
-    }
-
-    function executeCode(e) {
-      try {
-        var result = geval(e.target.value);
-      } catch (e) {
-        var result = "error — " + e.message;
-      }
-
-      var outputDiv = document.createElement("div");
-      var outputPara = document.createElement("p");
-
-      outputDiv.setAttribute("class", "output");
-      outputPara.textContent = "Resultado: " + result;
-      outputDiv.appendChild(outputPara);
-      document.body.appendChild(outputDiv);
-
-      e.target.disabled = true;
-      e.target.parentNode.style.opacity = "0.5";
-
-      createInput();
-    }
-
-    createInput();
-  </script>
-</html>
+```js
+const shopping = ["bread", "milk", "cheese", "hummus", "noodles"];
+console.log(shopping.length); // 5
 ```
 
-{{ EmbedLiveSample('Hidden_code', '100%', 300, "", "", "hide-codepen-jsfiddle") }}
+## Accediendo y modificando elementos de un arreglo
 
-### Creando un arreglo
-
-Las matrices se construyen con corchetes, que contiene una lista de elementos separdos por comas.
-
-1. Digamos que queríamos almacenar una lista de compras en un arreglo — haríamos algo como lo siguiente. Ingresa las siguientes líneas en la consola:
-
-   ```js
-   let shopping = ["bread", "milk", "cheese", "hummus", "noodles"];
-   shopping;
-   ```
-
-2. En este caso, cada elemento del arreglo es una cadena, pero ten en cuenta que puedes almacenar cualquier elemento en un arreglo — cadena, número, objeto, otra variable, incluso otro arreglo. También puedes mezclar y combinar tipos de elementos — no todos tienen que ser números, cadenas, etc. Prueba estos:
-
-   ```js
-   let sequence = [1, 1, 2, 3, 5, 8, 13];
-   let random = ["tree", 795, [0, 1, 2]];
-   ```
-
-3. Intenta creando un par de matrices por tu cuenta, antes de continuar.
-
-### Accediendo y modificando elementos del arreglo
-
-Puedes entonces acceder a elementos individuales en el arreglo mediante la notación de corchetes, del mismo modo que [accediste a las letras de una cadena](/es/docs/Learn_web_development/Core/Scripting/Useful_string_methods#retrieving_a_specific_string_character).
+Los arreglos son [colecciones indexadas](/es/docs/Web/JavaScript/Guide/Indexed_collections). Los elementos de un arreglo están numerados, comenzando desde cero. Este número se denomina _índice_ del elemento. Así, el primer elemento tiene el índice 0, el segundo tiene el índice 1, y así sucesivamente. Puedes acceder a elementos individuales del arreglo mediante la notación de corchetes, indicando el índice del elemento, de la misma manera en que [accediste a las letras de una cadena](/es/docs/Learn_web_development/Core/Scripting/Useful_string_methods#obtener_un_carácter_específico_de_una_cadena).
 
 1. Ingresa lo siguiente en tu consola:
 
    ```js
-   shopping[0];
+   const shopping = ["bread", "milk", "cheese", "hummus", "noodles"];
+   console.log(shopping[0]);
    // devuelve "bread"
    ```
 
-2. también puedes modificar un elemento en un arreglo simplemente dando a un item del arreglo un nuevo valor. Prueba esto:
+2. También puedes modificar un elemento de un arreglo simplemente asignándole un nuevo valor. Prueba esto:
 
    ```js
+   const shopping = ["bread", "milk", "cheese", "hummus", "noodles"];
    shopping[0] = "tahini";
-   shopping;
+   console.log(shopping);
    // shopping ahora devolverá [ "tahini", "milk", "cheese", "hummus", "noodles" ]
    ```
 
    > [!NOTE]
-   > Lo dijimos antes, pero solo como recordatorio — ¡ las computadoras comienzan a contar desde 0!
+   > Ya lo dijimos antes, pero solo como recordatorio — ¡JavaScript comienza a indexar los arreglos en cero!
 
-3. Ten en cuenta que un arreglo dentro de otro arreglo se llama arreglo multidimensional o matriz. Puedes acceder a los elementos de un arreglo que estén dentro de otro, encadenando dos pares de corchetes. Por ejemplo, para acceder a uno de los elementos dentro de la matriz, que a su vez, es el tercer elemento dentro de la matriz `random` (ver sección anterior), podríamos hacer algo como esto:
+3. Ten en cuenta que un arreglo dentro de otro arreglo se llama arreglo multidimensional. Puedes acceder a un elemento dentro de un arreglo que está a su vez dentro de otro arreglo encadenando dos pares de corchetes. Por ejemplo, para acceder a uno de los elementos dentro del arreglo que es el tercer elemento del arreglo `random` (ver sección anterior), podríamos hacer algo así:
 
    ```js
+   const random = ["tree", 795, [0, 1, 2]];
    random[2][2];
    ```
 
-4. Intenta seguir jugando y haciendo algunas modificaciones más a tus ejemplos de matriz antes de continuar.
+4. Antes de continuar, intenta hacer algunas modificaciones más a tus ejemplos de arreglos. Juega un poco y observa qué funciona y qué no.
 
-### Encontrar la longitud de un arreglo
+## Encontrando el índice de elementos en un arreglo
 
-Puedes averiguar la longitud de un arreglo (cuántos elementos contiene) exactamente de la misma manera que determinas la longitud (en caracteres) de una cadena— utilizando la propiedad {{jsxref("Array.prototype.length","length")}}. Prueba lo siguiente:
+Si no conoces el índice de un elemento, puedes usar el método {{jsxref("Array.prototype.indexOf()","indexOf()")}}.
+El método `indexOf()` toma un elemento como argumento y devuelve el índice de ese elemento, o `-1` si el elemento no está en el arreglo:
 
 ```js
-sequence.length;
-// Deve devolver 7
+const birds = ["Parrot", "Falcon", "Owl"];
+console.log(birds.indexOf("Owl")); //  2
+console.log(birds.indexOf("Rabbit")); // -1
 ```
 
-Esto tiene otros usos, pero se usa más comunmente para indicarle a un ciclo que continúe hasta que haya recorrido todos los elementos del arreglo. Así por ejemplo:
+## Agregando elementos
+
+Para agregar uno o más elementos al final de un arreglo podemos usar {{jsxref("Array.prototype.push()","push()")}}. Ten en cuenta que debes incluir uno o más elementos que quieras agregar al final de tu arreglo.
 
 ```js
-let sequence = [1, 1, 2, 3, 5, 8, 13];
-for (var i = 0; i < sequence.length; i++) {
-  console.log(sequence[i]);
+const cities = ["Manchester", "Liverpool"];
+cities.push("Cardiff");
+console.log(cities); // [ "Manchester", "Liverpool", "Cardiff" ]
+cities.push("Bradford", "Brighton");
+console.log(cities); // [ "Manchester", "Liverpool", "Cardiff", "Bradford", "Brighton" ]
+```
+
+La nueva longitud del arreglo se devuelve cuando finaliza la llamada al método. Si quisieras almacenar la nueva longitud del arreglo en una variable, podrías hacer algo como esto:
+
+```js
+const cities = ["Manchester", "Liverpool"];
+const newLength = cities.push("Bristol");
+console.log(cities); // [ "Manchester", "Liverpool", "Bristol" ]
+console.log(newLength); // 3
+```
+
+Para agregar un elemento al inicio del arreglo, usa {{jsxref("Array.prototype.unshift()","unshift()")}}:
+
+```js
+const cities = ["Manchester", "Liverpool"];
+cities.unshift("Edinburgh");
+console.log(cities); // [ "Edinburgh", "Manchester", "Liverpool" ]
+```
+
+## Eliminando elementos
+
+Para eliminar el último elemento del arreglo, usa {{jsxref("Array.prototype.pop()","pop()")}}.
+
+```js
+const cities = ["Manchester", "Liverpool"];
+cities.pop();
+console.log(cities); // [ "Manchester" ]
+```
+
+El método `pop()` devuelve el elemento que fue eliminado. Para guardar ese elemento en una nueva variable, podrías hacer esto:
+
+```js
+const cities = ["Manchester", "Liverpool"];
+const removedCity = cities.pop();
+console.log(removedCity); // "Liverpool"
+```
+
+Para eliminar el primer elemento de un arreglo, usa {{jsxref("Array.prototype.shift()","shift()")}}:
+
+```js
+const cities = ["Manchester", "Liverpool"];
+cities.shift();
+console.log(cities); // [ "Liverpool" ]
+```
+
+Si conoces el índice de un elemento, puedes eliminarlo del arreglo usando {{jsxref("Array.prototype.splice()","splice()")}}:
+
+```js
+const cities = ["Manchester", "Liverpool", "Edinburgh", "Carlisle"];
+const index = cities.indexOf("Liverpool");
+if (index !== -1) {
+  cities.splice(index, 1);
+}
+console.log(cities); // [ "Manchester", "Edinburgh", "Carlisle" ]
+```
+
+En esta llamada a `splice()`, el primer argumento indica dónde comenzar a eliminar elementos, y el segundo argumento indica cuántos elementos deben eliminarse. Así, puedes eliminar más de un elemento:
+
+```js
+const cities = ["Manchester", "Liverpool", "Edinburgh", "Carlisle"];
+const index = cities.indexOf("Liverpool");
+if (index !== -1) {
+  cities.splice(index, 2);
+}
+console.log(cities); // [ "Manchester", "Carlisle" ]
+```
+
+## Accediendo a cada elemento
+
+Muy a menudo querrás acceder a todos los elementos de un arreglo. Puedes hacerlo usando la sentencia {{jsxref("Statements/for...of","for...of")}}:
+
+```js
+const birds = ["Parrot", "Falcon", "Owl"];
+
+for (const bird of birds) {
+  console.log(bird);
 }
 ```
 
-Aprenderás acerca de bucles correctamente en un artículo futuro, pero brevemente, éste código dice:
+A veces querrás hacer lo mismo con cada elemento de un arreglo, y quedarte con un arreglo que contenga los elementos modificados. Puedes hacerlo usando {{jsxref("Array.prototype.map()","map()")}}. El siguiente código toma un arreglo de números y duplica cada número:
 
-1. Comienza el bucle en el elemento de la posición 0 en el arreglo.
-2. Detén el bucle en el número de item igual a la longitud del arreglo. Esto funcionará para un arreglo de cualquier longitid, pero en este caso el ciclo se detendrá en el elemento número 7 (esto es bueno, ya que el último elemento — que queremos que recorra el bucle — es 6.
-3. Para cada elemento, imprime en la consola del navegador con [`console.log()`](/es/docs/Web/API/console/log_static).
+```js
+function double(number) {
+  return number * 2;
+}
+const numbers = [5, 2, 7, 6];
+const doubled = numbers.map(double);
+console.log(doubled); // [ 10, 4, 14, 12 ]
+```
 
-## Algunos métodos de arreglo útiles
+Le damos una función a `map()`, y `map()` llama a esa función una vez por cada elemento del arreglo, pasándole el elemento. Luego agrega el valor de retorno de cada llamada a la función a un nuevo arreglo, y finalmente devuelve ese nuevo arreglo.
 
-En esta sección veremos algunos métodos bastante útiles relacionados con matrices que nos permiten dividir cadenas en elementos de arreglo y viceversa, y agregar nuevos elementos en matrices.
+A veces querrás crear un nuevo arreglo que contenga solo los elementos del arreglo original que cumplan cierta condición. Puedes hacerlo usando {{jsxref("Array.prototype.filter()","filter()")}}. El siguiente código toma un arreglo de cadenas y devuelve un arreglo que contiene solo las cadenas con más de 8 caracteres de longitud:
 
-### Conversión entre matrices y cadenas
+```js
+function isLong(city) {
+  return city.length > 8;
+}
+const cities = ["London", "Liverpool", "Totnes", "Edinburgh"];
+const longer = cities.filter(isLong);
+console.log(longer); // [ "Liverpool", "Edinburgh" ]
+```
 
-A menudo se te presentarán algunos datos brutos contenidos en una cadena larga y grande, y es posible que desees separar los elementos útiles de una forma más conveniente y luego hacerle cosas, como mostrarlos en una tabla de datos. Para hacer esto, podemos usar el método {{jsxref("String.prototype.split()","split()")}}. En su forma más simple, esto toma un único parámetro, el caracter que quieres separar de la cadena, y devuelve las subcadenas entre el separador como elementos en un arreglo.
+Al igual que con `map()`, le damos una función al método `filter()`, y `filter()` llama a esa función por cada elemento del arreglo, pasándole el elemento. Si la función devuelve `true`, el elemento se agrega a un nuevo arreglo. Finalmente, devuelve ese nuevo arreglo.
+
+## Convirtiendo entre cadenas y arreglos
+
+A menudo se te presentarán datos en bruto contenidos en una cadena larga, y es posible que quieras separar los elementos útiles en una forma más conveniente para luego hacer cosas con ellos, como mostrarlos en una tabla de datos. Para hacer esto, podemos usar el método {{jsxref("String.prototype.split()","split()")}}. En su forma más simple, toma un único parámetro, el carácter por el que quieres separar la cadena, y devuelve las subcadenas entre los separadores como elementos de un arreglo.
 
 > [!NOTE]
-> Bien, esto es técnicamente un método de cadena, no un método de arreglo, pero lo hemos incluido con las matrices, ya que va bien aquí.
+> Bien, esto es técnicamente un método de cadena, no un método de arreglo, pero lo incluimos junto con los arreglos ya que encaja bien aquí.
 
-1. Vamos a jugar con esto, para ver como funciona. Primero, crea una cadena en tu consola:
+1. Juguemos con esto para ver cómo funciona. Primero, crea una cadena en tu consola:
 
    ```js
-   let myData = "Manchester,London,Liverpool,Birmingham,Leeds,Carlisle";
+   const data = "Manchester,London,Liverpool,Birmingham,Leeds,Carlisle";
    ```
 
-2. Ahora dividámoslo en cada coma:
+2. Ahora separémosla en cada coma:
 
    ```js
-   let myArray = myData.split(",");
-   myArray;
+   const cities = data.split(",");
+   cities;
    ```
 
-3. Finalmente, intenta encontrar la longitud de tu nuevo arreglo y recuperar algunos elementos de ella:
+3. Finalmente, intenta encontrar la longitud de tu nuevo arreglo, y recuperar algunos elementos de él:
 
    ```js
-   myArray.length;
-   myArray[0]; // el primer elemento del arreglo
-   myArray[1]; // el segundo elemento del arreglo
-   myArray[myArray.length - 1]; // el último elemento del arreglo
+   cities.length;
+   cities[0]; // el primer elemento del arreglo
+   cities[1]; // el segundo elemento del arreglo
+   cities[cities.length - 1]; // el último elemento del arreglo
    ```
 
 4. También puedes ir en la dirección opuesta usando el método {{jsxref("Array.prototype.join()","join()")}}. Prueba lo siguiente:
 
    ```js
-   let myNewString = myArray.join(",");
-   myNewString;
+   const commaSeparated = cities.join(",");
+   commaSeparated;
    ```
 
-5. Otra forma de convertir un arreglo en cadena es usar el método {{jsxref("Array.prototype.toString()","toString()")}}. `toString()` es posiblemente más simple que `join()` ya que no toma un parámetro, pero es más limitado. Con `join()` puedes especificar diferentes separadores (intenta ejecutar el Paso 4 con un caracter diferente a la coma).
+5. Otra forma de convertir un arreglo en una cadena es usar el método {{jsxref("Array.prototype.toString()","toString()")}}. `toString()` es posiblemente más simple que `join()`, ya que no toma ningún parámetro, pero es más limitado. Con `join()` puedes especificar diferentes separadores, mientras que `toString()` siempre usa una coma. (Intenta ejecutar el Paso 4 con un carácter distinto de la coma.)
 
    ```js
-   let dogNames = ["Rocket", "Flash", "Bella", "Slugger"];
-   dogNames.toString(); //Rocket,Flash,Bella,Slugger
+   const dogNames = ["Rocket", "Flash", "Bella", "Slugger"];
+   dogNames.toString(); // Rocket,Flash,Bella,Slugger
    ```
 
-### Agregar y eliminar elementos del arreglo
+## Imprimiendo esos productos
 
-Todavia no hemos cubierto la posibilidad de agregar y eliminar elementos del arreglo — echemos un vistazo a esto ahora. Usaremos el arreglo `myArray` con la que terminamos en la última sección. Si todavía no has seguido esa sección, primero crea el arreglo en tu consola:
+Es tu turno. En este ejercicio volverás al ejemplo que describimos anteriormente — imprimir nombres de productos y precios en una factura, para luego sumar los precios e imprimirlos al final. Sigue los pasos a continuación para implementar la lógica necesaria.
 
-```js
-let myArray = [
-  "Manchester",
-  "London",
-  "Liverpool",
-  "Birmingham",
-  "Leeds",
-  "Carlisle",
-];
-```
+1. Haz clic en **"Play"** en el bloque de código de abajo para editar el ejemplo en el MDN Playground.
+2. Debajo del comentario `// Part 1` hay varias cadenas, cada una de las cuales contiene un nombre de producto y un precio separados por dos puntos. Nos gustaría que las descomentaras y las conviertas en un arreglo llamado `products`.
+3. Debajo del comentario `// Part 2`, inicia un bucle `for...of()` para recorrer todos los elementos del arreglo `products`.
+4. Debajo del comentario `// Part 3` queremos que escribas una línea de código que divida el elemento actual del arreglo (`name:price`) en dos elementos separados, uno que contenga el nombre y otro que contenga el precio. Si no estás seguro de cómo hacerlo, consulta el artículo [Métodos de cadenas útiles](/es/docs/Learn_web_development/Core/Scripting/Useful_string_methods) para obtener ayuda, o mejor aún, mira la sección [Convirtiendo entre cadenas y arreglos](#convirtiendo_entre_cadenas_y_arreglos) de este artículo.
+5. Como parte de la línea de código anterior, también querrás convertir el precio de una cadena a un número. Si no recuerdas cómo hacerlo, revisa el [primer artículo sobre cadenas](/es/docs/Learn_web_development/Core/Scripting/Strings#números_versus_cadenas).
+6. Hay una variable llamada `total` que se crea y se le da el valor `0` al inicio del código. Dentro del bucle (debajo de `// Part 4`) queremos que agregues una línea que sume el precio del elemento actual a ese total en cada iteración del bucle, de modo que al final del código se imprima el total correcto en la factura. Es posible que necesites un [operador de asignación](/es/docs/Learn_web_development/Core/Scripting/Math#operadores_de_asignación) para hacer esto.
+7. Queremos que cambies la línea siguiente al comentario `// Part 5` para que la variable `itemText` se iguale a "nombre del elemento actual — $precio del elemento actual", por ejemplo "Shoes — $23.99" en cada caso, de modo que se imprima la información correcta de cada elemento en la factura. Esto es concatenación básica de cadenas, algo que debería resultarte familiar si has seguido el material de aprendizaje hasta ahora.
+8. Finalmente, debajo del comentario `// Part 6`, deberás agregar una `}` para marcar el final del bucle `for...of()`.
 
-Antes que nada, para añdir o eliminar un elemento al final de un arreglo podemos usar {{jsxref("Array.prototype.push()","push()")}} y {{jsxref("Array.prototype.pop()","pop()")}} respectivamente.
+Si cometes un error, puedes borrar tu trabajo usando el botón _Reset_ del MDN Playground. Si te quedas realmente atascado, puedes ver la solución debajo de la salida en vivo.
 
-1. primero usemos `push()` — nota que necesitas incluir uno o más elementos que desees agregas al final de tu arreglo. Prueba esto:
-
-   ```js
-   myArray.push("Cardiff");
-   myArray;
-   myArray.push("Bradford", "Brighton");
-   myArray;
-   ```
-
-2. La nueva longitud del arreglo se devuelve cuando finaliza la llamada al método. Si quisieras almacenar la nueva longitud del arreglo en una variable, podrías hacer algo como esto:
-
-   ```js
-   let newLength = myArray.push("Bristol");
-   myArray;
-   newLength;
-   ```
-
-3. Eliminar el último elemento de un arreglo es tan simple como ejecutar `pop()` en ella. Prueba esto:
-
-   ```js
-   myArray.pop();
-   ```
-
-4. El elemento que sé eliminó se devuelve cuando se completa la llamada al método. Para guardar este elemento en una variable, puedes hacer lo siguiente:
-
-   ```js
-   let removedItem = myArray.pop();
-   myArray;
-   removedItem;
-   ```
-
-{{jsxref("Array.prototype.unshift()","unshift()")}} y {{jsxref("Array.prototype.shift()","shift()")}} funcionan exactamente igual de `push()` y `pop()`, respectivamente, excepto que funcionan al principio del arreglo, no al final.
-
-1. Primero `unshift()` — prueba el siguiente comando:
-
-   ```js
-   myArray.unshift("Edinburgh");
-   myArray;
-   ```
-
-2. Ahora `shift()`; prueba estos!
-
-   ```js
-   let removedItem = myArray.shift();
-   myArray;
-   removedItem;
-   ```
-
-## Aprendizaje activo: ¡Imprimiendo esos productos!
-
-Volvamos al ejemplo que describimos anteriormente — imprima los nombres de los productos y los precios en una factura, luego, sume los precios e imprímelos en la parte inferior. En el ejemplo editable a continuación, hay comentarios que contienen números — cada uno de estos marca un lugar donde debe agregar algo al código. Ellos son los siguientes:
-
-1. Debajo de `// number 1` hay un número de cadena, cada una de las cuales contiene un nombre de producto y un precio separados por dos puntos. Nos gustaría que conviertas esto en un arreglo y lo almacenamos en un arreglo llamda `products`.
-2. En la misma línea que el comentario `// number 2` es el comienzo de un ciclo for. En esta línea, actualmente tenemos `i <= 0`, que es una prueba condicional que hace que el [bucle for](/es/docs/Learn_web_development/Core/Scripting/A_first_splash#loops) se detenga inmediatamente, porque dice "detener cuando `i` es menor o igual 0", y `i` comienza en 0. Nos gustaría que reemplazaras esto con una prueba condicional que detenga el ciclo cuando `i` no sea inferior a la longitud del arreglo `products` .
-3. Justo debajo del comentario `// number 3` queremos que escriba una línea de código que divide el elemento actual del arreglo (`nombre:precio`) en dos elementos separados, uno que contiene solo el nombre y otros que contienen solo el precio. Si no está seguro de cómo hacerlo, consulte el artículo [Métodos de cadenas útiles](/es/docs/Learn_web_development/Core/Scripting/Useful_string_methods) para obtener ayuda o, mejor aún, consulte la sección [Conversión entre cadenas y matrices](#converting_between_strings_and_arrays) de este artículo.
-4. Como parte de la línea de código anterior, también querras convertir el precio de una cadena a un número. Si no pudes recordar como hacerlo, consulta el [primer artículo de cadenas](/es/docs/Learn_web_development/Core/Scripting/Strings#numbers_versus_strings).
-5. Hay una variable llamada `total` que se crea y se le da un valor de 0 en la parte superior del código. Dentro del ciclo (debajo de `// number 4`) queremos que agregues una línea que añade el precio actual del artículo a ese total en cada iteración del ciclo, de modo que al final del código el total correcto se imprima en la factura. Es posible que necesites un [operador de asignación](/es/docs/Learn_web_development/Core/Scripting/Math#assignment_operators) para hacer esto.
-6. Queremos que cambies la línea justo de bajo `// number 5` para que la variable `itemText` se iguale a "nombre de elemnto actual — $precio de elemento actual", por ejemplo "Zapatos — $23.99" en cada caso, por lo que la información correcta del artículo está impreso en la factura. Esto es simplemente una concatenación de cadenas, lo que debería ser familiar para ti.
-
-```html hidden
+```html hidden live-sample___arrays-1
 <h2>Salida en vivo</h2>
 
-<div class="output" style="min-height: 150px;">
+<div class="output">
   <ul></ul>
 
   <p></p>
 </div>
+```
 
-<h2>Código editable</h2>
+```css hidden live-sample___arrays-1
+.output {
+  min-height: 100px;
+}
+```
 
-<p class="a11y-label">
-  Presione Esc para alejar el foco del área de código (Tab inserta un carácter
-  de tabulación).
-</p>
+```js live-sample___arrays-1
+const list = document.querySelector(".output ul");
+const totalBox = document.querySelector(".output p");
+let total = 0;
+list.textContent = "";
+totalBox.textContent = "";
+// Part 1
+// "Underpants:6.99",
+// "Socks:5.99",
+// "T-shirt:14.99",
+// "Trousers:31.99",
+// "Shoes:23.99",
 
-<textarea id="code" class="playable-code" style="height: 410px;width: 95%">
-var list = document.querySelector('.output ul');
-var totalBox = document.querySelector('.output p');
-var total = 0;
-list.innerHTML = '';
-totalBox.textContent = '';
-// number 1
-                'Underpants:6.99'
-                'Socks:5.99'
-                'T-shirt:14.99'
-                'Trousers:31.99'
-                'Shoes:23.99';
+// Part 2
 
-for (var i = 0; i <= 0; i++) { // number 2
-  // number 3
+// Part 3
 
-  // number 4
+// Part 4
 
-  // number 5
-  itemText = 0;
+// Part 5
+let itemText = 0;
 
-  var listItem = document.createElement('li');
+const listItem = document.createElement("li");
+listItem.textContent = itemText;
+list.appendChild(listItem);
+
+// Part 6
+
+totalBox.textContent = `Total: $${total.toFixed(2)}`;
+```
+
+{{ EmbedLiveSample("arrays-1", "100%", 200) }}
+
+<details>
+<summary>Haz clic aquí para ver la solución</summary>
+
+Tu código JavaScript terminado debería verse así:
+
+```js
+const list = document.querySelector(".output ul");
+const totalBox = document.querySelector(".output p");
+let total = 0;
+list.textContent = "";
+totalBox.textContent = "";
+
+const products = [
+  "Underpants:6.99",
+  "Socks:5.99",
+  "T-shirt:14.99",
+  "Trousers:31.99",
+  "Shoes:23.99",
+];
+
+for (const product of products) {
+  const subArray = product.split(":");
+  const name = subArray[0];
+  const price = Number(subArray[1]);
+  total += price;
+  const itemText = `${name} — $${price}`;
+
+  const listItem = document.createElement("li");
   listItem.textContent = itemText;
   list.appendChild(listItem);
 }
 
-totalBox.textContent = 'Total: $' + total.toFixed(2);
-</textarea>
-
-<div class="playable-buttons">
-  <input id="reset" type="button" value="Restablecer" />
-  <input id="solution" type="button" value="Mostrar solución" />
-</div>
+totalBox.textContent = `Total: $${total.toFixed(2)}`;
 ```
 
-```js hidden
-var textarea = document.getElementById("code");
-var reset = document.getElementById("reset");
-var solution = document.getElementById("solution");
-var code = textarea.value;
-var userEntry = textarea.value;
+</details>
 
-function updateCode() {
-  eval(textarea.value);
-}
+## Almacenando las últimas 5 búsquedas
 
-reset.addEventListener("click", function () {
-  textarea.value = code;
-  userEntry = textarea.value;
-  solutionEntry = jsSolution;
-  solution.value = "Mostrar solución";
-  updateCode();
-});
+Hagamos otro ejercicio, para seguir practicando.
 
-solution.addEventListener("click", function () {
-  if (solution.value === "Mostrar solución") {
-    textarea.value = solutionEntry;
-    solution.value = "Ocultar solución";
-  } else {
-    textarea.value = userEntry;
-    solution.value = "Mostrar solución";
-  }
-  updateCode();
-});
+Un buen uso para métodos de arreglo como {{jsxref("Array.prototype.push()","push()")}} y {{jsxref("Array.prototype.pop()","pop()")}} es cuando estás manteniendo un registro de los elementos actualmente activos en una aplicación web. En una escena animada, por ejemplo, podrías tener un arreglo de objetos que representan los gráficos de fondo mostrados actualmente, y quizás solo quieras que se muestren 50 a la vez, por razones de rendimiento o de desorden visual. A medida que se crean y agregan nuevos objetos al arreglo, los más antiguos pueden eliminarse del arreglo para mantener la cantidad deseada.
 
-var jsSolution =
-  "var list = document.querySelector('.output ul');\nvar totalBox = document.querySelector('.output p');\nvar total = 0;\nlist.innerHTML = '';\ntotalBox.textContent = '';\n\nvar products = ['Underpants:6.99',\n 'Socks:5.99',\n 'T-shirt:14.99',\n 'Trousers:31.99',\n 'Shoes:23.99'];\n\nfor(var i = 0; i < products.length; i++) {\n var subArray = products[i].split(':');\n var name = subArray[0];\n var price = Number(subArray[1]);\n total += price;\n itemText = name + ' — $' + price;\n\n var listItem = document.createElement('li');\n listItem.textContent = itemText;\n list.appendChild(listItem);\n}\n\ntotalBox.textContent = 'Total: $' + total.toFixed(2);";
-var solutionEntry = jsSolution;
-
-textarea.addEventListener("input", updateCode);
-window.addEventListener("load", updateCode);
-
-// detener la tecla de tabulación fuera del área de texto y
-// hacer que escriba una tabulación en la posición del cursor
-
-textarea.onkeydown = function (e) {
-  if (e.keyCode === 9) {
-    e.preventDefault();
-    insertAtCaret("\t");
-  }
-
-  if (e.keyCode === 27) {
-    textarea.blur();
-  }
-};
-
-function insertAtCaret(text) {
-  var scrollPos = textarea.scrollTop;
-  var caretPos = textarea.selectionStart;
-
-  var front = textarea.value.substring(0, caretPos);
-  var back = textarea.value.substring(
-    textarea.selectionEnd,
-    textarea.value.length,
-  );
-  textarea.value = front + text + back;
-  caretPos = caretPos + text.length;
-  textarea.selectionStart = caretPos;
-  textarea.selectionEnd = caretPos;
-  textarea.focus();
-  textarea.scrollTop = scrollPos;
-}
-
-// Actualice el código de usuario guardado cada vez que el usuario actualice el código de área de texto
-
-textarea.onkeyup = function () {
-  // Solo queremos guardar el estado cuando se muestra el código de usuario,
-  // no la solución, para que esa solución no se guarde sobre el código de usuario.
-  if (solution.value === "Mostrar solución") {
-    userEntry = textarea.value;
-  } else {
-    solutionEntry = textarea.value;
-  }
-
-  updateCode();
-};
-```
-
-```css hidden
-html {
-  font-family: sans-serif;
-}
-
-h2 {
-  font-size: 16px;
-}
-
-.a11y-label {
-  margin: 0;
-  text-align: right;
-  font-size: 0.7rem;
-  width: 98%;
-}
-
-body {
-  margin: 10px;
-  background-color: #f5f9fa;
-}
-```
-
-{{ EmbedLiveSample('Playable_code', '100%', 730, "", "", "hide-codepen-jsfiddle") }}
-
-## Aprendizaje Activo: Top 5 búsquedas
-
-Un buen uso para los métodos de arreglo como {{jsxref("Array.prototype.push()","push()")}} y {{jsxref("Array.prototype.pop()","pop()")}} es cuando estás manteniendo un registro de elementos actualmente activos en una aplicación web. En una escena animada por ejemplo, es posible que tengas un arreglo de objetos que representan los gráficos de fondo que se muestran actualmente, y es posible que sólo desees que se muestren 50 a la vez, por razones de rendimiento o desorden. A medida que se crean y agregan nuevos objetos al arreglo, se puede eliminar los más antiguos del arreglo para mantener el número deseado.
-
-En este ejemplo vamos a mostrar un uso mucho más simple — aquí te daremos un sitio de búsqueda falso, con un cuadro de búsqueda. La idea es que cuando los términos se ingresan en un cuadro de búsqueda, se muetren el top 5 de términos de búsqueda previos en la lista. Cuando el número de términos supera el 5, el último término comienza a borrarse cada vez que agregas un nuevo término a la parte superior, por lo que siempre se muestran los 5 términos anteriores.
+En este ejemplo mostraremos un uso mucho más simple — aquí te daremos un sitio de búsqueda ficticio, con un cuadro de búsqueda. La idea es que, cuando se ingresan términos en el cuadro de búsqueda, se muestren en la lista los 5 términos de búsqueda anteriores. Cuando la cantidad de términos supera los 5, el último término comienza a eliminarse cada vez que se agrega un nuevo término en la parte superior, de modo que siempre se muestran los 5 términos anteriores.
 
 > [!NOTE]
-> En una aplicación de búsqueda real, probablemente puedas hacer clic en los términos de búsqueda anteriores para volver a los términos de búsqueda anteriores y ¡se motrarán los resultados de búsqueda reales! Solamente lo mantendremos simple por ahora.
+> En una aplicación de búsqueda real, probablemente podrías hacer clic en los términos de búsqueda anteriores para volver a búsquedas anteriores, ¡y se mostrarían resultados de búsqueda reales! Por ahora lo mantendremos simple.
 
-Para completar la aplicación necesitamos:
+Para completar el ejemplo, necesitamos que hagas lo siguiente:
 
-1. Agregar una línea debajo del comentario `// number 1` que agrega el valor actual ingresado en la entrada de la búsqueda al inicio del arreglo. Esto se puede recuperar usando `searchInput.value`.
-2. Agrega una línea debajo del comentario `// number 2` que elimina el valor actualmente al final del arreglo.
+1. Haz clic en **"Play"** en el bloque de código de abajo para editar el ejemplo en el MDN Playground.
+2. Agrega una línea debajo del comentario `// Part 1` que agregue el valor actual ingresado en el campo de búsqueda al inicio del arreglo. Esto puede recuperarse usando `searchInput.value`.
+3. Agrega una línea debajo del comentario `// Part 2` que elimine el valor que se encuentra actualmente al final del arreglo.
 
-```html hidden
-<h2>Salida en vivo</h2>
-<div class="output" style="min-height: 150px;">
-  <input type="text" /><button>Buscar</button>
+Si cometes un error, puedes borrar tu trabajo usando el botón _Reset_ del MDN Playground. Si te quedas realmente atascado, puedes ver la solución debajo de la salida en vivo.
+
+```html hidden live-sample___arrays-2
+<div class="output">
+  <label for="search-box">Ingresa un término de búsqueda: </label>
+  <input id="search-box" type="search" />
+  <button>Buscar</button>
 
   <ul></ul>
 </div>
+```
 
-<h2>Código editable</h2>
+```css hidden live-sample___arrays-2
+.output {
+  margin: 1rem;
+}
+```
 
-<p class="a11y-label">
-  Presione Esc para alejar el foco del área de código (Tab inserta un carácter
-  de tabulación).
-</p>
+```js live-sample___arrays-2
+const list = document.querySelector(".output ul");
+const searchInput = document.querySelector(".output input");
+const searchBtn = document.querySelector(".output button");
 
-<textarea id="code" class="playable-code" style="height: 370px; width: 95%">
-var list = document.querySelector('.output ul');
-var searchInput = document.querySelector('.output input');
-var searchBtn = document.querySelector('.output button');
+list.textContent = "";
 
-list.innerHTML = '';
+const myHistory = [];
+const MAX_HISTORY = 5;
 
-var myHistory = [];
+searchBtn.addEventListener("click", () => {
+  // solo permitiremos ingresar un término si el campo de búsqueda no está vacío
+  if (searchInput.value !== "") {
+    // Part 1
 
-searchBtn.onclick = function() {
-  // Solo permitiremos que se ingrese un término si la entrada de búsqueda no está vacía.
-  if (searchInput.value !== '') {
-    // number 1
+    // vaciamos la lista para no mostrar entradas duplicadas.
+    // la visualización se regenera cada vez que se ingresa un término de búsqueda.
+    list.textContent = "";
 
-    // Vacíe la lista para no mostrar entradas duplicadas. La pantalla
-    // se regenera cada vez que se ingresa un término de búsqueda.
-    list.innerHTML = '';
-
-    // recorrer el arreglo y mostrar todos los términos de búsqueda en la lista
-    for (var i = 0; i < myHistory.length; i++) {
-      itemText = myHistory[i];
-      var listItem = document.createElement('li');
+    // recorremos el arreglo, y mostramos todos los términos de búsqueda en la lista
+    for (const itemText of myHistory) {
+      const listItem = document.createElement("li");
       listItem.textContent = itemText;
       list.appendChild(listItem);
     }
 
-    // Si la longitud del arreglo es 5 o más, elimine el término de búsqueda más antiguo
-    if (myHistory.length >= 5) {
-      // number 2
-
+    // Si la longitud del arreglo es 5 o más, eliminamos el término de búsqueda más antiguo
+    if (myHistory.length >= MAX_HISTORY) {
+      // Part 2
     }
 
-    // vacíe la entrada de búsqueda y enfóquela, listo para ingresar el siguiente término
-    searchInput.value = '';
+    // vaciamos el campo de búsqueda y lo enfocamos, listo para ingresar el siguiente término
+    searchInput.value = "";
     searchInput.focus();
   }
-}
-</textarea>
-
-<div class="playable-buttons">
-  <input id="reset" type="button" value="Restablecer" />
-  <input id="solution" type="button" value="Mostrar solución" />
-</div>
-```
-
-```css hidden
-html {
-  font-family: sans-serif;
-}
-
-h2 {
-  font-size: 16px;
-}
-
-.a11y-label {
-  margin: 0;
-  text-align: right;
-  font-size: 0.7rem;
-  width: 98%;
-}
-
-body {
-  margin: 10px;
-  background: #f5f9fa;
-}
-```
-
-```js hidden
-var textarea = document.getElementById("code");
-var reset = document.getElementById("reset");
-var solution = document.getElementById("solution");
-var code = textarea.value;
-var userEntry = textarea.value;
-
-function updateCode() {
-  eval(textarea.value);
-}
-
-reset.addEventListener("click", function () {
-  textarea.value = code;
-  userEntry = textarea.value;
-  solutionEntry = jsSolution;
-  solution.value = "Mostrar solución";
-  updateCode();
 });
-
-solution.addEventListener("click", function () {
-  if (solution.value === "Mostrar solución") {
-    textarea.value = solutionEntry;
-    solution.value = "Ocultar solución";
-  } else {
-    textarea.value = userEntry;
-    solution.value = "Mostrar solución";
-  }
-  updateCode();
-});
-
-var jsSolution =
-  "var list = document.querySelector('.output ul');\nvar searchInput = document.querySelector('.output input');\nvar searchBtn = document.querySelector('.output button');\n\nlist.innerHTML = '';\n\nvar myHistory= [];\n\nsearchBtn.onclick = function() {\n if(searchInput.value !== '') {\n myHistory.unshift(searchInput.value);\n\n list.innerHTML = '';\n\n for(var i = 0; i < myHistory.length; i++) {\n itemText = myHistory[i];\n var listItem = document.createElement('li');\n listItem.textContent = itemText;\n list.appendChild(listItem);\n }\n\n if(myHistory.length >= 5) {\n myHistory.pop();\n }\n\n searchInput.value = '';\n searchInput.focus();\n }\n}";
-var solutionEntry = jsSolution;
-
-textarea.addEventListener("input", updateCode);
-window.addEventListener("load", updateCode);
-
-// detener la tecla de tabulación fuera del área de texto y
-// hacer que escriba una tabulación en la posición del cursor
-
-textarea.onkeydown = function (e) {
-  if (e.keyCode === 9) {
-    e.preventDefault();
-    insertAtCaret("\t");
-  }
-
-  if (e.keyCode === 27) {
-    textarea.blur();
-  }
-};
-
-function insertAtCaret(text) {
-  var scrollPos = textarea.scrollTop;
-  var caretPos = textarea.selectionStart;
-
-  var front = textarea.value.substring(0, caretPos);
-  var back = textarea.value.substring(
-    textarea.selectionEnd,
-    textarea.value.length,
-  );
-  textarea.value = front + text + back;
-  caretPos = caretPos + text.length;
-  textarea.selectionStart = caretPos;
-  textarea.selectionEnd = caretPos;
-  textarea.focus();
-  textarea.scrollTop = scrollPos;
-}
-
-// Actualice el código de usuario guardado cada vez que el usuario actualice el código de área de texto
-
-textarea.onkeyup = function () {
-  // Solo queremos guardar el estado cuando se muestra el código de usuario,
-  // no la solución, para que esa solución no se guarde sobre el código de usuario.
-  if (solution.value === "Mostrar solución") {
-    userEntry = textarea.value;
-  } else {
-    solutionEntry = textarea.value;
-  }
-
-  updateCode();
-};
 ```
 
-{{ EmbedLiveSample('Playable_code_2', '100%', 700, "", "", "hide-codepen-jsfiddle") }}
+{{ EmbedLiveSample("arrays-2", "100%", 200) }}
 
-## Conclusión
+<details>
+<summary>Haz clic aquí para ver la solución</summary>
 
-Después de leer este artículo, estamos seguros de que estaras de acuerdo en que las matrices parecen bastante útiles; las verás aparecer en todas partes en JavaScript, a menudo en asociación con bucles para hacer una misma cosa con cada elemento del arreglo. Te enseñaremos todos los aspectos básicos útiles que hay que conocer sobre los bucles en el siguiente módulo, pero por ahora debes darte un aplauso y tomarte un merecido descanso; ¡has trabajado en todos los artículos de este módulo!
+Tu código JavaScript terminado debería verse así:
 
-Lo único que queda por hacer es trabajar a través de la evaluación de este módulo, que te pondrá a prueba tu comprensión de los de los artículos anteriores.
+```js
+const list = document.querySelector(".output ul");
+const searchInput = document.querySelector(".output input");
+const searchBtn = document.querySelector(".output button");
 
-## See also
+list.textContent = "";
 
-- [Colecciones indexadas](/es/docs/Web/JavaScript/Guide/Indexed_collections) — una guía de nivel avanzado sobre arreglos y sus primos, los arreglos tipadosa.
-- {{jsxref("Array")}}: la página de referencia del objeto `Array`, para obtener una guía de referencia detallada de las funciones analizadas en esta página y muchas más.
+const myHistory = [];
+const MAX_HISTORY = 5;
 
-{{PreviousMenuNext("Learn_web_development/Core/Scripting/Useful_string_methods", "Learn_web_development/Core/Scripting/Silly_story_generator", "conflicting/Learn_web_development/Core/Scripting")}}
+searchBtn.addEventListener("click", () => {
+  // solo permitiremos ingresar un término si el campo de búsqueda no está vacío
+  if (searchInput.value !== "") {
+    myHistory.unshift(searchInput.value);
+
+    // vaciamos la lista para no mostrar entradas duplicadas.
+    // la visualización se regenera cada vez que se ingresa un término de búsqueda.
+    list.textContent = "";
+
+    // recorremos el arreglo, y mostramos todos los términos de búsqueda en la lista
+    for (const itemText of myHistory) {
+      const listItem = document.createElement("li");
+      listItem.textContent = itemText;
+      list.appendChild(listItem);
+    }
+
+    // Si la longitud del arreglo es 5 o más, eliminamos el término de búsqueda más antiguo
+    if (myHistory.length >= MAX_HISTORY) {
+      myHistory.pop();
+    }
+
+    // vaciamos el campo de búsqueda y lo enfocamos, listo para ingresar el siguiente término
+    searchInput.value = "";
+    searchInput.focus();
+  }
+});
+```
+
+</details>
+
+## Resumen
+
+Después de leer este artículo, estamos seguros de que estarás de acuerdo en que los arreglos son bastante útiles; los verás aparecer por todas partes en JavaScript, a menudo en conjunto con bucles, para hacer lo mismo con cada elemento de un arreglo. Te enseñaremos todo lo necesario sobre los bucles más adelante en el módulo.
+
+En el próximo artículo te daremos algunas pruebas que podrás usar para comprobar qué tan bien has entendido y retenido la información que te dimos sobre los arreglos.
+
+## Véase también
+
+- {{jsxref("Array")}}
+  - : La página de referencia del objeto `Array` ofrece una guía de referencia detallada sobre las funciones tratadas en esta página, y muchas otras funciones de `Array`.
+
+{{PreviousMenuNext("Learn_web_development/Core/Scripting/Test_your_skills/Strings", "Learn_web_development/Core/Scripting/Test_your_skills/Arrays", "Learn_web_development/Core/Scripting")}}


### PR DESCRIPTION
### Description
Sincroniza la traducción al español de "Arreglos" con la versión actual en inglés, que fue reescrita casi por completo (nuevas secciones sobre `indexOf()`, `splice()`, `forEach()`/`map()`/`filter()`, y los ejercicios interactivos migrados al MDN Playground).

### Motivation
La traducción en español estaba muy desactualizada respecto al inglés (usaba el front-matter antiguo con `original_slug` en lugar de `l10n.sourceCommit`, y no reflejaba la reestructuración del artículo).

### Additional details
- Front-matter actualizado al formato vigente (`title`, `slug`, `l10n.sourceCommit`), eliminando `original_slug`.
- Se tradujeron ambos bloques `live-sample___arrays-1` y `live-sample___arrays-2` (HTML visible, comentarios y soluciones), preservando identificadores de código.
- Se preservaron intactas las macros de Kumascript (`{{jsxref}}`, `{{PreviousMenuNext}}`, `{{EmbedLiveSample}}`).
- Se actualizaron enlaces internos de `/en-US/` a `/es/` y se recalcularon los fragmentos de anclaje según los encabezados ya traducidos en las páginas de destino (por ejemplo, `Useful_string_methods#extrayendo_un_caracter_específico_de_la_cadena`, `Strings#números_versus_cadenas`, `Math#operadores_de_asignación`, `Learning_content#enlaces_externos_o_embebidos`).
- Validaciones corridas sobre el archivo: `prettier --write`, `markdownlint-cli2 --fix`, `check-url-locale.js` (sin errores).

### Related issues and pull requests
Fixes #37274