### PR TITLE
fix(pt-BR): replace broken text-overflow images

### DIFF
--- a/files/pt-br/web/css/reference/properties/text-overflow/index.md
+++ b/files/pt-br/web/css/reference/properties/text-overflow/index.md
@@ -113,13 +113,7 @@ p {
     </tr>
     <tr>
       <td><code>text-overflow: clip</code></td>
-      <td style="padding: 1px; font-family: monospace">
-        <img
-          alt="t-o_clip.png"
-          class="default internal"
-          src="t-o_clip.png"
-        />
-      </td>
+      <td style="padding: 1px; font-family: monospace">123456</td>
       <td style="direction: ltr">
         <div
           style="
@@ -134,13 +128,7 @@ p {
           123456
         </div>
       </td>
-      <td style="padding: 1px; font-family: monospace">
-        <img
-          alt="t-o_clip_rtl.png"
-          class="default internal"
-          src="t-o_clip_rtl.png"
-        />
-      </td>
+      <td style="padding: 1px; font-family: monospace">654321</td>
       <td style="direction: rtl">
         <div
           style="


### PR DESCRIPTION
### Description

Replaces the two missing `text-overflow: clip` result images with their equivalent monospace text values.

### Motivation

The missing assets currently render as broken images in the example table.

### Additional details

The replacement values match the adjacent live examples for left-to-right and right-to-left text.

### Related issues and pull requests

Fixes #19393
